### PR TITLE
Adding latency measurement to InfoPanel

### DIFF
--- a/src/base-canvas.js
+++ b/src/base-canvas.js
@@ -245,7 +245,6 @@ export class BaseCanvas extends LitElement {
     this._renderer = null;
     this._pointerRawUpdate = false;
     this._pointerDown = false;
-    this._latestEvent = null;
 
     // renderer-specific properties
     this._currentColor = '#000000';
@@ -262,21 +261,18 @@ export class BaseCanvas extends LitElement {
   undoPath() {
     this._renderer.undoPath();
     this.paths = this._renderer.paths;
-    this.latestEvent = null;
     this._draw();
   }
 
   redoPath() {
     this._renderer.redoPath();
     this.paths = this._renderer.paths;
-    this.latestEvent = null;
     this._draw();
   }
 
   deleteAllPaths() {
     this._renderer.deleteAllPaths();
     this.paths = this._renderer.paths;
-    this.latestEvent = null;
     this._draw();
   }
 
@@ -284,9 +280,9 @@ export class BaseCanvas extends LitElement {
     if(this._pointerDown && event.pointerId !== this._pointerId)
       return;
 
+    this._app.currentEvent = event;
     this._pointerDown = true;
     this._pointerId = event.pointerId;
-    this._latestEvent = event;
     this._renderer.beginPath(this._getPoint(event));
     this._draw();
     event.preventDefault();
@@ -299,7 +295,7 @@ export class BaseCanvas extends LitElement {
         return;
     }
 
-    this._latestEvent = event;
+    this._app.currentEvent = event;
     if(this._pointerDown && event.pointerId === this._pointerId) {
       let points = [];
       let predictedPoints = [];
@@ -338,7 +334,7 @@ export class BaseCanvas extends LitElement {
   }
 
   _onPointerUp = async (event) => {
-    this._latestEvent = event;
+    this._app.currentEvent = event;
     if (this._pointerDown) {
       if (event.pointerId !== this._pointerId)
         return;
@@ -347,7 +343,6 @@ export class BaseCanvas extends LitElement {
       this._pointerDown = false;
       this._pointerId = null;
     }
-    this._app._updateInfoPanel(event);
   }
 
   _onResize = async (event) => {
@@ -363,8 +358,6 @@ export class BaseCanvas extends LitElement {
 
   _draw() {
     this._renderer.render();
-    if (this._latestEvent)
-      this._app._updateInfoPanel(this._latestEvent);
   }
 
   // return a simplified version of the event for ease of serialization to worker

--- a/src/info-panel.js
+++ b/src/info-panel.js
@@ -39,7 +39,8 @@ export class InfoPanel extends LitElement {
              tangentialPressure : {type: Number, reflectToAttribute: true, attribute: true},
              tiltX : {type: Number, reflectToAttribute: true, attribute: true},
              tiltY : {type: Number, reflectToAttribute: true, attribute: true},
-             Twist : {type: Number, reflectToAttribute: true, attribute: true}};
+             twist : {type: Number, reflectToAttribute: true, attribute: true},
+             avgLatency : {type: Number, reflectToAttribute: true, attribute: true}};
     }
 
   set eventType(eventType) {
@@ -154,6 +155,14 @@ export class InfoPanel extends LitElement {
 
   get twist() { return this._twist; }
 
+  set avgLatency(avgLatency) {
+    let oldAvgLatency = this._avgLatency;
+    this._avgLatency = avgLatency;
+    this.requestUpdate('avgLatency', oldAvgLatency);
+  }
+
+  get avgLatency() { return this._avgLatency; }
+
   constructor() {
     super();
   }
@@ -173,7 +182,8 @@ export class InfoPanel extends LitElement {
       <div class="name">Tangential pressure</div><div class="value">${String(this._tangentialPressure)}</div>
       <div class="name">Tilt x</div><div class="value">${String(this._tiltX)}</div>
       <div class="name">Tilt y</div><div class="value">${String(this._tiltY)}</div>
-      <div class="name">Twist</div><div class="value">${String(this._twist)}</div>`;
+      <div class="name">Twist</div><div class="value">${String(this._twist)}</div>
+      <div class="name">Avg latency</div><div class="value">${String(this._avgLatency)}ms</div>`;
   }
 }
 


### PR DESCRIPTION
Measure input latency of the time between an event being dispatched in
the document and the event being handled in requestAnimationFrame callback,
which is called before the next repaint.  It keeps track of the last 60
event samples when the stylus is active and takes an average of the
samples.