### PR TITLE
Custom prediction using KalmanFilter

### DIFF
--- a/build/dist/utils.js
+++ b/build/dist/utils.js
@@ -1,0 +1,29 @@
+class DataSamples {
+  constructor(size) {
+    this._elements = [];
+    this._maxSize = size;
+  }
+
+  clear() {
+    this._elements = [];
+  }
+
+  push(value) {
+    if (this._elements.length >= this._maxSize) {
+      this._elements.shift();
+    }
+
+    this._elements.push(value);
+  }
+
+  avg() {
+    if (this._elements.length === 0) return 0;
+
+    let sum = this._elements.reduce(function (a, b) {
+      return a + b;
+    }, 0);
+
+    return sum / this._elements.length;
+  }
+
+}

--- a/build/web_modules/@material/mwc-select.js
+++ b/build/web_modules/@material/mwc-select.js
@@ -1,0 +1,7274 @@
+import { L as LitElement, h as html, c as css, d as directive, n as nothing } from '../common/lit-element-58192bd6.js';
+import { p as property, q as query, b as classMap, c as customElement, i as internalProperty, a as queryAsync, e as eventOptions } from '../common/class-map-b1acbdf1.js';
+import { s as styleMap } from '../common/style-map-e65726ec.js';
+import { i as ifDefined } from '../common/if-defined-f73d3e22.js';
+
+/*! *****************************************************************************
+Copyright (c) Microsoft Corporation.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+***************************************************************************** */
+/* global Reflect, Promise */
+
+var extendStatics = function(d, b) {
+    extendStatics = Object.setPrototypeOf ||
+        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+        function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+    return extendStatics(d, b);
+};
+
+function __extends(d, b) {
+    if (typeof b !== "function" && b !== null)
+        throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+    extendStatics(d, b);
+    function __() { this.constructor = d; }
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+}
+
+var __assign = function() {
+    __assign = Object.assign || function __assign(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
+
+function __decorate(decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+}
+
+function __values(o) {
+    var s = typeof Symbol === "function" && Symbol.iterator, m = s && o[s], i = 0;
+    if (m) return m.call(o);
+    if (o && typeof o.length === "number") return {
+        next: function () {
+            if (o && i >= o.length) o = void 0;
+            return { value: o && o[i++], done: !o };
+        }
+    };
+    throw new TypeError(s ? "Object is not iterable." : "Symbol.iterator is not defined.");
+}
+
+/*! *****************************************************************************
+Copyright (c) Microsoft Corporation.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+***************************************************************************** */
+
+function __decorate$1(decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+}
+
+/**
+@license
+Copyright 2018 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+const fn = () => { };
+const optionsBlock = {
+    get passive() {
+        return false;
+    }
+};
+document.addEventListener('x', fn, optionsBlock);
+document.removeEventListener('x', fn);
+
+/**
+@license
+Copyright 2018 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/** @soyCompatible */
+class BaseElement extends LitElement {
+    click() {
+        if (this.mdcRoot) {
+            this.mdcRoot.focus();
+            this.mdcRoot.click();
+            return;
+        }
+        super.click();
+    }
+    /**
+     * Create and attach the MDC Foundation to the instance
+     */
+    createFoundation() {
+        if (this.mdcFoundation !== undefined) {
+            this.mdcFoundation.destroy();
+        }
+        if (this.mdcFoundationClass) {
+            this.mdcFoundation = new this.mdcFoundationClass(this.createAdapter());
+            this.mdcFoundation.init();
+        }
+    }
+    firstUpdated() {
+        this.createFoundation();
+    }
+}
+
+/*! *****************************************************************************
+Copyright (c) Microsoft Corporation.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+***************************************************************************** */
+/* global Reflect, Promise */
+
+var extendStatics$1 = function(d, b) {
+    extendStatics$1 = Object.setPrototypeOf ||
+        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+        function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+    return extendStatics$1(d, b);
+};
+
+function __extends$1(d, b) {
+    if (typeof b !== "function" && b !== null)
+        throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+    extendStatics$1(d, b);
+    function __() { this.constructor = d; }
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+}
+
+var __assign$1 = function() {
+    __assign$1 = Object.assign || function __assign(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign$1.apply(this, arguments);
+};
+
+/**
+ * @license
+ * Copyright 2016 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+var MDCFoundation = /** @class */ (function () {
+    function MDCFoundation(adapter) {
+        if (adapter === void 0) { adapter = {}; }
+        this.adapter = adapter;
+    }
+    Object.defineProperty(MDCFoundation, "cssClasses", {
+        get: function () {
+            // Classes extending MDCFoundation should implement this method to return an object which exports every
+            // CSS class the foundation class needs as a property. e.g. {ACTIVE: 'mdc-component--active'}
+            return {};
+        },
+        enumerable: false,
+        configurable: true
+    });
+    Object.defineProperty(MDCFoundation, "strings", {
+        get: function () {
+            // Classes extending MDCFoundation should implement this method to return an object which exports all
+            // semantic strings as constants. e.g. {ARIA_ROLE: 'tablist'}
+            return {};
+        },
+        enumerable: false,
+        configurable: true
+    });
+    Object.defineProperty(MDCFoundation, "numbers", {
+        get: function () {
+            // Classes extending MDCFoundation should implement this method to return an object which exports all
+            // of its semantic numbers as constants. e.g. {ANIMATION_DELAY_MS: 350}
+            return {};
+        },
+        enumerable: false,
+        configurable: true
+    });
+    Object.defineProperty(MDCFoundation, "defaultAdapter", {
+        get: function () {
+            // Classes extending MDCFoundation may choose to implement this getter in order to provide a convenient
+            // way of viewing the necessary methods of an adapter. In the future, this could also be used for adapter
+            // validation.
+            return {};
+        },
+        enumerable: false,
+        configurable: true
+    });
+    MDCFoundation.prototype.init = function () {
+        // Subclasses should override this method to perform initialization routines (registering events, etc.)
+    };
+    MDCFoundation.prototype.destroy = function () {
+        // Subclasses should override this method to perform de-initialization routines (de-registering events, etc.)
+    };
+    return MDCFoundation;
+}());
+
+/**
+ * @license
+ * Copyright 2018 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+var strings = {
+    NOTCH_ELEMENT_SELECTOR: '.mdc-notched-outline__notch',
+};
+var numbers = {
+    // This should stay in sync with $mdc-notched-outline-padding * 2.
+    NOTCH_ELEMENT_PADDING: 8,
+};
+var cssClasses = {
+    NO_LABEL: 'mdc-notched-outline--no-label',
+    OUTLINE_NOTCHED: 'mdc-notched-outline--notched',
+    OUTLINE_UPGRADED: 'mdc-notched-outline--upgraded',
+};
+
+/**
+ * @license
+ * Copyright 2017 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+var MDCNotchedOutlineFoundation = /** @class */ (function (_super) {
+    __extends$1(MDCNotchedOutlineFoundation, _super);
+    function MDCNotchedOutlineFoundation(adapter) {
+        return _super.call(this, __assign$1(__assign$1({}, MDCNotchedOutlineFoundation.defaultAdapter), adapter)) || this;
+    }
+    Object.defineProperty(MDCNotchedOutlineFoundation, "strings", {
+        get: function () {
+            return strings;
+        },
+        enumerable: false,
+        configurable: true
+    });
+    Object.defineProperty(MDCNotchedOutlineFoundation, "cssClasses", {
+        get: function () {
+            return cssClasses;
+        },
+        enumerable: false,
+        configurable: true
+    });
+    Object.defineProperty(MDCNotchedOutlineFoundation, "numbers", {
+        get: function () {
+            return numbers;
+        },
+        enumerable: false,
+        configurable: true
+    });
+    Object.defineProperty(MDCNotchedOutlineFoundation, "defaultAdapter", {
+        /**
+         * See {@link MDCNotchedOutlineAdapter} for typing information on parameters and return types.
+         */
+        get: function () {
+            // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
+            return {
+                addClass: function () { return undefined; },
+                removeClass: function () { return undefined; },
+                setNotchWidthProperty: function () { return undefined; },
+                removeNotchWidthProperty: function () { return undefined; },
+            };
+            // tslint:enable:object-literal-sort-keys
+        },
+        enumerable: false,
+        configurable: true
+    });
+    /**
+     * Adds the outline notched selector and updates the notch width calculated based off of notchWidth.
+     */
+    MDCNotchedOutlineFoundation.prototype.notch = function (notchWidth) {
+        var OUTLINE_NOTCHED = MDCNotchedOutlineFoundation.cssClasses.OUTLINE_NOTCHED;
+        if (notchWidth > 0) {
+            notchWidth += numbers.NOTCH_ELEMENT_PADDING; // Add padding from left/right.
+        }
+        this.adapter.setNotchWidthProperty(notchWidth);
+        this.adapter.addClass(OUTLINE_NOTCHED);
+    };
+    /**
+     * Removes notched outline selector to close the notch in the outline.
+     */
+    MDCNotchedOutlineFoundation.prototype.closeNotch = function () {
+        var OUTLINE_NOTCHED = MDCNotchedOutlineFoundation.cssClasses.OUTLINE_NOTCHED;
+        this.adapter.removeClass(OUTLINE_NOTCHED);
+        this.adapter.removeNotchWidthProperty();
+    };
+    return MDCNotchedOutlineFoundation;
+}(MDCFoundation));
+
+class NotchedOutlineBase extends BaseElement {
+    constructor() {
+        super(...arguments);
+        this.mdcFoundationClass = MDCNotchedOutlineFoundation;
+        this.width = 0;
+        this.open = false;
+        this.lastOpen = this.open;
+    }
+    createAdapter() {
+        return {
+            addClass: (className) => this.mdcRoot.classList.add(className),
+            removeClass: (className) => this.mdcRoot.classList.remove(className),
+            setNotchWidthProperty: (width) => this.notchElement.style.setProperty('width', `${width}px`),
+            removeNotchWidthProperty: () => this.notchElement.style.removeProperty('width'),
+        };
+    }
+    openOrClose(shouldOpen, width) {
+        if (!this.mdcFoundation) {
+            return;
+        }
+        if (shouldOpen && width !== undefined) {
+            this.mdcFoundation.notch(width);
+        }
+        else {
+            this.mdcFoundation.closeNotch();
+        }
+    }
+    render() {
+        this.openOrClose(this.open, this.width);
+        const classes = classMap({
+            'mdc-notched-outline--notched': this.open,
+        });
+        return html `
+      <span class="mdc-notched-outline ${classes}">
+        <span class="mdc-notched-outline__leading"></span>
+        <span class="mdc-notched-outline__notch">
+          <slot></slot>
+        </span>
+        <span class="mdc-notched-outline__trailing"></span>
+      </span>`;
+    }
+}
+__decorate$1([
+    query('.mdc-notched-outline')
+], NotchedOutlineBase.prototype, "mdcRoot", void 0);
+__decorate$1([
+    property({ type: Number })
+], NotchedOutlineBase.prototype, "width", void 0);
+__decorate$1([
+    property({ type: Boolean, reflect: true })
+], NotchedOutlineBase.prototype, "open", void 0);
+__decorate$1([
+    query('.mdc-notched-outline__notch')
+], NotchedOutlineBase.prototype, "notchElement", void 0);
+
+/**
+@license
+Copyright 2018 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+const style = css `.mdc-notched-outline{display:flex;position:absolute;top:0;right:0;left:0;box-sizing:border-box;width:100%;max-width:100%;height:100%;text-align:left;pointer-events:none}[dir=rtl] .mdc-notched-outline,.mdc-notched-outline[dir=rtl]{text-align:right}.mdc-notched-outline__leading,.mdc-notched-outline__notch,.mdc-notched-outline__trailing{box-sizing:border-box;height:100%;border-top:1px solid;border-bottom:1px solid;pointer-events:none}.mdc-notched-outline__leading{border-left:1px solid;border-right:none;width:12px}[dir=rtl] .mdc-notched-outline__leading,.mdc-notched-outline__leading[dir=rtl]{border-left:none;border-right:1px solid}.mdc-notched-outline__trailing{border-left:none;border-right:1px solid;flex-grow:1}[dir=rtl] .mdc-notched-outline__trailing,.mdc-notched-outline__trailing[dir=rtl]{border-left:1px solid;border-right:none}.mdc-notched-outline__notch{flex:0 0 auto;width:auto;max-width:calc(100% - 12px * 2)}.mdc-notched-outline .mdc-floating-label{display:inline-block;position:relative;max-width:100%}.mdc-notched-outline .mdc-floating-label--float-above{text-overflow:clip}.mdc-notched-outline--upgraded .mdc-floating-label--float-above{max-width:calc(100% / 0.75)}.mdc-notched-outline--notched .mdc-notched-outline__notch{padding-left:0;padding-right:8px;border-top:none}[dir=rtl] .mdc-notched-outline--notched .mdc-notched-outline__notch,.mdc-notched-outline--notched .mdc-notched-outline__notch[dir=rtl]{padding-left:8px;padding-right:0}.mdc-notched-outline--no-label .mdc-notched-outline__notch{display:none}:host{display:block;position:absolute;right:0;left:0;box-sizing:border-box;width:100%;max-width:100%;height:100%;text-align:left;pointer-events:none}[dir=rtl] :host,:host[dir=rtl]{text-align:right}::slotted(.mdc-floating-label){display:inline-block;position:relative;top:17px;bottom:auto;max-width:100%}::slotted(.mdc-floating-label--float-above){text-overflow:clip}.mdc-notched-outline--upgraded ::slotted(.mdc-floating-label--float-above){max-width:calc(100% / 0.75)}.mdc-notched-outline .mdc-notched-outline__leading{border-top-left-radius:4px;border-top-left-radius:var(--mdc-shape-small, 4px);border-top-right-radius:0;border-bottom-right-radius:0;border-bottom-left-radius:4px;border-bottom-left-radius:var(--mdc-shape-small, 4px)}[dir=rtl] .mdc-notched-outline .mdc-notched-outline__leading,.mdc-notched-outline .mdc-notched-outline__leading[dir=rtl]{border-top-left-radius:0;border-top-right-radius:4px;border-top-right-radius:var(--mdc-shape-small, 4px);border-bottom-right-radius:4px;border-bottom-right-radius:var(--mdc-shape-small, 4px);border-bottom-left-radius:0}@supports(top: max(0%)){.mdc-notched-outline .mdc-notched-outline__leading{width:max(12px, var(--mdc-shape-small, 4px))}}@supports(top: max(0%)){.mdc-notched-outline .mdc-notched-outline__notch{max-width:calc(100% - max(12px, var(--mdc-shape-small, 4px)) * 2)}}.mdc-notched-outline .mdc-notched-outline__trailing{border-top-left-radius:0;border-top-right-radius:4px;border-top-right-radius:var(--mdc-shape-small, 4px);border-bottom-right-radius:4px;border-bottom-right-radius:var(--mdc-shape-small, 4px);border-bottom-left-radius:0}[dir=rtl] .mdc-notched-outline .mdc-notched-outline__trailing,.mdc-notched-outline .mdc-notched-outline__trailing[dir=rtl]{border-top-left-radius:4px;border-top-left-radius:var(--mdc-shape-small, 4px);border-top-right-radius:0;border-bottom-right-radius:0;border-bottom-left-radius:4px;border-bottom-left-radius:var(--mdc-shape-small, 4px)}.mdc-notched-outline__leading,.mdc-notched-outline__notch,.mdc-notched-outline__trailing{border-color:var(--mdc-notched-outline-border-color, var(--mdc-theme-primary, #6200ee));border-width:1px;border-width:var(--mdc-notched-outline-stroke-width, 1px)}.mdc-notched-outline--notched .mdc-notched-outline__notch{padding-top:0;padding-top:var(--mdc-notched-outline-notch-offset, 0)}`;
+
+let NotchedOutline = class NotchedOutline extends NotchedOutlineBase {
+};
+NotchedOutline.styles = style;
+NotchedOutline = __decorate$1([
+    customElement('mwc-notched-outline')
+], NotchedOutline);
+
+/**
+ * @license
+ * Copyright 2018 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+function matches(element, selector) {
+    var nativeMatches = element.matches
+        || element.webkitMatchesSelector
+        || element.msMatchesSelector;
+    return nativeMatches.call(element, selector);
+}
+
+/**
+@license
+Copyright 2018 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/**
+ * Determines whether a node is an element.
+ *
+ * @param node Node to check
+ */
+const isNodeElement = (node) => {
+    return node.nodeType === Node.ELEMENT_NODE;
+};
+function findAssignedElement(slot, selector) {
+    for (const node of slot.assignedNodes({ flatten: true })) {
+        if (isNodeElement(node)) {
+            const el = node;
+            if (matches(el, selector)) {
+                return el;
+            }
+        }
+    }
+    return null;
+}
+function addHasRemoveClass(element) {
+    return {
+        addClass: (className) => {
+            element.classList.add(className);
+        },
+        removeClass: (className) => {
+            element.classList.remove(className);
+        },
+        hasClass: (className) => element.classList.contains(className),
+    };
+}
+const fn$1 = () => { };
+const optionsBlock$1 = {
+    get passive() {
+        return false;
+    }
+};
+document.addEventListener('x', fn$1, optionsBlock$1);
+document.removeEventListener('x', fn$1);
+const deepActiveElementPath = (doc = window.document) => {
+    let activeElement = doc.activeElement;
+    const path = [];
+    if (!activeElement) {
+        return path;
+    }
+    while (activeElement) {
+        path.push(activeElement);
+        if (activeElement.shadowRoot) {
+            activeElement = activeElement.shadowRoot.activeElement;
+        }
+        else {
+            break;
+        }
+    }
+    return path;
+};
+const doesElementContainFocus = (element) => {
+    const activePath = deepActiveElementPath();
+    if (!activePath.length) {
+        return false;
+    }
+    const deepActiveElement = activePath[activePath.length - 1];
+    const focusEv = new Event('check-if-focused', { bubbles: true, composed: true });
+    let composedPath = [];
+    const listener = (ev) => {
+        composedPath = ev.composedPath();
+    };
+    document.body.addEventListener('check-if-focused', listener);
+    deepActiveElement.dispatchEvent(focusEv);
+    document.body.removeEventListener('check-if-focused', listener);
+    return composedPath.indexOf(element) !== -1;
+};
+
+/**
+@license
+Copyright 2018 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/** @soyCompatible */
+class BaseElement$1 extends LitElement {
+    click() {
+        if (this.mdcRoot) {
+            this.mdcRoot.focus();
+            this.mdcRoot.click();
+            return;
+        }
+        super.click();
+    }
+    /**
+     * Create and attach the MDC Foundation to the instance
+     */
+    createFoundation() {
+        if (this.mdcFoundation !== undefined) {
+            this.mdcFoundation.destroy();
+        }
+        if (this.mdcFoundationClass) {
+            this.mdcFoundation = new this.mdcFoundationClass(this.createAdapter());
+            this.mdcFoundation.init();
+        }
+    }
+    firstUpdated() {
+        this.createFoundation();
+    }
+}
+
+/**
+ * @license
+ * Copyright 2016 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+var MDCFoundation$1 = /** @class */ (function () {
+    function MDCFoundation(adapter) {
+        if (adapter === void 0) { adapter = {}; }
+        this.adapter = adapter;
+    }
+    Object.defineProperty(MDCFoundation, "cssClasses", {
+        get: function () {
+            // Classes extending MDCFoundation should implement this method to return an object which exports every
+            // CSS class the foundation class needs as a property. e.g. {ACTIVE: 'mdc-component--active'}
+            return {};
+        },
+        enumerable: false,
+        configurable: true
+    });
+    Object.defineProperty(MDCFoundation, "strings", {
+        get: function () {
+            // Classes extending MDCFoundation should implement this method to return an object which exports all
+            // semantic strings as constants. e.g. {ARIA_ROLE: 'tablist'}
+            return {};
+        },
+        enumerable: false,
+        configurable: true
+    });
+    Object.defineProperty(MDCFoundation, "numbers", {
+        get: function () {
+            // Classes extending MDCFoundation should implement this method to return an object which exports all
+            // of its semantic numbers as constants. e.g. {ANIMATION_DELAY_MS: 350}
+            return {};
+        },
+        enumerable: false,
+        configurable: true
+    });
+    Object.defineProperty(MDCFoundation, "defaultAdapter", {
+        get: function () {
+            // Classes extending MDCFoundation may choose to implement this getter in order to provide a convenient
+            // way of viewing the necessary methods of an adapter. In the future, this could also be used for adapter
+            // validation.
+            return {};
+        },
+        enumerable: false,
+        configurable: true
+    });
+    MDCFoundation.prototype.init = function () {
+        // Subclasses should override this method to perform initialization routines (registering events, etc.)
+    };
+    MDCFoundation.prototype.destroy = function () {
+        // Subclasses should override this method to perform de-initialization routines (de-registering events, etc.)
+    };
+    return MDCFoundation;
+}());
+
+/**
+ * @license
+ * Copyright 2016 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+var cssClasses$1 = {
+    // Ripple is a special case where the "root" component is really a "mixin" of sorts,
+    // given that it's an 'upgrade' to an existing component. That being said it is the root
+    // CSS class that all other CSS classes derive from.
+    BG_FOCUSED: 'mdc-ripple-upgraded--background-focused',
+    FG_ACTIVATION: 'mdc-ripple-upgraded--foreground-activation',
+    FG_DEACTIVATION: 'mdc-ripple-upgraded--foreground-deactivation',
+    ROOT: 'mdc-ripple-upgraded',
+    UNBOUNDED: 'mdc-ripple-upgraded--unbounded',
+};
+var strings$1 = {
+    VAR_FG_SCALE: '--mdc-ripple-fg-scale',
+    VAR_FG_SIZE: '--mdc-ripple-fg-size',
+    VAR_FG_TRANSLATE_END: '--mdc-ripple-fg-translate-end',
+    VAR_FG_TRANSLATE_START: '--mdc-ripple-fg-translate-start',
+    VAR_LEFT: '--mdc-ripple-left',
+    VAR_TOP: '--mdc-ripple-top',
+};
+var numbers$1 = {
+    DEACTIVATION_TIMEOUT_MS: 225,
+    FG_DEACTIVATION_MS: 150,
+    INITIAL_ORIGIN_SCALE: 0.6,
+    PADDING: 10,
+    TAP_DELAY_MS: 300, // Delay between touch and simulated mouse events on touch devices
+};
+
+/**
+ * Stores result from supportsCssVariables to avoid redundant processing to
+ * detect CSS custom variable support.
+ */
+function getNormalizedEventCoords(evt, pageOffset, clientRect) {
+    if (!evt) {
+        return { x: 0, y: 0 };
+    }
+    var x = pageOffset.x, y = pageOffset.y;
+    var documentX = x + clientRect.left;
+    var documentY = y + clientRect.top;
+    var normalizedX;
+    var normalizedY;
+    // Determine touch point relative to the ripple container.
+    if (evt.type === 'touchstart') {
+        var touchEvent = evt;
+        normalizedX = touchEvent.changedTouches[0].pageX - documentX;
+        normalizedY = touchEvent.changedTouches[0].pageY - documentY;
+    }
+    else {
+        var mouseEvent = evt;
+        normalizedX = mouseEvent.pageX - documentX;
+        normalizedY = mouseEvent.pageY - documentY;
+    }
+    return { x: normalizedX, y: normalizedY };
+}
+
+/**
+ * @license
+ * Copyright 2016 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+// Activation events registered on the root element of each instance for activation
+var ACTIVATION_EVENT_TYPES = [
+    'touchstart', 'pointerdown', 'mousedown', 'keydown',
+];
+// Deactivation events registered on documentElement when a pointer-related down event occurs
+var POINTER_DEACTIVATION_EVENT_TYPES = [
+    'touchend', 'pointerup', 'mouseup', 'contextmenu',
+];
+// simultaneous nested activations
+var activatedTargets = [];
+var MDCRippleFoundation = /** @class */ (function (_super) {
+    __extends(MDCRippleFoundation, _super);
+    function MDCRippleFoundation(adapter) {
+        var _this = _super.call(this, __assign(__assign({}, MDCRippleFoundation.defaultAdapter), adapter)) || this;
+        _this.activationAnimationHasEnded_ = false;
+        _this.activationTimer_ = 0;
+        _this.fgDeactivationRemovalTimer_ = 0;
+        _this.fgScale_ = '0';
+        _this.frame_ = { width: 0, height: 0 };
+        _this.initialSize_ = 0;
+        _this.layoutFrame_ = 0;
+        _this.maxRadius_ = 0;
+        _this.unboundedCoords_ = { left: 0, top: 0 };
+        _this.activationState_ = _this.defaultActivationState_();
+        _this.activationTimerCallback_ = function () {
+            _this.activationAnimationHasEnded_ = true;
+            _this.runDeactivationUXLogicIfReady_();
+        };
+        _this.activateHandler_ = function (e) { return _this.activate_(e); };
+        _this.deactivateHandler_ = function () { return _this.deactivate_(); };
+        _this.focusHandler_ = function () { return _this.handleFocus(); };
+        _this.blurHandler_ = function () { return _this.handleBlur(); };
+        _this.resizeHandler_ = function () { return _this.layout(); };
+        return _this;
+    }
+    Object.defineProperty(MDCRippleFoundation, "cssClasses", {
+        get: function () {
+            return cssClasses$1;
+        },
+        enumerable: false,
+        configurable: true
+    });
+    Object.defineProperty(MDCRippleFoundation, "strings", {
+        get: function () {
+            return strings$1;
+        },
+        enumerable: false,
+        configurable: true
+    });
+    Object.defineProperty(MDCRippleFoundation, "numbers", {
+        get: function () {
+            return numbers$1;
+        },
+        enumerable: false,
+        configurable: true
+    });
+    Object.defineProperty(MDCRippleFoundation, "defaultAdapter", {
+        get: function () {
+            return {
+                addClass: function () { return undefined; },
+                browserSupportsCssVars: function () { return true; },
+                computeBoundingRect: function () { return ({ top: 0, right: 0, bottom: 0, left: 0, width: 0, height: 0 }); },
+                containsEventTarget: function () { return true; },
+                deregisterDocumentInteractionHandler: function () { return undefined; },
+                deregisterInteractionHandler: function () { return undefined; },
+                deregisterResizeHandler: function () { return undefined; },
+                getWindowPageOffset: function () { return ({ x: 0, y: 0 }); },
+                isSurfaceActive: function () { return true; },
+                isSurfaceDisabled: function () { return true; },
+                isUnbounded: function () { return true; },
+                registerDocumentInteractionHandler: function () { return undefined; },
+                registerInteractionHandler: function () { return undefined; },
+                registerResizeHandler: function () { return undefined; },
+                removeClass: function () { return undefined; },
+                updateCssVariable: function () { return undefined; },
+            };
+        },
+        enumerable: false,
+        configurable: true
+    });
+    MDCRippleFoundation.prototype.init = function () {
+        var _this = this;
+        var supportsPressRipple = this.supportsPressRipple_();
+        this.registerRootHandlers_(supportsPressRipple);
+        if (supportsPressRipple) {
+            var _a = MDCRippleFoundation.cssClasses, ROOT_1 = _a.ROOT, UNBOUNDED_1 = _a.UNBOUNDED;
+            requestAnimationFrame(function () {
+                _this.adapter.addClass(ROOT_1);
+                if (_this.adapter.isUnbounded()) {
+                    _this.adapter.addClass(UNBOUNDED_1);
+                    // Unbounded ripples need layout logic applied immediately to set coordinates for both shade and ripple
+                    _this.layoutInternal_();
+                }
+            });
+        }
+    };
+    MDCRippleFoundation.prototype.destroy = function () {
+        var _this = this;
+        if (this.supportsPressRipple_()) {
+            if (this.activationTimer_) {
+                clearTimeout(this.activationTimer_);
+                this.activationTimer_ = 0;
+                this.adapter.removeClass(MDCRippleFoundation.cssClasses.FG_ACTIVATION);
+            }
+            if (this.fgDeactivationRemovalTimer_) {
+                clearTimeout(this.fgDeactivationRemovalTimer_);
+                this.fgDeactivationRemovalTimer_ = 0;
+                this.adapter.removeClass(MDCRippleFoundation.cssClasses.FG_DEACTIVATION);
+            }
+            var _a = MDCRippleFoundation.cssClasses, ROOT_2 = _a.ROOT, UNBOUNDED_2 = _a.UNBOUNDED;
+            requestAnimationFrame(function () {
+                _this.adapter.removeClass(ROOT_2);
+                _this.adapter.removeClass(UNBOUNDED_2);
+                _this.removeCssVars_();
+            });
+        }
+        this.deregisterRootHandlers_();
+        this.deregisterDeactivationHandlers_();
+    };
+    /**
+     * @param evt Optional event containing position information.
+     */
+    MDCRippleFoundation.prototype.activate = function (evt) {
+        this.activate_(evt);
+    };
+    MDCRippleFoundation.prototype.deactivate = function () {
+        this.deactivate_();
+    };
+    MDCRippleFoundation.prototype.layout = function () {
+        var _this = this;
+        if (this.layoutFrame_) {
+            cancelAnimationFrame(this.layoutFrame_);
+        }
+        this.layoutFrame_ = requestAnimationFrame(function () {
+            _this.layoutInternal_();
+            _this.layoutFrame_ = 0;
+        });
+    };
+    MDCRippleFoundation.prototype.setUnbounded = function (unbounded) {
+        var UNBOUNDED = MDCRippleFoundation.cssClasses.UNBOUNDED;
+        if (unbounded) {
+            this.adapter.addClass(UNBOUNDED);
+        }
+        else {
+            this.adapter.removeClass(UNBOUNDED);
+        }
+    };
+    MDCRippleFoundation.prototype.handleFocus = function () {
+        var _this = this;
+        requestAnimationFrame(function () { return _this.adapter.addClass(MDCRippleFoundation.cssClasses.BG_FOCUSED); });
+    };
+    MDCRippleFoundation.prototype.handleBlur = function () {
+        var _this = this;
+        requestAnimationFrame(function () { return _this.adapter.removeClass(MDCRippleFoundation.cssClasses.BG_FOCUSED); });
+    };
+    /**
+     * We compute this property so that we are not querying information about the client
+     * until the point in time where the foundation requests it. This prevents scenarios where
+     * client-side feature-detection may happen too early, such as when components are rendered on the server
+     * and then initialized at mount time on the client.
+     */
+    MDCRippleFoundation.prototype.supportsPressRipple_ = function () {
+        return this.adapter.browserSupportsCssVars();
+    };
+    MDCRippleFoundation.prototype.defaultActivationState_ = function () {
+        return {
+            activationEvent: undefined,
+            hasDeactivationUXRun: false,
+            isActivated: false,
+            isProgrammatic: false,
+            wasActivatedByPointer: false,
+            wasElementMadeActive: false,
+        };
+    };
+    /**
+     * supportsPressRipple Passed from init to save a redundant function call
+     */
+    MDCRippleFoundation.prototype.registerRootHandlers_ = function (supportsPressRipple) {
+        var _this = this;
+        if (supportsPressRipple) {
+            ACTIVATION_EVENT_TYPES.forEach(function (evtType) {
+                _this.adapter.registerInteractionHandler(evtType, _this.activateHandler_);
+            });
+            if (this.adapter.isUnbounded()) {
+                this.adapter.registerResizeHandler(this.resizeHandler_);
+            }
+        }
+        this.adapter.registerInteractionHandler('focus', this.focusHandler_);
+        this.adapter.registerInteractionHandler('blur', this.blurHandler_);
+    };
+    MDCRippleFoundation.prototype.registerDeactivationHandlers_ = function (evt) {
+        var _this = this;
+        if (evt.type === 'keydown') {
+            this.adapter.registerInteractionHandler('keyup', this.deactivateHandler_);
+        }
+        else {
+            POINTER_DEACTIVATION_EVENT_TYPES.forEach(function (evtType) {
+                _this.adapter.registerDocumentInteractionHandler(evtType, _this.deactivateHandler_);
+            });
+        }
+    };
+    MDCRippleFoundation.prototype.deregisterRootHandlers_ = function () {
+        var _this = this;
+        ACTIVATION_EVENT_TYPES.forEach(function (evtType) {
+            _this.adapter.deregisterInteractionHandler(evtType, _this.activateHandler_);
+        });
+        this.adapter.deregisterInteractionHandler('focus', this.focusHandler_);
+        this.adapter.deregisterInteractionHandler('blur', this.blurHandler_);
+        if (this.adapter.isUnbounded()) {
+            this.adapter.deregisterResizeHandler(this.resizeHandler_);
+        }
+    };
+    MDCRippleFoundation.prototype.deregisterDeactivationHandlers_ = function () {
+        var _this = this;
+        this.adapter.deregisterInteractionHandler('keyup', this.deactivateHandler_);
+        POINTER_DEACTIVATION_EVENT_TYPES.forEach(function (evtType) {
+            _this.adapter.deregisterDocumentInteractionHandler(evtType, _this.deactivateHandler_);
+        });
+    };
+    MDCRippleFoundation.prototype.removeCssVars_ = function () {
+        var _this = this;
+        var rippleStrings = MDCRippleFoundation.strings;
+        var keys = Object.keys(rippleStrings);
+        keys.forEach(function (key) {
+            if (key.indexOf('VAR_') === 0) {
+                _this.adapter.updateCssVariable(rippleStrings[key], null);
+            }
+        });
+    };
+    MDCRippleFoundation.prototype.activate_ = function (evt) {
+        var _this = this;
+        if (this.adapter.isSurfaceDisabled()) {
+            return;
+        }
+        var activationState = this.activationState_;
+        if (activationState.isActivated) {
+            return;
+        }
+        // Avoid reacting to follow-on events fired by touch device after an already-processed user interaction
+        var previousActivationEvent = this.previousActivationEvent_;
+        var isSameInteraction = previousActivationEvent && evt !== undefined && previousActivationEvent.type !== evt.type;
+        if (isSameInteraction) {
+            return;
+        }
+        activationState.isActivated = true;
+        activationState.isProgrammatic = evt === undefined;
+        activationState.activationEvent = evt;
+        activationState.wasActivatedByPointer = activationState.isProgrammatic ? false : evt !== undefined && (evt.type === 'mousedown' || evt.type === 'touchstart' || evt.type === 'pointerdown');
+        var hasActivatedChild = evt !== undefined &&
+            activatedTargets.length > 0 &&
+            activatedTargets.some(function (target) { return _this.adapter.containsEventTarget(target); });
+        if (hasActivatedChild) {
+            // Immediately reset activation state, while preserving logic that prevents touch follow-on events
+            this.resetActivationState_();
+            return;
+        }
+        if (evt !== undefined) {
+            activatedTargets.push(evt.target);
+            this.registerDeactivationHandlers_(evt);
+        }
+        activationState.wasElementMadeActive = this.checkElementMadeActive_(evt);
+        if (activationState.wasElementMadeActive) {
+            this.animateActivation_();
+        }
+        requestAnimationFrame(function () {
+            // Reset array on next frame after the current event has had a chance to bubble to prevent ancestor ripples
+            activatedTargets = [];
+            if (!activationState.wasElementMadeActive
+                && evt !== undefined
+                && (evt.key === ' ' || evt.keyCode === 32)) {
+                // If space was pressed, try again within an rAF call to detect :active, because different UAs report
+                // active states inconsistently when they're called within event handling code:
+                // - https://bugs.chromium.org/p/chromium/issues/detail?id=635971
+                // - https://bugzilla.mozilla.org/show_bug.cgi?id=1293741
+                // We try first outside rAF to support Edge, which does not exhibit this problem, but will crash if a CSS
+                // variable is set within a rAF callback for a submit button interaction (#2241).
+                activationState.wasElementMadeActive = _this.checkElementMadeActive_(evt);
+                if (activationState.wasElementMadeActive) {
+                    _this.animateActivation_();
+                }
+            }
+            if (!activationState.wasElementMadeActive) {
+                // Reset activation state immediately if element was not made active.
+                _this.activationState_ = _this.defaultActivationState_();
+            }
+        });
+    };
+    MDCRippleFoundation.prototype.checkElementMadeActive_ = function (evt) {
+        return (evt !== undefined && evt.type === 'keydown') ?
+            this.adapter.isSurfaceActive() :
+            true;
+    };
+    MDCRippleFoundation.prototype.animateActivation_ = function () {
+        var _this = this;
+        var _a = MDCRippleFoundation.strings, VAR_FG_TRANSLATE_START = _a.VAR_FG_TRANSLATE_START, VAR_FG_TRANSLATE_END = _a.VAR_FG_TRANSLATE_END;
+        var _b = MDCRippleFoundation.cssClasses, FG_DEACTIVATION = _b.FG_DEACTIVATION, FG_ACTIVATION = _b.FG_ACTIVATION;
+        var DEACTIVATION_TIMEOUT_MS = MDCRippleFoundation.numbers.DEACTIVATION_TIMEOUT_MS;
+        this.layoutInternal_();
+        var translateStart = '';
+        var translateEnd = '';
+        if (!this.adapter.isUnbounded()) {
+            var _c = this.getFgTranslationCoordinates_(), startPoint = _c.startPoint, endPoint = _c.endPoint;
+            translateStart = startPoint.x + "px, " + startPoint.y + "px";
+            translateEnd = endPoint.x + "px, " + endPoint.y + "px";
+        }
+        this.adapter.updateCssVariable(VAR_FG_TRANSLATE_START, translateStart);
+        this.adapter.updateCssVariable(VAR_FG_TRANSLATE_END, translateEnd);
+        // Cancel any ongoing activation/deactivation animations
+        clearTimeout(this.activationTimer_);
+        clearTimeout(this.fgDeactivationRemovalTimer_);
+        this.rmBoundedActivationClasses_();
+        this.adapter.removeClass(FG_DEACTIVATION);
+        // Force layout in order to re-trigger the animation.
+        this.adapter.computeBoundingRect();
+        this.adapter.addClass(FG_ACTIVATION);
+        this.activationTimer_ = setTimeout(function () { return _this.activationTimerCallback_(); }, DEACTIVATION_TIMEOUT_MS);
+    };
+    MDCRippleFoundation.prototype.getFgTranslationCoordinates_ = function () {
+        var _a = this.activationState_, activationEvent = _a.activationEvent, wasActivatedByPointer = _a.wasActivatedByPointer;
+        var startPoint;
+        if (wasActivatedByPointer) {
+            startPoint = getNormalizedEventCoords(activationEvent, this.adapter.getWindowPageOffset(), this.adapter.computeBoundingRect());
+        }
+        else {
+            startPoint = {
+                x: this.frame_.width / 2,
+                y: this.frame_.height / 2,
+            };
+        }
+        // Center the element around the start point.
+        startPoint = {
+            x: startPoint.x - (this.initialSize_ / 2),
+            y: startPoint.y - (this.initialSize_ / 2),
+        };
+        var endPoint = {
+            x: (this.frame_.width / 2) - (this.initialSize_ / 2),
+            y: (this.frame_.height / 2) - (this.initialSize_ / 2),
+        };
+        return { startPoint: startPoint, endPoint: endPoint };
+    };
+    MDCRippleFoundation.prototype.runDeactivationUXLogicIfReady_ = function () {
+        var _this = this;
+        // This method is called both when a pointing device is released, and when the activation animation ends.
+        // The deactivation animation should only run after both of those occur.
+        var FG_DEACTIVATION = MDCRippleFoundation.cssClasses.FG_DEACTIVATION;
+        var _a = this.activationState_, hasDeactivationUXRun = _a.hasDeactivationUXRun, isActivated = _a.isActivated;
+        var activationHasEnded = hasDeactivationUXRun || !isActivated;
+        if (activationHasEnded && this.activationAnimationHasEnded_) {
+            this.rmBoundedActivationClasses_();
+            this.adapter.addClass(FG_DEACTIVATION);
+            this.fgDeactivationRemovalTimer_ = setTimeout(function () {
+                _this.adapter.removeClass(FG_DEACTIVATION);
+            }, numbers$1.FG_DEACTIVATION_MS);
+        }
+    };
+    MDCRippleFoundation.prototype.rmBoundedActivationClasses_ = function () {
+        var FG_ACTIVATION = MDCRippleFoundation.cssClasses.FG_ACTIVATION;
+        this.adapter.removeClass(FG_ACTIVATION);
+        this.activationAnimationHasEnded_ = false;
+        this.adapter.computeBoundingRect();
+    };
+    MDCRippleFoundation.prototype.resetActivationState_ = function () {
+        var _this = this;
+        this.previousActivationEvent_ = this.activationState_.activationEvent;
+        this.activationState_ = this.defaultActivationState_();
+        // Touch devices may fire additional events for the same interaction within a short time.
+        // Store the previous event until it's safe to assume that subsequent events are for new interactions.
+        setTimeout(function () { return _this.previousActivationEvent_ = undefined; }, MDCRippleFoundation.numbers.TAP_DELAY_MS);
+    };
+    MDCRippleFoundation.prototype.deactivate_ = function () {
+        var _this = this;
+        var activationState = this.activationState_;
+        // This can happen in scenarios such as when you have a keyup event that blurs the element.
+        if (!activationState.isActivated) {
+            return;
+        }
+        var state = __assign({}, activationState);
+        if (activationState.isProgrammatic) {
+            requestAnimationFrame(function () { return _this.animateDeactivation_(state); });
+            this.resetActivationState_();
+        }
+        else {
+            this.deregisterDeactivationHandlers_();
+            requestAnimationFrame(function () {
+                _this.activationState_.hasDeactivationUXRun = true;
+                _this.animateDeactivation_(state);
+                _this.resetActivationState_();
+            });
+        }
+    };
+    MDCRippleFoundation.prototype.animateDeactivation_ = function (_a) {
+        var wasActivatedByPointer = _a.wasActivatedByPointer, wasElementMadeActive = _a.wasElementMadeActive;
+        if (wasActivatedByPointer || wasElementMadeActive) {
+            this.runDeactivationUXLogicIfReady_();
+        }
+    };
+    MDCRippleFoundation.prototype.layoutInternal_ = function () {
+        var _this = this;
+        this.frame_ = this.adapter.computeBoundingRect();
+        var maxDim = Math.max(this.frame_.height, this.frame_.width);
+        // Surface diameter is treated differently for unbounded vs. bounded ripples.
+        // Unbounded ripple diameter is calculated smaller since the surface is expected to already be padded appropriately
+        // to extend the hitbox, and the ripple is expected to meet the edges of the padded hitbox (which is typically
+        // square). Bounded ripples, on the other hand, are fully expected to expand beyond the surface's longest diameter
+        // (calculated based on the diagonal plus a constant padding), and are clipped at the surface's border via
+        // `overflow: hidden`.
+        var getBoundedRadius = function () {
+            var hypotenuse = Math.sqrt(Math.pow(_this.frame_.width, 2) + Math.pow(_this.frame_.height, 2));
+            return hypotenuse + MDCRippleFoundation.numbers.PADDING;
+        };
+        this.maxRadius_ = this.adapter.isUnbounded() ? maxDim : getBoundedRadius();
+        // Ripple is sized as a fraction of the largest dimension of the surface, then scales up using a CSS scale transform
+        var initialSize = Math.floor(maxDim * MDCRippleFoundation.numbers.INITIAL_ORIGIN_SCALE);
+        // Unbounded ripple size should always be even number to equally center align.
+        if (this.adapter.isUnbounded() && initialSize % 2 !== 0) {
+            this.initialSize_ = initialSize - 1;
+        }
+        else {
+            this.initialSize_ = initialSize;
+        }
+        this.fgScale_ = "" + this.maxRadius_ / this.initialSize_;
+        this.updateLayoutCssVars_();
+    };
+    MDCRippleFoundation.prototype.updateLayoutCssVars_ = function () {
+        var _a = MDCRippleFoundation.strings, VAR_FG_SIZE = _a.VAR_FG_SIZE, VAR_LEFT = _a.VAR_LEFT, VAR_TOP = _a.VAR_TOP, VAR_FG_SCALE = _a.VAR_FG_SCALE;
+        this.adapter.updateCssVariable(VAR_FG_SIZE, this.initialSize_ + "px");
+        this.adapter.updateCssVariable(VAR_FG_SCALE, this.fgScale_);
+        if (this.adapter.isUnbounded()) {
+            this.unboundedCoords_ = {
+                left: Math.round((this.frame_.width / 2) - (this.initialSize_ / 2)),
+                top: Math.round((this.frame_.height / 2) - (this.initialSize_ / 2)),
+            };
+            this.adapter.updateCssVariable(VAR_LEFT, this.unboundedCoords_.left + "px");
+            this.adapter.updateCssVariable(VAR_TOP, this.unboundedCoords_.top + "px");
+        }
+    };
+    return MDCRippleFoundation;
+}(MDCFoundation$1));
+
+/** @soyCompatible */
+class RippleBase extends BaseElement$1 {
+    constructor() {
+        super(...arguments);
+        this.primary = false;
+        this.accent = false;
+        this.unbounded = false;
+        this.disabled = false;
+        this.activated = false;
+        this.selected = false;
+        this.hovering = false;
+        this.bgFocused = false;
+        this.fgActivation = false;
+        this.fgDeactivation = false;
+        this.fgScale = '';
+        this.fgSize = '';
+        this.translateStart = '';
+        this.translateEnd = '';
+        this.leftPos = '';
+        this.topPos = '';
+        this.mdcFoundationClass = MDCRippleFoundation;
+    }
+    get isActive() {
+        return matches(this.parentElement || this, ':active');
+    }
+    createAdapter() {
+        return {
+            browserSupportsCssVars: () => true,
+            isUnbounded: () => this.unbounded,
+            isSurfaceActive: () => this.isActive,
+            isSurfaceDisabled: () => this.disabled,
+            addClass: (className) => {
+                switch (className) {
+                    case 'mdc-ripple-upgraded--background-focused':
+                        this.bgFocused = true;
+                        break;
+                    case 'mdc-ripple-upgraded--foreground-activation':
+                        this.fgActivation = true;
+                        break;
+                    case 'mdc-ripple-upgraded--foreground-deactivation':
+                        this.fgDeactivation = true;
+                        break;
+                }
+            },
+            removeClass: (className) => {
+                switch (className) {
+                    case 'mdc-ripple-upgraded--background-focused':
+                        this.bgFocused = false;
+                        break;
+                    case 'mdc-ripple-upgraded--foreground-activation':
+                        this.fgActivation = false;
+                        break;
+                    case 'mdc-ripple-upgraded--foreground-deactivation':
+                        this.fgDeactivation = false;
+                        break;
+                }
+            },
+            containsEventTarget: () => true,
+            registerInteractionHandler: () => undefined,
+            deregisterInteractionHandler: () => undefined,
+            registerDocumentInteractionHandler: () => undefined,
+            deregisterDocumentInteractionHandler: () => undefined,
+            registerResizeHandler: () => undefined,
+            deregisterResizeHandler: () => undefined,
+            updateCssVariable: (varName, value) => {
+                switch (varName) {
+                    case '--mdc-ripple-fg-scale':
+                        this.fgScale = value;
+                        break;
+                    case '--mdc-ripple-fg-size':
+                        this.fgSize = value;
+                        break;
+                    case '--mdc-ripple-fg-translate-end':
+                        this.translateEnd = value;
+                        break;
+                    case '--mdc-ripple-fg-translate-start':
+                        this.translateStart = value;
+                        break;
+                    case '--mdc-ripple-left':
+                        this.leftPos = value;
+                        break;
+                    case '--mdc-ripple-top':
+                        this.topPos = value;
+                        break;
+                }
+            },
+            computeBoundingRect: () => (this.parentElement || this).getBoundingClientRect(),
+            getWindowPageOffset: () => ({ x: window.pageXOffset, y: window.pageYOffset }),
+        };
+    }
+    startPress(ev) {
+        this.waitForFoundation(() => {
+            this.mdcFoundation.activate(ev);
+        });
+    }
+    endPress() {
+        this.waitForFoundation(() => {
+            this.mdcFoundation.deactivate();
+        });
+    }
+    startFocus() {
+        this.waitForFoundation(() => {
+            this.mdcFoundation.handleFocus();
+        });
+    }
+    endFocus() {
+        this.waitForFoundation(() => {
+            this.mdcFoundation.handleBlur();
+        });
+    }
+    startHover() {
+        this.hovering = true;
+    }
+    endHover() {
+        this.hovering = false;
+    }
+    /**
+     * Wait for the MDCFoundation to be created by `firstUpdated`
+     */
+    waitForFoundation(fn) {
+        if (this.mdcFoundation) {
+            fn();
+        }
+        else {
+            this.updateComplete.then(fn);
+        }
+    }
+    update(changedProperties) {
+        if (changedProperties.has('disabled')) {
+            // stop hovering when ripple is disabled to prevent a stuck "hover" state
+            // When re-enabled, the outer component will get a `mouseenter` event on
+            // the first movement, which will call `startHover()`
+            if (this.disabled) {
+                this.endHover();
+            }
+        }
+        super.update(changedProperties);
+    }
+    /** @soyTemplate */
+    render() {
+        const shouldActivateInPrimary = this.activated && (this.primary || !this.accent);
+        const shouldSelectInPrimary = this.selected && (this.primary || !this.accent);
+        /** @classMap */
+        const classes = {
+            'mdc-ripple-surface--accent': this.accent,
+            'mdc-ripple-surface--primary--activated': shouldActivateInPrimary,
+            'mdc-ripple-surface--accent--activated': this.accent && this.activated,
+            'mdc-ripple-surface--primary--selected': shouldSelectInPrimary,
+            'mdc-ripple-surface--accent--selected': this.accent && this.selected,
+            'mdc-ripple-surface--disabled': this.disabled,
+            'mdc-ripple-surface--hover': this.hovering,
+            'mdc-ripple-surface--primary': this.primary,
+            'mdc-ripple-surface--selected': this.selected,
+            'mdc-ripple-upgraded--background-focused': this.bgFocused,
+            'mdc-ripple-upgraded--foreground-activation': this.fgActivation,
+            'mdc-ripple-upgraded--foreground-deactivation': this.fgDeactivation,
+            'mdc-ripple-upgraded--unbounded': this.unbounded,
+        };
+        return html `
+        <div class="mdc-ripple-surface mdc-ripple-upgraded ${classMap(classes)}"
+          style="${styleMap({
+            '--mdc-ripple-fg-scale': this.fgScale,
+            '--mdc-ripple-fg-size': this.fgSize,
+            '--mdc-ripple-fg-translate-end': this.translateEnd,
+            '--mdc-ripple-fg-translate-start': this.translateStart,
+            '--mdc-ripple-left': this.leftPos,
+            '--mdc-ripple-top': this.topPos,
+        })}"></div>`;
+    }
+}
+__decorate([
+    query('.mdc-ripple-surface')
+], RippleBase.prototype, "mdcRoot", void 0);
+__decorate([
+    property({ type: Boolean })
+], RippleBase.prototype, "primary", void 0);
+__decorate([
+    property({ type: Boolean })
+], RippleBase.prototype, "accent", void 0);
+__decorate([
+    property({ type: Boolean })
+], RippleBase.prototype, "unbounded", void 0);
+__decorate([
+    property({ type: Boolean })
+], RippleBase.prototype, "disabled", void 0);
+__decorate([
+    property({ type: Boolean })
+], RippleBase.prototype, "activated", void 0);
+__decorate([
+    property({ type: Boolean })
+], RippleBase.prototype, "selected", void 0);
+__decorate([
+    internalProperty()
+], RippleBase.prototype, "hovering", void 0);
+__decorate([
+    internalProperty()
+], RippleBase.prototype, "bgFocused", void 0);
+__decorate([
+    internalProperty()
+], RippleBase.prototype, "fgActivation", void 0);
+__decorate([
+    internalProperty()
+], RippleBase.prototype, "fgDeactivation", void 0);
+__decorate([
+    internalProperty()
+], RippleBase.prototype, "fgScale", void 0);
+__decorate([
+    internalProperty()
+], RippleBase.prototype, "fgSize", void 0);
+__decorate([
+    internalProperty()
+], RippleBase.prototype, "translateStart", void 0);
+__decorate([
+    internalProperty()
+], RippleBase.prototype, "translateEnd", void 0);
+__decorate([
+    internalProperty()
+], RippleBase.prototype, "leftPos", void 0);
+__decorate([
+    internalProperty()
+], RippleBase.prototype, "topPos", void 0);
+
+/**
+@license
+Copyright 2018 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+const style$1 = css `.mdc-ripple-surface{--mdc-ripple-fg-size: 0;--mdc-ripple-left: 0;--mdc-ripple-top: 0;--mdc-ripple-fg-scale: 1;--mdc-ripple-fg-translate-end: 0;--mdc-ripple-fg-translate-start: 0;-webkit-tap-highlight-color:rgba(0,0,0,0);will-change:transform,opacity;position:relative;outline:none;overflow:hidden}.mdc-ripple-surface::before,.mdc-ripple-surface::after{position:absolute;border-radius:50%;opacity:0;pointer-events:none;content:""}.mdc-ripple-surface::before{transition:opacity 15ms linear,background-color 15ms linear;z-index:1;z-index:var(--mdc-ripple-z-index, 1)}.mdc-ripple-surface::after{z-index:0;z-index:var(--mdc-ripple-z-index, 0)}.mdc-ripple-surface.mdc-ripple-upgraded::before{transform:scale(var(--mdc-ripple-fg-scale, 1))}.mdc-ripple-surface.mdc-ripple-upgraded::after{top:0;left:0;transform:scale(0);transform-origin:center center}.mdc-ripple-surface.mdc-ripple-upgraded--unbounded::after{top:var(--mdc-ripple-top, 0);left:var(--mdc-ripple-left, 0)}.mdc-ripple-surface.mdc-ripple-upgraded--foreground-activation::after{animation:mdc-ripple-fg-radius-in 225ms forwards,mdc-ripple-fg-opacity-in 75ms forwards}.mdc-ripple-surface.mdc-ripple-upgraded--foreground-deactivation::after{animation:mdc-ripple-fg-opacity-out 150ms;transform:translate(var(--mdc-ripple-fg-translate-end, 0)) scale(var(--mdc-ripple-fg-scale, 1))}.mdc-ripple-surface::before,.mdc-ripple-surface::after{background-color:#000;background-color:var(--mdc-ripple-color, #000)}.mdc-ripple-surface:hover::before,.mdc-ripple-surface.mdc-ripple-surface--hover::before{opacity:0.04;opacity:var(--mdc-ripple-hover-opacity, 0.04)}.mdc-ripple-surface.mdc-ripple-upgraded--background-focused::before,.mdc-ripple-surface:not(.mdc-ripple-upgraded):focus::before{transition-duration:75ms;opacity:0.12;opacity:var(--mdc-ripple-focus-opacity, 0.12)}.mdc-ripple-surface:not(.mdc-ripple-upgraded)::after{transition:opacity 150ms linear}.mdc-ripple-surface:not(.mdc-ripple-upgraded):active::after{transition-duration:75ms;opacity:0.12;opacity:var(--mdc-ripple-press-opacity, 0.12)}.mdc-ripple-surface.mdc-ripple-upgraded{--mdc-ripple-fg-opacity: var(--mdc-ripple-press-opacity, 0.12)}.mdc-ripple-surface::before,.mdc-ripple-surface::after{top:calc(50% - 100%);left:calc(50% - 100%);width:200%;height:200%}.mdc-ripple-surface.mdc-ripple-upgraded::after{width:var(--mdc-ripple-fg-size, 100%);height:var(--mdc-ripple-fg-size, 100%)}.mdc-ripple-surface[data-mdc-ripple-is-unbounded],.mdc-ripple-upgraded--unbounded{overflow:visible}.mdc-ripple-surface[data-mdc-ripple-is-unbounded]::before,.mdc-ripple-surface[data-mdc-ripple-is-unbounded]::after,.mdc-ripple-upgraded--unbounded::before,.mdc-ripple-upgraded--unbounded::after{top:calc(50% - 50%);left:calc(50% - 50%);width:100%;height:100%}.mdc-ripple-surface[data-mdc-ripple-is-unbounded].mdc-ripple-upgraded::before,.mdc-ripple-surface[data-mdc-ripple-is-unbounded].mdc-ripple-upgraded::after,.mdc-ripple-upgraded--unbounded.mdc-ripple-upgraded::before,.mdc-ripple-upgraded--unbounded.mdc-ripple-upgraded::after{top:var(--mdc-ripple-top, calc(50% - 50%));left:var(--mdc-ripple-left, calc(50% - 50%));width:var(--mdc-ripple-fg-size, 100%);height:var(--mdc-ripple-fg-size, 100%)}.mdc-ripple-surface[data-mdc-ripple-is-unbounded].mdc-ripple-upgraded::after,.mdc-ripple-upgraded--unbounded.mdc-ripple-upgraded::after{width:var(--mdc-ripple-fg-size, 100%);height:var(--mdc-ripple-fg-size, 100%)}@keyframes mdc-ripple-fg-radius-in{from{animation-timing-function:cubic-bezier(0.4, 0, 0.2, 1);transform:translate(var(--mdc-ripple-fg-translate-start, 0)) scale(1)}to{transform:translate(var(--mdc-ripple-fg-translate-end, 0)) scale(var(--mdc-ripple-fg-scale, 1))}}@keyframes mdc-ripple-fg-opacity-in{from{animation-timing-function:linear;opacity:0}to{opacity:var(--mdc-ripple-fg-opacity, 0)}}@keyframes mdc-ripple-fg-opacity-out{from{animation-timing-function:linear;opacity:var(--mdc-ripple-fg-opacity, 0)}to{opacity:0}}:host{position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none;display:block}:host .mdc-ripple-surface{position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none;will-change:unset}.mdc-ripple-surface--primary::before,.mdc-ripple-surface--primary::after{background-color:#6200ee;background-color:var(--mdc-ripple-color, var(--mdc-theme-primary, #6200ee))}.mdc-ripple-surface--primary:hover::before,.mdc-ripple-surface--primary.mdc-ripple-surface--hover::before{opacity:0.04;opacity:var(--mdc-ripple-hover-opacity, 0.04)}.mdc-ripple-surface--primary.mdc-ripple-upgraded--background-focused::before,.mdc-ripple-surface--primary:not(.mdc-ripple-upgraded):focus::before{transition-duration:75ms;opacity:0.12;opacity:var(--mdc-ripple-focus-opacity, 0.12)}.mdc-ripple-surface--primary:not(.mdc-ripple-upgraded)::after{transition:opacity 150ms linear}.mdc-ripple-surface--primary:not(.mdc-ripple-upgraded):active::after{transition-duration:75ms;opacity:0.12;opacity:var(--mdc-ripple-press-opacity, 0.12)}.mdc-ripple-surface--primary.mdc-ripple-upgraded{--mdc-ripple-fg-opacity: var(--mdc-ripple-press-opacity, 0.12)}.mdc-ripple-surface--primary--activated::before{opacity:0.12;opacity:var(--mdc-ripple-activated-opacity, 0.12)}.mdc-ripple-surface--primary--activated::before,.mdc-ripple-surface--primary--activated::after{background-color:#6200ee;background-color:var(--mdc-ripple-color, var(--mdc-theme-primary, #6200ee))}.mdc-ripple-surface--primary--activated:hover::before,.mdc-ripple-surface--primary--activated.mdc-ripple-surface--hover::before{opacity:0.16;opacity:var(--mdc-ripple-hover-opacity, 0.16)}.mdc-ripple-surface--primary--activated.mdc-ripple-upgraded--background-focused::before,.mdc-ripple-surface--primary--activated:not(.mdc-ripple-upgraded):focus::before{transition-duration:75ms;opacity:0.24;opacity:var(--mdc-ripple-focus-opacity, 0.24)}.mdc-ripple-surface--primary--activated:not(.mdc-ripple-upgraded)::after{transition:opacity 150ms linear}.mdc-ripple-surface--primary--activated:not(.mdc-ripple-upgraded):active::after{transition-duration:75ms;opacity:0.24;opacity:var(--mdc-ripple-press-opacity, 0.24)}.mdc-ripple-surface--primary--activated.mdc-ripple-upgraded{--mdc-ripple-fg-opacity: var(--mdc-ripple-press-opacity, 0.24)}.mdc-ripple-surface--primary--selected::before{opacity:0.08;opacity:var(--mdc-ripple-selected-opacity, 0.08)}.mdc-ripple-surface--primary--selected::before,.mdc-ripple-surface--primary--selected::after{background-color:#6200ee;background-color:var(--mdc-ripple-color, var(--mdc-theme-primary, #6200ee))}.mdc-ripple-surface--primary--selected:hover::before,.mdc-ripple-surface--primary--selected.mdc-ripple-surface--hover::before{opacity:0.12;opacity:var(--mdc-ripple-hover-opacity, 0.12)}.mdc-ripple-surface--primary--selected.mdc-ripple-upgraded--background-focused::before,.mdc-ripple-surface--primary--selected:not(.mdc-ripple-upgraded):focus::before{transition-duration:75ms;opacity:0.2;opacity:var(--mdc-ripple-focus-opacity, 0.2)}.mdc-ripple-surface--primary--selected:not(.mdc-ripple-upgraded)::after{transition:opacity 150ms linear}.mdc-ripple-surface--primary--selected:not(.mdc-ripple-upgraded):active::after{transition-duration:75ms;opacity:0.2;opacity:var(--mdc-ripple-press-opacity, 0.2)}.mdc-ripple-surface--primary--selected.mdc-ripple-upgraded{--mdc-ripple-fg-opacity: var(--mdc-ripple-press-opacity, 0.2)}.mdc-ripple-surface--accent::before,.mdc-ripple-surface--accent::after{background-color:#018786;background-color:var(--mdc-ripple-color, var(--mdc-theme-secondary, #018786))}.mdc-ripple-surface--accent:hover::before,.mdc-ripple-surface--accent.mdc-ripple-surface--hover::before{opacity:0.04;opacity:var(--mdc-ripple-hover-opacity, 0.04)}.mdc-ripple-surface--accent.mdc-ripple-upgraded--background-focused::before,.mdc-ripple-surface--accent:not(.mdc-ripple-upgraded):focus::before{transition-duration:75ms;opacity:0.12;opacity:var(--mdc-ripple-focus-opacity, 0.12)}.mdc-ripple-surface--accent:not(.mdc-ripple-upgraded)::after{transition:opacity 150ms linear}.mdc-ripple-surface--accent:not(.mdc-ripple-upgraded):active::after{transition-duration:75ms;opacity:0.12;opacity:var(--mdc-ripple-press-opacity, 0.12)}.mdc-ripple-surface--accent.mdc-ripple-upgraded{--mdc-ripple-fg-opacity: var(--mdc-ripple-press-opacity, 0.12)}.mdc-ripple-surface--accent--activated::before{opacity:0.12;opacity:var(--mdc-ripple-activated-opacity, 0.12)}.mdc-ripple-surface--accent--activated::before,.mdc-ripple-surface--accent--activated::after{background-color:#018786;background-color:var(--mdc-ripple-color, var(--mdc-theme-secondary, #018786))}.mdc-ripple-surface--accent--activated:hover::before,.mdc-ripple-surface--accent--activated.mdc-ripple-surface--hover::before{opacity:0.16;opacity:var(--mdc-ripple-hover-opacity, 0.16)}.mdc-ripple-surface--accent--activated.mdc-ripple-upgraded--background-focused::before,.mdc-ripple-surface--accent--activated:not(.mdc-ripple-upgraded):focus::before{transition-duration:75ms;opacity:0.24;opacity:var(--mdc-ripple-focus-opacity, 0.24)}.mdc-ripple-surface--accent--activated:not(.mdc-ripple-upgraded)::after{transition:opacity 150ms linear}.mdc-ripple-surface--accent--activated:not(.mdc-ripple-upgraded):active::after{transition-duration:75ms;opacity:0.24;opacity:var(--mdc-ripple-press-opacity, 0.24)}.mdc-ripple-surface--accent--activated.mdc-ripple-upgraded{--mdc-ripple-fg-opacity: var(--mdc-ripple-press-opacity, 0.24)}.mdc-ripple-surface--accent--selected::before{opacity:0.08;opacity:var(--mdc-ripple-selected-opacity, 0.08)}.mdc-ripple-surface--accent--selected::before,.mdc-ripple-surface--accent--selected::after{background-color:#018786;background-color:var(--mdc-ripple-color, var(--mdc-theme-secondary, #018786))}.mdc-ripple-surface--accent--selected:hover::before,.mdc-ripple-surface--accent--selected.mdc-ripple-surface--hover::before{opacity:0.12;opacity:var(--mdc-ripple-hover-opacity, 0.12)}.mdc-ripple-surface--accent--selected.mdc-ripple-upgraded--background-focused::before,.mdc-ripple-surface--accent--selected:not(.mdc-ripple-upgraded):focus::before{transition-duration:75ms;opacity:0.2;opacity:var(--mdc-ripple-focus-opacity, 0.2)}.mdc-ripple-surface--accent--selected:not(.mdc-ripple-upgraded)::after{transition:opacity 150ms linear}.mdc-ripple-surface--accent--selected:not(.mdc-ripple-upgraded):active::after{transition-duration:75ms;opacity:0.2;opacity:var(--mdc-ripple-press-opacity, 0.2)}.mdc-ripple-surface--accent--selected.mdc-ripple-upgraded{--mdc-ripple-fg-opacity: var(--mdc-ripple-press-opacity, 0.2)}.mdc-ripple-surface--disabled{opacity:0}`;
+
+/** @soyCompatible */
+let Ripple = class Ripple extends RippleBase {
+};
+Ripple.styles = style$1;
+Ripple = __decorate([
+    customElement('mwc-ripple')
+], Ripple);
+
+/**
+@license
+Copyright 2018 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/ // tslint:disable:no-any
+/**
+ * Specifies an observer callback that is run when the decorated property
+ * changes. The observer receives the current and old value as arguments.
+ */
+const observer = (observer) => 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(proto, propName) => {
+    // if we haven't wrapped `updated` in this class, do so
+    if (!proto.constructor
+        ._observers) {
+        proto.constructor._observers = new Map();
+        const userUpdated = proto.updated;
+        proto.updated = function (changedProperties) {
+            userUpdated.call(this, changedProperties);
+            changedProperties.forEach((v, k) => {
+                const observers = this.constructor
+                    ._observers;
+                const observer = observers.get(k);
+                if (observer !== undefined) {
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    observer.call(this, this[k], v);
+                }
+            });
+        };
+        // clone any existing observers (superclasses)
+        // eslint-disable-next-line no-prototype-builtins
+    }
+    else if (!proto.constructor.hasOwnProperty('_observers')) {
+        const observers = proto.constructor._observers;
+        proto.constructor._observers = new Map();
+        observers.forEach(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (v, k) => proto.constructor._observers.set(k, v));
+    }
+    // set this method
+    proto.constructor._observers.set(propName, observer);
+};
+
+/**
+@license
+Copyright 2020 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/**
+ * Class that encapsulates the events handlers for `mwc-ripple`
+ *
+ *
+ * Example:
+ * ```
+ * class XFoo extends LitElement {
+ *   async getRipple() {
+ *     this.renderRipple = true;
+ *     await this.updateComplete;
+ *     return this.renderRoot.querySelector('mwc-ripple');
+ *   }
+ *   rippleHandlers = new RippleHandlers(() => this.getRipple());
+ *
+ *   render() {
+ *     return html`
+ *       <div @mousedown=${this.rippleHandlers.startPress}></div>
+ *       ${this.renderRipple ? html`<mwc-ripple></mwc-ripple>` : ''}
+ *     `;
+ *   }
+ * }
+ * ```
+ */
+class RippleHandlers {
+    constructor(
+    /** Function that returns a `mwc-ripple` */
+    rippleFn) {
+        this.startPress = (ev) => {
+            rippleFn().then((r) => {
+                r && r.startPress(ev);
+            });
+        };
+        this.endPress = () => {
+            rippleFn().then((r) => {
+                r && r.endPress();
+            });
+        };
+        this.startFocus = () => {
+            rippleFn().then((r) => {
+                r && r.startFocus();
+            });
+        };
+        this.endFocus = () => {
+            rippleFn().then((r) => {
+                r && r.endFocus();
+            });
+        };
+        this.startHover = () => {
+            rippleFn().then((r) => {
+                r && r.startHover();
+            });
+        };
+        this.endHover = () => {
+            rippleFn().then((r) => {
+                r && r.endHover();
+            });
+        };
+    }
+}
+
+/**
+ @license
+ Copyright 2020 Google Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+/**
+ * @fires request-selected {RequestSelectedDetail}
+ * @fires list-item-rendered
+ */
+class ListItemBase extends LitElement {
+    constructor() {
+        super(...arguments);
+        this.value = '';
+        this.group = null;
+        this.tabindex = -1;
+        this.disabled = false;
+        this.twoline = false;
+        this.activated = false;
+        this.graphic = null;
+        this.multipleGraphics = false;
+        this.hasMeta = false;
+        this.noninteractive = false;
+        this.selected = false;
+        this.shouldRenderRipple = false;
+        this._managingList = null;
+        this.boundOnClick = this.onClick.bind(this);
+        this._firstChanged = true;
+        this._skipPropRequest = false;
+        this.rippleHandlers = new RippleHandlers(() => {
+            this.shouldRenderRipple = true;
+            return this.ripple;
+        });
+        this.listeners = [
+            {
+                target: this,
+                eventNames: ['click'],
+                cb: () => {
+                    this.onClick();
+                },
+            },
+            {
+                target: this,
+                eventNames: ['mouseenter'],
+                cb: this.rippleHandlers.startHover,
+            },
+            {
+                target: this,
+                eventNames: ['mouseleave'],
+                cb: this.rippleHandlers.endHover,
+            },
+            {
+                target: this,
+                eventNames: ['focus'],
+                cb: this.rippleHandlers.startFocus,
+            },
+            {
+                target: this,
+                eventNames: ['blur'],
+                cb: this.rippleHandlers.endFocus,
+            },
+            {
+                target: this,
+                eventNames: ['mousedown', 'touchstart'],
+                cb: (e) => {
+                    const name = e.type;
+                    this.onDown(name === 'mousedown' ? 'mouseup' : 'touchend', e);
+                },
+            },
+        ];
+    }
+    get text() {
+        const textContent = this.textContent;
+        return textContent ? textContent.trim() : '';
+    }
+    render() {
+        const text = this.renderText();
+        const graphic = this.graphic ? this.renderGraphic() : html ``;
+        const meta = this.hasMeta ? this.renderMeta() : html ``;
+        return html `
+      ${this.renderRipple()}
+      ${graphic}
+      ${text}
+      ${meta}`;
+    }
+    renderRipple() {
+        if (this.shouldRenderRipple) {
+            return html `
+      <mwc-ripple
+        .activated=${this.activated}>
+      </mwc-ripple>`;
+        }
+        else if (this.activated) {
+            return html `<div class="fake-activated-ripple"></div>`;
+        }
+        else {
+            return '';
+        }
+    }
+    renderGraphic() {
+        const graphicClasses = {
+            multi: this.multipleGraphics,
+        };
+        return html `
+      <span class="mdc-deprecated-list-item__graphic material-icons ${classMap(graphicClasses)}">
+        <slot name="graphic"></slot>
+      </span>`;
+    }
+    renderMeta() {
+        return html `
+      <span class="mdc-deprecated-list-item__meta material-icons">
+        <slot name="meta"></slot>
+      </span>`;
+    }
+    renderText() {
+        const inner = this.twoline ? this.renderTwoline() : this.renderSingleLine();
+        return html `
+      <span class="mdc-deprecated-list-item__text">
+        ${inner}
+      </span>`;
+    }
+    renderSingleLine() {
+        return html `<slot></slot>`;
+    }
+    renderTwoline() {
+        return html `
+      <span class="mdc-deprecated-list-item__primary-text">
+        <slot></slot>
+      </span>
+      <span class="mdc-deprecated-list-item__secondary-text">
+        <slot name="secondary"></slot>
+      </span>
+    `;
+    }
+    onClick() {
+        this.fireRequestSelected(!this.selected, 'interaction');
+    }
+    onDown(upName, evt) {
+        const onUp = () => {
+            window.removeEventListener(upName, onUp);
+            this.rippleHandlers.endPress();
+        };
+        window.addEventListener(upName, onUp);
+        this.rippleHandlers.startPress(evt);
+    }
+    fireRequestSelected(selected, source) {
+        if (this.noninteractive) {
+            return;
+        }
+        const customEv = new CustomEvent('request-selected', { bubbles: true, composed: true, detail: { source, selected } });
+        this.dispatchEvent(customEv);
+    }
+    connectedCallback() {
+        super.connectedCallback();
+        if (!this.noninteractive) {
+            this.setAttribute('mwc-list-item', '');
+        }
+        for (const listener of this.listeners) {
+            for (const eventName of listener.eventNames) {
+                listener.target.addEventListener(eventName, listener.cb, { passive: true });
+            }
+        }
+    }
+    disconnectedCallback() {
+        super.disconnectedCallback();
+        for (const listener of this.listeners) {
+            for (const eventName of listener.eventNames) {
+                listener.target.removeEventListener(eventName, listener.cb);
+            }
+        }
+        if (this._managingList) {
+            this._managingList.debouncedLayout ?
+                this._managingList.debouncedLayout(true) :
+                this._managingList.layout(true);
+        }
+    }
+    // composed flag, event fire through shadow root and up through composed tree
+    firstUpdated() {
+        const ev = new Event('list-item-rendered', { bubbles: true, composed: true });
+        this.dispatchEvent(ev);
+    }
+}
+__decorate([
+    query('slot')
+], ListItemBase.prototype, "slotElement", void 0);
+__decorate([
+    queryAsync('mwc-ripple')
+], ListItemBase.prototype, "ripple", void 0);
+__decorate([
+    property({ type: String })
+], ListItemBase.prototype, "value", void 0);
+__decorate([
+    property({ type: String, reflect: true })
+], ListItemBase.prototype, "group", void 0);
+__decorate([
+    property({ type: Number, reflect: true })
+], ListItemBase.prototype, "tabindex", void 0);
+__decorate([
+    property({ type: Boolean, reflect: true }),
+    observer(function (value) {
+        if (value) {
+            this.setAttribute('aria-disabled', 'true');
+        }
+        else {
+            this.setAttribute('aria-disabled', 'false');
+        }
+    })
+], ListItemBase.prototype, "disabled", void 0);
+__decorate([
+    property({ type: Boolean, reflect: true })
+], ListItemBase.prototype, "twoline", void 0);
+__decorate([
+    property({ type: Boolean, reflect: true })
+], ListItemBase.prototype, "activated", void 0);
+__decorate([
+    property({ type: String, reflect: true })
+], ListItemBase.prototype, "graphic", void 0);
+__decorate([
+    property({ type: Boolean })
+], ListItemBase.prototype, "multipleGraphics", void 0);
+__decorate([
+    property({ type: Boolean })
+], ListItemBase.prototype, "hasMeta", void 0);
+__decorate([
+    property({ type: Boolean, reflect: true }),
+    observer(function (value) {
+        if (value) {
+            this.removeAttribute('aria-checked');
+            this.removeAttribute('mwc-list-item');
+            this.selected = false;
+            this.activated = false;
+            this.tabIndex = -1;
+        }
+        else {
+            this.setAttribute('mwc-list-item', '');
+        }
+    })
+], ListItemBase.prototype, "noninteractive", void 0);
+__decorate([
+    property({ type: Boolean, reflect: true }),
+    observer(function (value) {
+        const role = this.getAttribute('role');
+        const isAriaSelectable = role === 'gridcell' || role === 'option' ||
+            role === 'row' || role === 'tab';
+        if (isAriaSelectable && value) {
+            this.setAttribute('aria-selected', 'true');
+        }
+        else if (isAriaSelectable) {
+            this.setAttribute('aria-selected', 'false');
+        }
+        if (this._firstChanged) {
+            this._firstChanged = false;
+            return;
+        }
+        if (this._skipPropRequest) {
+            return;
+        }
+        this.fireRequestSelected(value, 'property');
+    })
+], ListItemBase.prototype, "selected", void 0);
+__decorate([
+    internalProperty()
+], ListItemBase.prototype, "shouldRenderRipple", void 0);
+__decorate([
+    internalProperty()
+], ListItemBase.prototype, "_managingList", void 0);
+
+/**
+@license
+Copyright 2018 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+const style$2 = css `:host{cursor:pointer;user-select:none;-webkit-tap-highlight-color:transparent;height:48px;display:flex;position:relative;align-items:center;justify-content:flex-start;overflow:hidden;padding:0;padding-left:var(--mdc-list-side-padding, 16px);padding-right:var(--mdc-list-side-padding, 16px);outline:none;height:48px;color:rgba(0,0,0,.87);color:var(--mdc-theme-text-primary-on-background, rgba(0, 0, 0, 0.87))}:host:focus{outline:none}:host([activated]){color:#6200ee;color:var(--mdc-theme-primary, #6200ee);--mdc-ripple-color: var( --mdc-theme-primary, #6200ee )}:host([activated]) .mdc-deprecated-list-item__graphic{color:#6200ee;color:var(--mdc-theme-primary, #6200ee)}:host([activated]) .fake-activated-ripple::before{position:absolute;display:block;top:0;bottom:0;left:0;right:0;width:100%;height:100%;pointer-events:none;z-index:1;content:"";opacity:0.12;opacity:var(--mdc-ripple-activated-opacity, 0.12);background-color:#6200ee;background-color:var(--mdc-ripple-color, var(--mdc-theme-primary, #6200ee))}.mdc-deprecated-list-item__graphic{flex-shrink:0;align-items:center;justify-content:center;fill:currentColor;display:inline-flex}.mdc-deprecated-list-item__graphic ::slotted(*){flex-shrink:0;align-items:center;justify-content:center;fill:currentColor;width:100%;height:100%;text-align:center}.mdc-deprecated-list-item__meta{width:var(--mdc-list-item-meta-size, 24px);height:var(--mdc-list-item-meta-size, 24px);margin-left:auto;margin-right:0;color:rgba(0, 0, 0, 0.38);color:var(--mdc-theme-text-hint-on-background, rgba(0, 0, 0, 0.38))}.mdc-deprecated-list-item__meta.multi{width:auto}.mdc-deprecated-list-item__meta ::slotted(*){width:var(--mdc-list-item-meta-size, 24px);line-height:var(--mdc-list-item-meta-size, 24px)}.mdc-deprecated-list-item__meta ::slotted(.material-icons),.mdc-deprecated-list-item__meta ::slotted(mwc-icon){line-height:var(--mdc-list-item-meta-size, 24px) !important}.mdc-deprecated-list-item__meta ::slotted(:not(.material-icons):not(mwc-icon)){-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased;font-family:Roboto, sans-serif;font-family:var(--mdc-typography-caption-font-family, var(--mdc-typography-font-family, Roboto, sans-serif));font-size:0.75rem;font-size:var(--mdc-typography-caption-font-size, 0.75rem);line-height:1.25rem;line-height:var(--mdc-typography-caption-line-height, 1.25rem);font-weight:400;font-weight:var(--mdc-typography-caption-font-weight, 400);letter-spacing:0.0333333333em;letter-spacing:var(--mdc-typography-caption-letter-spacing, 0.0333333333em);text-decoration:inherit;text-decoration:var(--mdc-typography-caption-text-decoration, inherit);text-transform:inherit;text-transform:var(--mdc-typography-caption-text-transform, inherit)}[dir=rtl] .mdc-deprecated-list-item__meta,.mdc-deprecated-list-item__meta[dir=rtl]{margin-left:0;margin-right:auto}.mdc-deprecated-list-item__meta ::slotted(*){width:100%;height:100%}.mdc-deprecated-list-item__text{text-overflow:ellipsis;white-space:nowrap;overflow:hidden}.mdc-deprecated-list-item__text ::slotted([for]),.mdc-deprecated-list-item__text[for]{pointer-events:none}.mdc-deprecated-list-item__primary-text{text-overflow:ellipsis;white-space:nowrap;overflow:hidden;display:block;margin-top:0;line-height:normal;margin-bottom:-20px;display:block}.mdc-deprecated-list-item__primary-text::before{display:inline-block;width:0;height:32px;content:"";vertical-align:0}.mdc-deprecated-list-item__primary-text::after{display:inline-block;width:0;height:20px;content:"";vertical-align:-20px}.mdc-deprecated-list-item__secondary-text{-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased;font-family:Roboto, sans-serif;font-family:var(--mdc-typography-body2-font-family, var(--mdc-typography-font-family, Roboto, sans-serif));font-size:0.875rem;font-size:var(--mdc-typography-body2-font-size, 0.875rem);line-height:1.25rem;line-height:var(--mdc-typography-body2-line-height, 1.25rem);font-weight:400;font-weight:var(--mdc-typography-body2-font-weight, 400);letter-spacing:0.0178571429em;letter-spacing:var(--mdc-typography-body2-letter-spacing, 0.0178571429em);text-decoration:inherit;text-decoration:var(--mdc-typography-body2-text-decoration, inherit);text-transform:inherit;text-transform:var(--mdc-typography-body2-text-transform, inherit);text-overflow:ellipsis;white-space:nowrap;overflow:hidden;display:block;margin-top:0;line-height:normal;display:block}.mdc-deprecated-list-item__secondary-text::before{display:inline-block;width:0;height:20px;content:"";vertical-align:0}.mdc-deprecated-list--dense .mdc-deprecated-list-item__secondary-text{font-size:inherit}* ::slotted(a),a{color:inherit;text-decoration:none}:host([twoline]){height:72px}:host([twoline]) .mdc-deprecated-list-item__text{align-self:flex-start}:host([disabled]),:host([noninteractive]){cursor:default;pointer-events:none}:host([disabled]) .mdc-deprecated-list-item__text ::slotted(*){opacity:.38}:host([disabled]) .mdc-deprecated-list-item__text ::slotted(*),:host([disabled]) .mdc-deprecated-list-item__primary-text ::slotted(*),:host([disabled]) .mdc-deprecated-list-item__secondary-text ::slotted(*){color:#000;color:var(--mdc-theme-on-surface, #000)}.mdc-deprecated-list-item__secondary-text ::slotted(*){color:rgba(0, 0, 0, 0.54);color:var(--mdc-theme-text-secondary-on-background, rgba(0, 0, 0, 0.54))}.mdc-deprecated-list-item__graphic ::slotted(*){background-color:transparent;color:rgba(0, 0, 0, 0.38);color:var(--mdc-theme-text-icon-on-background, rgba(0, 0, 0, 0.38))}.mdc-deprecated-list-group__subheader ::slotted(*){color:rgba(0, 0, 0, 0.87);color:var(--mdc-theme-text-primary-on-background, rgba(0, 0, 0, 0.87))}:host([graphic=avatar]) .mdc-deprecated-list-item__graphic{width:var(--mdc-list-item-graphic-size, 40px);height:var(--mdc-list-item-graphic-size, 40px)}:host([graphic=avatar]) .mdc-deprecated-list-item__graphic.multi{width:auto}:host([graphic=avatar]) .mdc-deprecated-list-item__graphic ::slotted(*){width:var(--mdc-list-item-graphic-size, 40px);line-height:var(--mdc-list-item-graphic-size, 40px)}:host([graphic=avatar]) .mdc-deprecated-list-item__graphic ::slotted(.material-icons),:host([graphic=avatar]) .mdc-deprecated-list-item__graphic ::slotted(mwc-icon){line-height:var(--mdc-list-item-graphic-size, 40px) !important}:host([graphic=avatar]) .mdc-deprecated-list-item__graphic ::slotted(*){border-radius:50%}:host([graphic=avatar]) .mdc-deprecated-list-item__graphic,:host([graphic=medium]) .mdc-deprecated-list-item__graphic,:host([graphic=large]) .mdc-deprecated-list-item__graphic,:host([graphic=control]) .mdc-deprecated-list-item__graphic{margin-left:0;margin-right:var(--mdc-list-item-graphic-margin, 16px)}[dir=rtl] :host([graphic=avatar]) .mdc-deprecated-list-item__graphic,:host([graphic=avatar]) .mdc-deprecated-list-item__graphic[dir=rtl],[dir=rtl] :host([graphic=medium]) .mdc-deprecated-list-item__graphic,:host([graphic=medium]) .mdc-deprecated-list-item__graphic[dir=rtl],[dir=rtl] :host([graphic=large]) .mdc-deprecated-list-item__graphic,:host([graphic=large]) .mdc-deprecated-list-item__graphic[dir=rtl],[dir=rtl] :host([graphic=control]) .mdc-deprecated-list-item__graphic,:host([graphic=control]) .mdc-deprecated-list-item__graphic[dir=rtl]{margin-left:var(--mdc-list-item-graphic-margin, 16px);margin-right:0}:host([graphic=icon]) .mdc-deprecated-list-item__graphic{width:var(--mdc-list-item-graphic-size, 24px);height:var(--mdc-list-item-graphic-size, 24px);margin-left:0;margin-right:var(--mdc-list-item-graphic-margin, 32px)}:host([graphic=icon]) .mdc-deprecated-list-item__graphic.multi{width:auto}:host([graphic=icon]) .mdc-deprecated-list-item__graphic ::slotted(*){width:var(--mdc-list-item-graphic-size, 24px);line-height:var(--mdc-list-item-graphic-size, 24px)}:host([graphic=icon]) .mdc-deprecated-list-item__graphic ::slotted(.material-icons),:host([graphic=icon]) .mdc-deprecated-list-item__graphic ::slotted(mwc-icon){line-height:var(--mdc-list-item-graphic-size, 24px) !important}[dir=rtl] :host([graphic=icon]) .mdc-deprecated-list-item__graphic,:host([graphic=icon]) .mdc-deprecated-list-item__graphic[dir=rtl]{margin-left:var(--mdc-list-item-graphic-margin, 32px);margin-right:0}:host([graphic=avatar]:not([twoLine])),:host([graphic=icon]:not([twoLine])){height:56px}:host([graphic=medium]:not([twoLine])),:host([graphic=large]:not([twoLine])){height:72px}:host([graphic=medium]) .mdc-deprecated-list-item__graphic,:host([graphic=large]) .mdc-deprecated-list-item__graphic{width:var(--mdc-list-item-graphic-size, 56px);height:var(--mdc-list-item-graphic-size, 56px)}:host([graphic=medium]) .mdc-deprecated-list-item__graphic.multi,:host([graphic=large]) .mdc-deprecated-list-item__graphic.multi{width:auto}:host([graphic=medium]) .mdc-deprecated-list-item__graphic ::slotted(*),:host([graphic=large]) .mdc-deprecated-list-item__graphic ::slotted(*){width:var(--mdc-list-item-graphic-size, 56px);line-height:var(--mdc-list-item-graphic-size, 56px)}:host([graphic=medium]) .mdc-deprecated-list-item__graphic ::slotted(.material-icons),:host([graphic=medium]) .mdc-deprecated-list-item__graphic ::slotted(mwc-icon),:host([graphic=large]) .mdc-deprecated-list-item__graphic ::slotted(.material-icons),:host([graphic=large]) .mdc-deprecated-list-item__graphic ::slotted(mwc-icon){line-height:var(--mdc-list-item-graphic-size, 56px) !important}:host([graphic=large]){padding-left:0px}`;
+
+/**
+@license
+Copyright 2020 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+let ListItem = class ListItem extends ListItemBase {
+};
+ListItem.styles = style$2;
+ListItem = __decorate([
+    customElement('mwc-list-item')
+], ListItem);
+
+/**
+ * @license
+ * Copyright 2020 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+/**
+ * KEY provides normalized string values for keys.
+ */
+var KEY = {
+    UNKNOWN: 'Unknown',
+    BACKSPACE: 'Backspace',
+    ENTER: 'Enter',
+    SPACEBAR: 'Spacebar',
+    PAGE_UP: 'PageUp',
+    PAGE_DOWN: 'PageDown',
+    END: 'End',
+    HOME: 'Home',
+    ARROW_LEFT: 'ArrowLeft',
+    ARROW_UP: 'ArrowUp',
+    ARROW_RIGHT: 'ArrowRight',
+    ARROW_DOWN: 'ArrowDown',
+    DELETE: 'Delete',
+    ESCAPE: 'Escape',
+    TAB: 'Tab',
+};
+var normalizedKeys = new Set();
+// IE11 has no support for new Map with iterable so we need to initialize this
+// by hand.
+normalizedKeys.add(KEY.BACKSPACE);
+normalizedKeys.add(KEY.ENTER);
+normalizedKeys.add(KEY.SPACEBAR);
+normalizedKeys.add(KEY.PAGE_UP);
+normalizedKeys.add(KEY.PAGE_DOWN);
+normalizedKeys.add(KEY.END);
+normalizedKeys.add(KEY.HOME);
+normalizedKeys.add(KEY.ARROW_LEFT);
+normalizedKeys.add(KEY.ARROW_UP);
+normalizedKeys.add(KEY.ARROW_RIGHT);
+normalizedKeys.add(KEY.ARROW_DOWN);
+normalizedKeys.add(KEY.DELETE);
+normalizedKeys.add(KEY.ESCAPE);
+normalizedKeys.add(KEY.TAB);
+var KEY_CODE = {
+    BACKSPACE: 8,
+    ENTER: 13,
+    SPACEBAR: 32,
+    PAGE_UP: 33,
+    PAGE_DOWN: 34,
+    END: 35,
+    HOME: 36,
+    ARROW_LEFT: 37,
+    ARROW_UP: 38,
+    ARROW_RIGHT: 39,
+    ARROW_DOWN: 40,
+    DELETE: 46,
+    ESCAPE: 27,
+    TAB: 9,
+};
+var mappedKeyCodes = new Map();
+// IE11 has no support for new Map with iterable so we need to initialize this
+// by hand.
+mappedKeyCodes.set(KEY_CODE.BACKSPACE, KEY.BACKSPACE);
+mappedKeyCodes.set(KEY_CODE.ENTER, KEY.ENTER);
+mappedKeyCodes.set(KEY_CODE.SPACEBAR, KEY.SPACEBAR);
+mappedKeyCodes.set(KEY_CODE.PAGE_UP, KEY.PAGE_UP);
+mappedKeyCodes.set(KEY_CODE.PAGE_DOWN, KEY.PAGE_DOWN);
+mappedKeyCodes.set(KEY_CODE.END, KEY.END);
+mappedKeyCodes.set(KEY_CODE.HOME, KEY.HOME);
+mappedKeyCodes.set(KEY_CODE.ARROW_LEFT, KEY.ARROW_LEFT);
+mappedKeyCodes.set(KEY_CODE.ARROW_UP, KEY.ARROW_UP);
+mappedKeyCodes.set(KEY_CODE.ARROW_RIGHT, KEY.ARROW_RIGHT);
+mappedKeyCodes.set(KEY_CODE.ARROW_DOWN, KEY.ARROW_DOWN);
+mappedKeyCodes.set(KEY_CODE.DELETE, KEY.DELETE);
+mappedKeyCodes.set(KEY_CODE.ESCAPE, KEY.ESCAPE);
+mappedKeyCodes.set(KEY_CODE.TAB, KEY.TAB);
+var navigationKeys = new Set();
+// IE11 has no support for new Set with iterable so we need to initialize this
+// by hand.
+navigationKeys.add(KEY.PAGE_UP);
+navigationKeys.add(KEY.PAGE_DOWN);
+navigationKeys.add(KEY.END);
+navigationKeys.add(KEY.HOME);
+navigationKeys.add(KEY.ARROW_LEFT);
+navigationKeys.add(KEY.ARROW_UP);
+navigationKeys.add(KEY.ARROW_RIGHT);
+navigationKeys.add(KEY.ARROW_DOWN);
+/**
+ * normalizeKey returns the normalized string for a navigational action.
+ */
+function normalizeKey(evt) {
+    var key = evt.key;
+    // If the event already has a normalized key, return it
+    if (normalizedKeys.has(key)) {
+        return key;
+    }
+    // tslint:disable-next-line:deprecation
+    var mappedKey = mappedKeyCodes.get(evt.keyCode);
+    if (mappedKey) {
+        return mappedKey;
+    }
+    return KEY.UNKNOWN;
+}
+
+/**
+ * @license
+ * Copyright 2018 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+var _a, _b;
+var cssClasses$2 = {
+    LIST_ITEM_ACTIVATED_CLASS: 'mdc-list-item--activated',
+    LIST_ITEM_CLASS: 'mdc-list-item',
+    LIST_ITEM_DISABLED_CLASS: 'mdc-list-item--disabled',
+    LIST_ITEM_SELECTED_CLASS: 'mdc-list-item--selected',
+    LIST_ITEM_TEXT_CLASS: 'mdc-list-item__text',
+    LIST_ITEM_PRIMARY_TEXT_CLASS: 'mdc-list-item__primary-text',
+    ROOT: 'mdc-list',
+};
+var evolutionClassNameMap = (_a = {},
+    _a["" + cssClasses$2.LIST_ITEM_ACTIVATED_CLASS] = 'mdc-list-item--activated',
+    _a["" + cssClasses$2.LIST_ITEM_CLASS] = 'mdc-list-item',
+    _a["" + cssClasses$2.LIST_ITEM_DISABLED_CLASS] = 'mdc-list-item--disabled',
+    _a["" + cssClasses$2.LIST_ITEM_SELECTED_CLASS] = 'mdc-list-item--selected',
+    _a["" + cssClasses$2.LIST_ITEM_PRIMARY_TEXT_CLASS] = 'mdc-list-item__primary-text',
+    _a["" + cssClasses$2.ROOT] = 'mdc-list',
+    _a);
+var deprecatedClassNameMap = (_b = {},
+    _b["" + cssClasses$2.LIST_ITEM_ACTIVATED_CLASS] = 'mdc-deprecated-list-item--activated',
+    _b["" + cssClasses$2.LIST_ITEM_CLASS] = 'mdc-deprecated-list-item',
+    _b["" + cssClasses$2.LIST_ITEM_DISABLED_CLASS] = 'mdc-deprecated-list-item--disabled',
+    _b["" + cssClasses$2.LIST_ITEM_SELECTED_CLASS] = 'mdc-deprecated-list-item--selected',
+    _b["" + cssClasses$2.LIST_ITEM_TEXT_CLASS] = 'mdc-deprecated-list-item__text',
+    _b["" + cssClasses$2.LIST_ITEM_PRIMARY_TEXT_CLASS] = 'mdc-deprecated-list-item__primary-text',
+    _b["" + cssClasses$2.ROOT] = 'mdc-deprecated-list',
+    _b);
+var strings$2 = {
+    ACTION_EVENT: 'MDCList:action',
+    ARIA_CHECKED: 'aria-checked',
+    ARIA_CHECKED_CHECKBOX_SELECTOR: '[role="checkbox"][aria-checked="true"]',
+    ARIA_CHECKED_RADIO_SELECTOR: '[role="radio"][aria-checked="true"]',
+    ARIA_CURRENT: 'aria-current',
+    ARIA_DISABLED: 'aria-disabled',
+    ARIA_ORIENTATION: 'aria-orientation',
+    ARIA_ORIENTATION_HORIZONTAL: 'horizontal',
+    ARIA_ROLE_CHECKBOX_SELECTOR: '[role="checkbox"]',
+    ARIA_SELECTED: 'aria-selected',
+    ARIA_INTERACTIVE_ROLES_SELECTOR: '[role="listbox"], [role="menu"]',
+    ARIA_MULTI_SELECTABLE_SELECTOR: '[aria-multiselectable="true"]',
+    CHECKBOX_RADIO_SELECTOR: 'input[type="checkbox"], input[type="radio"]',
+    CHECKBOX_SELECTOR: 'input[type="checkbox"]',
+    CHILD_ELEMENTS_TO_TOGGLE_TABINDEX: "\n    ." + cssClasses$2.LIST_ITEM_CLASS + " button:not(:disabled),\n    ." + cssClasses$2.LIST_ITEM_CLASS + " a,\n    ." + deprecatedClassNameMap[cssClasses$2.LIST_ITEM_CLASS] + " button:not(:disabled),\n    ." + deprecatedClassNameMap[cssClasses$2.LIST_ITEM_CLASS] + " a\n  ",
+    DEPRECATED_SELECTOR: '.mdc-deprecated-list',
+    FOCUSABLE_CHILD_ELEMENTS: "\n    ." + cssClasses$2.LIST_ITEM_CLASS + " button:not(:disabled),\n    ." + cssClasses$2.LIST_ITEM_CLASS + " a,\n    ." + cssClasses$2.LIST_ITEM_CLASS + " input[type=\"radio\"]:not(:disabled),\n    ." + cssClasses$2.LIST_ITEM_CLASS + " input[type=\"checkbox\"]:not(:disabled),\n    ." + deprecatedClassNameMap[cssClasses$2.LIST_ITEM_CLASS] + " button:not(:disabled),\n    ." + deprecatedClassNameMap[cssClasses$2.LIST_ITEM_CLASS] + " a,\n    ." + deprecatedClassNameMap[cssClasses$2.LIST_ITEM_CLASS] + " input[type=\"radio\"]:not(:disabled),\n    ." + deprecatedClassNameMap[cssClasses$2.LIST_ITEM_CLASS] + " input[type=\"checkbox\"]:not(:disabled)\n  ",
+    RADIO_SELECTOR: 'input[type="radio"]',
+    SELECTED_ITEM_SELECTOR: '[aria-selected="true"], [aria-current="true"]',
+};
+var numbers$2 = {
+    UNSET_INDEX: -1,
+    TYPEAHEAD_BUFFER_CLEAR_TIMEOUT_MS: 300
+};
+
+/**
+ @license
+ Copyright 2020 Google Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+const integerSort = (a, b) => {
+    return a - b;
+};
+const findIndexDiff = (oldSet, newSet) => {
+    const oldArr = Array.from(oldSet);
+    const newArr = Array.from(newSet);
+    const diff = { added: [], removed: [] };
+    const oldSorted = oldArr.sort(integerSort);
+    const newSorted = newArr.sort(integerSort);
+    let i = 0;
+    let j = 0;
+    while (i < oldSorted.length || j < newSorted.length) {
+        const oldVal = oldSorted[i];
+        const newVal = newSorted[j];
+        if (oldVal === newVal) {
+            i++;
+            j++;
+            continue;
+        }
+        if (oldVal !== undefined && (newVal === undefined || oldVal < newVal)) {
+            diff.removed.push(oldVal);
+            i++;
+            continue;
+        }
+        if (newVal !== undefined && (oldVal === undefined || newVal < oldVal)) {
+            diff.added.push(newVal);
+            j++;
+            continue;
+        }
+    }
+    return diff;
+};
+const ELEMENTS_KEY_ALLOWED_IN = ['input', 'button', 'textarea', 'select'];
+function isIndexSet(selectedIndex) {
+    return selectedIndex instanceof Set;
+}
+const createSetFromIndex = (index) => {
+    const entry = index === numbers$2.UNSET_INDEX ? new Set() : index;
+    return isIndexSet(entry) ? new Set(entry) : new Set([entry]);
+};
+class MDCListFoundation extends MDCFoundation$1 {
+    constructor(adapter) {
+        super(Object.assign(Object.assign({}, MDCListFoundation.defaultAdapter), adapter));
+        this.isMulti_ = false;
+        this.wrapFocus_ = false;
+        this.isVertical_ = true;
+        this.selectedIndex_ = numbers$2.UNSET_INDEX;
+        this.focusedItemIndex_ = numbers$2.UNSET_INDEX;
+        this.useActivatedClass_ = false;
+        this.ariaCurrentAttrValue_ = null;
+    }
+    static get strings() {
+        return strings$2;
+    }
+    static get numbers() {
+        return numbers$2;
+    }
+    static get defaultAdapter() {
+        return {
+            focusItemAtIndex: () => undefined,
+            getFocusedElementIndex: () => 0,
+            getListItemCount: () => 0,
+            isFocusInsideList: () => false,
+            isRootFocused: () => false,
+            notifyAction: () => undefined,
+            notifySelected: () => undefined,
+            getSelectedStateForElementIndex: () => false,
+            setDisabledStateForElementIndex: () => undefined,
+            getDisabledStateForElementIndex: () => false,
+            setSelectedStateForElementIndex: () => undefined,
+            setActivatedStateForElementIndex: () => undefined,
+            setTabIndexForElementIndex: () => undefined,
+            setAttributeForElementIndex: () => undefined,
+            getAttributeForElementIndex: () => null,
+        };
+    }
+    /**
+     * Sets the private wrapFocus_ variable.
+     */
+    setWrapFocus(value) {
+        this.wrapFocus_ = value;
+    }
+    /**
+     * Sets the private wrapFocus_ variable.
+     */
+    setMulti(value) {
+        this.isMulti_ = value;
+        const currentIndex = this.selectedIndex_;
+        if (value) {
+            // number to set
+            if (!isIndexSet(currentIndex)) {
+                const isUnset = currentIndex === numbers$2.UNSET_INDEX;
+                this.selectedIndex_ = isUnset ? new Set() : new Set([currentIndex]);
+            }
+        }
+        else {
+            // set to first sorted number in set
+            if (isIndexSet(currentIndex)) {
+                if (currentIndex.size) {
+                    const vals = Array.from(currentIndex).sort(integerSort);
+                    this.selectedIndex_ = vals[0];
+                }
+                else {
+                    this.selectedIndex_ = numbers$2.UNSET_INDEX;
+                }
+            }
+        }
+    }
+    /**
+     * Sets the isVertical_ private variable.
+     */
+    setVerticalOrientation(value) {
+        this.isVertical_ = value;
+    }
+    /**
+     * Sets the useActivatedClass_ private variable.
+     */
+    setUseActivatedClass(useActivated) {
+        this.useActivatedClass_ = useActivated;
+    }
+    getSelectedIndex() {
+        return this.selectedIndex_;
+    }
+    setSelectedIndex(index) {
+        if (!this.isIndexValid_(index)) {
+            return;
+        }
+        if (this.isMulti_) {
+            this.setMultiSelectionAtIndex_(createSetFromIndex(index));
+        }
+        else {
+            this.setSingleSelectionAtIndex_(index);
+        }
+    }
+    /**
+     * Focus in handler for the list items.
+     */
+    handleFocusIn(_, listItemIndex) {
+        if (listItemIndex >= 0) {
+            this.adapter.setTabIndexForElementIndex(listItemIndex, 0);
+        }
+    }
+    /**
+     * Focus out handler for the list items.
+     */
+    handleFocusOut(_, listItemIndex) {
+        if (listItemIndex >= 0) {
+            this.adapter.setTabIndexForElementIndex(listItemIndex, -1);
+        }
+        /**
+         * Between Focusout & Focusin some browsers do not have focus on any
+         * element. Setting a delay to wait till the focus is moved to next element.
+         */
+        setTimeout(() => {
+            if (!this.adapter.isFocusInsideList()) {
+                this.setTabindexToFirstSelectedItem_();
+            }
+        }, 0);
+    }
+    /**
+     * Key handler for the list.
+     */
+    handleKeydown(event, isRootListItem, listItemIndex) {
+        const isArrowLeft = normalizeKey(event) === 'ArrowLeft';
+        const isArrowUp = normalizeKey(event) === 'ArrowUp';
+        const isArrowRight = normalizeKey(event) === 'ArrowRight';
+        const isArrowDown = normalizeKey(event) === 'ArrowDown';
+        const isHome = normalizeKey(event) === 'Home';
+        const isEnd = normalizeKey(event) === 'End';
+        const isEnter = normalizeKey(event) === 'Enter';
+        const isSpace = normalizeKey(event) === 'Spacebar';
+        if (this.adapter.isRootFocused()) {
+            if (isArrowUp || isEnd) {
+                event.preventDefault();
+                this.focusLastElement();
+            }
+            else if (isArrowDown || isHome) {
+                event.preventDefault();
+                this.focusFirstElement();
+            }
+            return;
+        }
+        let currentIndex = this.adapter.getFocusedElementIndex();
+        if (currentIndex === -1) {
+            currentIndex = listItemIndex;
+            if (currentIndex < 0) {
+                // If this event doesn't have a mdc-deprecated-list-item ancestor from
+                // the current list (not from a sublist), return early.
+                return;
+            }
+        }
+        let nextIndex;
+        if ((this.isVertical_ && isArrowDown) ||
+            (!this.isVertical_ && isArrowRight)) {
+            this.preventDefaultEvent(event);
+            nextIndex = this.focusNextElement(currentIndex);
+        }
+        else if ((this.isVertical_ && isArrowUp) || (!this.isVertical_ && isArrowLeft)) {
+            this.preventDefaultEvent(event);
+            nextIndex = this.focusPrevElement(currentIndex);
+        }
+        else if (isHome) {
+            this.preventDefaultEvent(event);
+            nextIndex = this.focusFirstElement();
+        }
+        else if (isEnd) {
+            this.preventDefaultEvent(event);
+            nextIndex = this.focusLastElement();
+        }
+        else if (isEnter || isSpace) {
+            if (isRootListItem) {
+                // Return early if enter key is pressed on anchor element which triggers
+                // synthetic MouseEvent event.
+                const target = event.target;
+                if (target && target.tagName === 'A' && isEnter) {
+                    return;
+                }
+                this.preventDefaultEvent(event);
+                this.setSelectedIndexOnAction_(currentIndex, true);
+            }
+        }
+        this.focusedItemIndex_ = currentIndex;
+        if (nextIndex !== undefined) {
+            this.setTabindexAtIndex_(nextIndex);
+            this.focusedItemIndex_ = nextIndex;
+        }
+    }
+    /**
+     * Click handler for the list.
+     */
+    handleSingleSelection(index, isInteraction, force) {
+        if (index === numbers$2.UNSET_INDEX) {
+            return;
+        }
+        this.setSelectedIndexOnAction_(index, isInteraction, force);
+        this.setTabindexAtIndex_(index);
+        this.focusedItemIndex_ = index;
+    }
+    /**
+     * Focuses the next element on the list.
+     */
+    focusNextElement(index) {
+        const count = this.adapter.getListItemCount();
+        let nextIndex = index + 1;
+        if (nextIndex >= count) {
+            if (this.wrapFocus_) {
+                nextIndex = 0;
+            }
+            else {
+                // Return early because last item is already focused.
+                return index;
+            }
+        }
+        this.adapter.focusItemAtIndex(nextIndex);
+        return nextIndex;
+    }
+    /**
+     * Focuses the previous element on the list.
+     */
+    focusPrevElement(index) {
+        let prevIndex = index - 1;
+        if (prevIndex < 0) {
+            if (this.wrapFocus_) {
+                prevIndex = this.adapter.getListItemCount() - 1;
+            }
+            else {
+                // Return early because first item is already focused.
+                return index;
+            }
+        }
+        this.adapter.focusItemAtIndex(prevIndex);
+        return prevIndex;
+    }
+    focusFirstElement() {
+        this.adapter.focusItemAtIndex(0);
+        return 0;
+    }
+    focusLastElement() {
+        const lastIndex = this.adapter.getListItemCount() - 1;
+        this.adapter.focusItemAtIndex(lastIndex);
+        return lastIndex;
+    }
+    /**
+     * @param itemIndex Index of the list item
+     * @param isEnabled Sets the list item to enabled or disabled.
+     */
+    setEnabled(itemIndex, isEnabled) {
+        if (!this.isIndexValid_(itemIndex)) {
+            return;
+        }
+        this.adapter.setDisabledStateForElementIndex(itemIndex, !isEnabled);
+    }
+    /**
+     * Ensures that preventDefault is only called if the containing element
+     * doesn't consume the event, and it will cause an unintended scroll.
+     */
+    preventDefaultEvent(evt) {
+        const target = evt.target;
+        const tagName = `${target.tagName}`.toLowerCase();
+        if (ELEMENTS_KEY_ALLOWED_IN.indexOf(tagName) === -1) {
+            evt.preventDefault();
+        }
+    }
+    setSingleSelectionAtIndex_(index, isInteraction = true) {
+        if (this.selectedIndex_ === index) {
+            return;
+        }
+        // unset previous
+        if (this.selectedIndex_ !== numbers$2.UNSET_INDEX) {
+            this.adapter.setSelectedStateForElementIndex(this.selectedIndex_, false);
+            if (this.useActivatedClass_) {
+                this.adapter.setActivatedStateForElementIndex(this.selectedIndex_, false);
+            }
+        }
+        // set new
+        if (isInteraction) {
+            this.adapter.setSelectedStateForElementIndex(index, true);
+        }
+        if (this.useActivatedClass_) {
+            this.adapter.setActivatedStateForElementIndex(index, true);
+        }
+        this.setAriaForSingleSelectionAtIndex_(index);
+        this.selectedIndex_ = index;
+        this.adapter.notifySelected(index);
+    }
+    setMultiSelectionAtIndex_(newIndex, isInteraction = true) {
+        const oldIndex = createSetFromIndex(this.selectedIndex_);
+        const diff = findIndexDiff(oldIndex, newIndex);
+        if (!diff.removed.length && !diff.added.length) {
+            return;
+        }
+        for (const removed of diff.removed) {
+            if (isInteraction) {
+                this.adapter.setSelectedStateForElementIndex(removed, false);
+            }
+            if (this.useActivatedClass_) {
+                this.adapter.setActivatedStateForElementIndex(removed, false);
+            }
+        }
+        for (const added of diff.added) {
+            if (isInteraction) {
+                this.adapter.setSelectedStateForElementIndex(added, true);
+            }
+            if (this.useActivatedClass_) {
+                this.adapter.setActivatedStateForElementIndex(added, true);
+            }
+        }
+        this.selectedIndex_ = newIndex;
+        this.adapter.notifySelected(newIndex, diff);
+    }
+    /**
+     * Sets aria attribute for single selection at given index.
+     */
+    setAriaForSingleSelectionAtIndex_(index) {
+        // Detect the presence of aria-current and get the value only during list
+        // initialization when it is in unset state.
+        if (this.selectedIndex_ === numbers$2.UNSET_INDEX) {
+            this.ariaCurrentAttrValue_ =
+                this.adapter.getAttributeForElementIndex(index, strings$2.ARIA_CURRENT);
+        }
+        const isAriaCurrent = this.ariaCurrentAttrValue_ !== null;
+        const ariaAttribute = isAriaCurrent ? strings$2.ARIA_CURRENT : strings$2.ARIA_SELECTED;
+        if (this.selectedIndex_ !== numbers$2.UNSET_INDEX) {
+            this.adapter.setAttributeForElementIndex(this.selectedIndex_, ariaAttribute, 'false');
+        }
+        const ariaAttributeValue = isAriaCurrent ? this.ariaCurrentAttrValue_ : 'true';
+        this.adapter.setAttributeForElementIndex(index, ariaAttribute, ariaAttributeValue);
+    }
+    setTabindexAtIndex_(index) {
+        if (this.focusedItemIndex_ === numbers$2.UNSET_INDEX && index !== 0) {
+            // If no list item was selected set first list item's tabindex to -1.
+            // Generally, tabindex is set to 0 on first list item of list that has no
+            // preselected items.
+            this.adapter.setTabIndexForElementIndex(0, -1);
+        }
+        else if (this.focusedItemIndex_ >= 0 && this.focusedItemIndex_ !== index) {
+            this.adapter.setTabIndexForElementIndex(this.focusedItemIndex_, -1);
+        }
+        this.adapter.setTabIndexForElementIndex(index, 0);
+    }
+    setTabindexToFirstSelectedItem_() {
+        let targetIndex = 0;
+        if (typeof this.selectedIndex_ === 'number' &&
+            this.selectedIndex_ !== numbers$2.UNSET_INDEX) {
+            targetIndex = this.selectedIndex_;
+        }
+        else if (isIndexSet(this.selectedIndex_) && this.selectedIndex_.size > 0) {
+            targetIndex = Math.min(...this.selectedIndex_);
+        }
+        this.setTabindexAtIndex_(targetIndex);
+    }
+    isIndexValid_(index) {
+        if (index instanceof Set) {
+            if (!this.isMulti_) {
+                throw new Error('MDCListFoundation: Array of index is only supported for checkbox based list');
+            }
+            if (index.size === 0) {
+                return true;
+            }
+            else {
+                let isOneInRange = false;
+                for (const entry of index) {
+                    isOneInRange = this.isIndexInRange_(entry);
+                    if (isOneInRange) {
+                        break;
+                    }
+                }
+                return isOneInRange;
+            }
+        }
+        else if (typeof index === 'number') {
+            if (this.isMulti_) {
+                throw new Error('MDCListFoundation: Expected array of index for checkbox based list but got number: ' +
+                    index);
+            }
+            return index === numbers$2.UNSET_INDEX || this.isIndexInRange_(index);
+        }
+        else {
+            return false;
+        }
+    }
+    isIndexInRange_(index) {
+        const listSize = this.adapter.getListItemCount();
+        return index >= 0 && index < listSize;
+    }
+    /**
+     * Sets selected index on user action, toggles checkbox / radio based on
+     * toggleCheckbox value. User interaction should not toggle list item(s) when
+     * disabled.
+     */
+    setSelectedIndexOnAction_(index, isInteraction, force) {
+        if (this.adapter.getDisabledStateForElementIndex(index)) {
+            return;
+        }
+        let checkedIndex = index;
+        if (this.isMulti_) {
+            checkedIndex = new Set([index]);
+        }
+        if (!this.isIndexValid_(checkedIndex)) {
+            return;
+        }
+        if (this.isMulti_) {
+            this.toggleMultiAtIndex(index, force, isInteraction);
+        }
+        else {
+            if (isInteraction || force) {
+                this.setSingleSelectionAtIndex_(index, isInteraction);
+            }
+            else {
+                const isDeselection = this.selectedIndex_ === index;
+                if (isDeselection) {
+                    this.setSingleSelectionAtIndex_(numbers$2.UNSET_INDEX);
+                }
+            }
+        }
+        if (isInteraction) {
+            this.adapter.notifyAction(index);
+        }
+    }
+    toggleMultiAtIndex(index, force, isInteraction = true) {
+        let newSelectionValue = false;
+        if (force === undefined) {
+            newSelectionValue = !this.adapter.getSelectedStateForElementIndex(index);
+        }
+        else {
+            newSelectionValue = force;
+        }
+        const newSet = createSetFromIndex(this.selectedIndex_);
+        if (newSelectionValue) {
+            newSet.add(index);
+        }
+        else {
+            newSet.delete(index);
+        }
+        this.setMultiSelectionAtIndex_(newSet, isInteraction);
+    }
+}
+
+function debounceLayout(callback, waitInMS = 50) {
+    let timeoutId;
+    // tslint:disable-next-line
+    return function (updateItems = true) {
+        clearTimeout(timeoutId);
+        timeoutId = setTimeout(() => {
+            callback(updateItems);
+        }, waitInMS);
+    };
+}
+const isListItem = (element) => {
+    return element.hasAttribute('mwc-list-item');
+};
+function clearAndCreateItemsReadyPromise() {
+    const oldResolver = this.itemsReadyResolver;
+    this.itemsReady = new Promise((res) => {
+        // TODO(b/175626389): Type '(value: never[] | PromiseLike<never[]>) => void'
+        // is not assignable to type '(value?: never[] | PromiseLike<never[]> |
+        // undefined) => void'.
+        return this.itemsReadyResolver = res;
+    });
+    oldResolver();
+}
+/**
+ * @fires selected {SelectedDetail}
+ * @fires action {ActionDetail}
+ * @fires items-updated
+ */
+class ListBase extends BaseElement$1 {
+    constructor() {
+        super();
+        this.mdcAdapter = null;
+        this.mdcFoundationClass = MDCListFoundation;
+        this.activatable = false;
+        this.multi = false;
+        this.wrapFocus = false;
+        this.itemRoles = null;
+        this.innerRole = null;
+        this.innerAriaLabel = null;
+        this.rootTabbable = false;
+        this.previousTabindex = null;
+        this.noninteractive = false;
+        this.itemsReadyResolver = (() => {
+            //
+        });
+        this.itemsReady = Promise.resolve([]);
+        this.items_ = [];
+        const debouncedFunction = debounceLayout(this.layout.bind(this));
+        this.debouncedLayout = (updateItems = true) => {
+            clearAndCreateItemsReadyPromise.call(this);
+            debouncedFunction(updateItems);
+        };
+    }
+    // tslint:disable:ban-ts-ignore
+    async _getUpdateComplete() {
+        let result = false;
+        // @ts-ignore
+        if (super._getUpdateComplete) {
+            // @ts-ignore
+            await super._getUpdateComplete();
+        }
+        else {
+            // @ts-ignore
+            result = await super.getUpdateComplete();
+        }
+        await this.itemsReady;
+        return result;
+    }
+    // tslint:enable:ban-ts-ignore
+    async getUpdateComplete() {
+        return this._getUpdateComplete();
+    }
+    get assignedElements() {
+        const slot = this.slotElement;
+        if (slot) {
+            return slot.assignedNodes({ flatten: true }).filter(isNodeElement);
+        }
+        return [];
+    }
+    get items() {
+        return this.items_;
+    }
+    updateItems() {
+        const nodes = this.assignedElements;
+        const listItems = [];
+        for (const node of nodes) {
+            if (isListItem(node)) {
+                listItems.push(node);
+                node._managingList = this;
+            }
+            if (node.hasAttribute('divider') && !node.hasAttribute('role')) {
+                node.setAttribute('role', 'separator');
+            }
+        }
+        this.items_ = listItems;
+        const selectedIndices = new Set();
+        this.items_.forEach((item, index) => {
+            if (this.itemRoles) {
+                item.setAttribute('role', this.itemRoles);
+            }
+            else {
+                item.removeAttribute('role');
+            }
+            if (item.selected) {
+                selectedIndices.add(index);
+            }
+        });
+        if (this.multi) {
+            this.select(selectedIndices);
+        }
+        else {
+            const index = selectedIndices.size ? selectedIndices.entries().next().value[1] : -1;
+            this.select(index);
+        }
+        const itemsUpdatedEv = new Event('items-updated', { bubbles: true, composed: true });
+        this.dispatchEvent(itemsUpdatedEv);
+    }
+    get selected() {
+        const index = this.index;
+        if (!isIndexSet(index)) {
+            if (index === -1) {
+                return null;
+            }
+            return this.items[index];
+        }
+        const selected = [];
+        for (const entry of index) {
+            selected.push(this.items[entry]);
+        }
+        return selected;
+    }
+    get index() {
+        if (this.mdcFoundation) {
+            return this.mdcFoundation.getSelectedIndex();
+        }
+        return -1;
+    }
+    render() {
+        const role = this.innerRole === null ? undefined : this.innerRole;
+        const ariaLabel = this.innerAriaLabel === null ? undefined : this.innerAriaLabel;
+        const tabindex = this.rootTabbable ? '0' : '-1';
+        return html `
+      <!-- @ts-ignore -->
+      <ul
+          tabindex=${tabindex}
+          role="${ifDefined(role)}"
+          aria-label="${ifDefined(ariaLabel)}"
+          class="mdc-deprecated-list"
+          @keydown=${this.onKeydown}
+          @focusin=${this.onFocusIn}
+          @focusout=${this.onFocusOut}
+          @request-selected=${this.onRequestSelected}
+          @list-item-rendered=${this.onListItemConnected}>
+        <slot></slot>
+        ${this.renderPlaceholder()}
+      </ul>
+    `;
+    }
+    renderPlaceholder() {
+        if (this.emptyMessage !== undefined && this.assignedElements.length === 0) {
+            return html `
+        <mwc-list-item noninteractive>${this.emptyMessage}</mwc-list-item>
+      `;
+        }
+        return null;
+    }
+    firstUpdated() {
+        super.firstUpdated();
+        if (!this.items.length) {
+            // required because this is called before observers
+            this.mdcFoundation.setMulti(this.multi);
+            // for when children upgrade before list
+            this.layout();
+        }
+    }
+    onFocusIn(evt) {
+        if (this.mdcFoundation && this.mdcRoot) {
+            const index = this.getIndexOfTarget(evt);
+            this.mdcFoundation.handleFocusIn(evt, index);
+        }
+    }
+    onFocusOut(evt) {
+        if (this.mdcFoundation && this.mdcRoot) {
+            const index = this.getIndexOfTarget(evt);
+            this.mdcFoundation.handleFocusOut(evt, index);
+        }
+    }
+    onKeydown(evt) {
+        if (this.mdcFoundation && this.mdcRoot) {
+            const index = this.getIndexOfTarget(evt);
+            const target = evt.target;
+            const isRootListItem = isListItem(target);
+            this.mdcFoundation.handleKeydown(evt, isRootListItem, index);
+        }
+    }
+    onRequestSelected(evt) {
+        if (this.mdcFoundation) {
+            let index = this.getIndexOfTarget(evt);
+            // might happen in shady dom slowness. Recalc children
+            if (index === -1) {
+                this.layout();
+                index = this.getIndexOfTarget(evt);
+                // still not found; may not be mwc-list-item. Unsupported case.
+                if (index === -1) {
+                    return;
+                }
+            }
+            const element = this.items[index];
+            if (element.disabled) {
+                return;
+            }
+            const selected = evt.detail.selected;
+            const source = evt.detail.source;
+            this.mdcFoundation.handleSingleSelection(index, source === 'interaction', selected);
+            evt.stopPropagation();
+        }
+    }
+    getIndexOfTarget(evt) {
+        const elements = this.items;
+        const path = evt.composedPath();
+        for (const pathItem of path) {
+            let index = -1;
+            if (isNodeElement(pathItem) && isListItem(pathItem)) {
+                index = elements.indexOf(pathItem);
+            }
+            if (index !== -1) {
+                return index;
+            }
+        }
+        return -1;
+    }
+    createAdapter() {
+        this.mdcAdapter = {
+            getListItemCount: () => {
+                if (this.mdcRoot) {
+                    return this.items.length;
+                }
+                return 0;
+            },
+            getFocusedElementIndex: this.getFocusedItemIndex,
+            getAttributeForElementIndex: (index, attr) => {
+                const listElement = this.mdcRoot;
+                if (!listElement) {
+                    return '';
+                }
+                const element = this.items[index];
+                return element ? element.getAttribute(attr) : '';
+            },
+            setAttributeForElementIndex: (index, attr, val) => {
+                if (!this.mdcRoot) {
+                    return;
+                }
+                const element = this.items[index];
+                if (element) {
+                    element.setAttribute(attr, val);
+                }
+            },
+            focusItemAtIndex: (index) => {
+                const element = this.items[index];
+                if (element) {
+                    element.focus();
+                }
+            },
+            setTabIndexForElementIndex: (index, value) => {
+                const item = this.items[index];
+                if (item) {
+                    item.tabindex = value;
+                }
+            },
+            notifyAction: (index) => {
+                const init = { bubbles: true, composed: true };
+                init.detail = { index };
+                const ev = new CustomEvent('action', init);
+                this.dispatchEvent(ev);
+            },
+            notifySelected: (index, diff) => {
+                const init = { bubbles: true, composed: true };
+                init.detail = { index, diff };
+                const ev = new CustomEvent('selected', init);
+                this.dispatchEvent(ev);
+            },
+            isFocusInsideList: () => {
+                return doesElementContainFocus(this);
+            },
+            isRootFocused: () => {
+                const mdcRoot = this.mdcRoot;
+                const root = mdcRoot.getRootNode();
+                return root.activeElement === mdcRoot;
+            },
+            setDisabledStateForElementIndex: (index, value) => {
+                const item = this.items[index];
+                if (!item) {
+                    return;
+                }
+                item.disabled = value;
+            },
+            getDisabledStateForElementIndex: (index) => {
+                const item = this.items[index];
+                if (!item) {
+                    return false;
+                }
+                return item.disabled;
+            },
+            setSelectedStateForElementIndex: (index, value) => {
+                const item = this.items[index];
+                if (!item) {
+                    return;
+                }
+                item.selected = value;
+            },
+            getSelectedStateForElementIndex: (index) => {
+                const item = this.items[index];
+                if (!item) {
+                    return false;
+                }
+                return item.selected;
+            },
+            setActivatedStateForElementIndex: (index, value) => {
+                const item = this.items[index];
+                if (!item) {
+                    return;
+                }
+                item.activated = value;
+            },
+        };
+        return this.mdcAdapter;
+    }
+    selectUi(index, activate = false) {
+        const item = this.items[index];
+        if (item) {
+            item.selected = true;
+            item.activated = activate;
+        }
+    }
+    deselectUi(index) {
+        const item = this.items[index];
+        if (item) {
+            item.selected = false;
+            item.activated = false;
+        }
+    }
+    select(index) {
+        if (!this.mdcFoundation) {
+            return;
+        }
+        this.mdcFoundation.setSelectedIndex(index);
+    }
+    toggle(index, force) {
+        if (this.multi) {
+            this.mdcFoundation.toggleMultiAtIndex(index, force);
+        }
+    }
+    onListItemConnected(e) {
+        const target = e.target;
+        this.layout(this.items.indexOf(target) === -1);
+    }
+    layout(updateItems = true) {
+        if (updateItems) {
+            this.updateItems();
+        }
+        const first = this.items[0];
+        for (const item of this.items) {
+            item.tabindex = -1;
+        }
+        if (first) {
+            if (this.noninteractive) {
+                if (!this.previousTabindex) {
+                    this.previousTabindex = first;
+                }
+            }
+            else {
+                first.tabindex = 0;
+            }
+        }
+        this.itemsReadyResolver();
+    }
+    getFocusedItemIndex() {
+        if (!this.mdcRoot) {
+            return -1;
+        }
+        if (!this.items.length) {
+            return -1;
+        }
+        const activeElementPath = deepActiveElementPath();
+        if (!activeElementPath.length) {
+            return -1;
+        }
+        for (let i = activeElementPath.length - 1; i >= 0; i--) {
+            const activeItem = activeElementPath[i];
+            if (isListItem(activeItem)) {
+                return this.items.indexOf(activeItem);
+            }
+        }
+        return -1;
+    }
+    focusItemAtIndex(index) {
+        for (const item of this.items) {
+            if (item.tabindex === 0) {
+                item.tabindex = -1;
+                break;
+            }
+        }
+        this.items[index].tabindex = 0;
+        this.items[index].focus();
+    }
+    focus() {
+        const root = this.mdcRoot;
+        if (root) {
+            root.focus();
+        }
+    }
+    blur() {
+        const root = this.mdcRoot;
+        if (root) {
+            root.blur();
+        }
+    }
+}
+__decorate([
+    property({ type: String })
+], ListBase.prototype, "emptyMessage", void 0);
+__decorate([
+    query('.mdc-deprecated-list')
+], ListBase.prototype, "mdcRoot", void 0);
+__decorate([
+    query('slot')
+], ListBase.prototype, "slotElement", void 0);
+__decorate([
+    property({ type: Boolean }),
+    observer(function (value) {
+        if (this.mdcFoundation) {
+            this.mdcFoundation.setUseActivatedClass(value);
+        }
+    })
+], ListBase.prototype, "activatable", void 0);
+__decorate([
+    property({ type: Boolean }),
+    observer(function (newValue, oldValue) {
+        if (this.mdcFoundation) {
+            this.mdcFoundation.setMulti(newValue);
+        }
+        if (oldValue !== undefined) {
+            this.layout();
+        }
+    })
+], ListBase.prototype, "multi", void 0);
+__decorate([
+    property({ type: Boolean }),
+    observer(function (value) {
+        if (this.mdcFoundation) {
+            this.mdcFoundation.setWrapFocus(value);
+        }
+    })
+], ListBase.prototype, "wrapFocus", void 0);
+__decorate([
+    property({ type: String }),
+    observer(function (_newValue, oldValue) {
+        if (oldValue !== undefined) {
+            this.updateItems();
+        }
+    })
+], ListBase.prototype, "itemRoles", void 0);
+__decorate([
+    property({ type: String })
+], ListBase.prototype, "innerRole", void 0);
+__decorate([
+    property({ type: String })
+], ListBase.prototype, "innerAriaLabel", void 0);
+__decorate([
+    property({ type: Boolean })
+], ListBase.prototype, "rootTabbable", void 0);
+__decorate([
+    property({ type: Boolean, reflect: true }),
+    observer(function (value) {
+        const slot = this.slotElement;
+        if (value && slot) {
+            const tabbable = findAssignedElement(slot, '[tabindex="0"]');
+            this.previousTabindex = tabbable;
+            if (tabbable) {
+                tabbable.setAttribute('tabindex', '-1');
+            }
+        }
+        else if (!value && this.previousTabindex) {
+            this.previousTabindex.setAttribute('tabindex', '0');
+            this.previousTabindex = null;
+        }
+    })
+], ListBase.prototype, "noninteractive", void 0);
+
+/**
+@license
+Copyright 2018 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+const style$3 = css `@keyframes mdc-ripple-fg-radius-in{from{animation-timing-function:cubic-bezier(0.4, 0, 0.2, 1);transform:translate(var(--mdc-ripple-fg-translate-start, 0)) scale(1)}to{transform:translate(var(--mdc-ripple-fg-translate-end, 0)) scale(var(--mdc-ripple-fg-scale, 1))}}@keyframes mdc-ripple-fg-opacity-in{from{animation-timing-function:linear;opacity:0}to{opacity:var(--mdc-ripple-fg-opacity, 0)}}@keyframes mdc-ripple-fg-opacity-out{from{animation-timing-function:linear;opacity:var(--mdc-ripple-fg-opacity, 0)}to{opacity:0}}:host{display:block}.mdc-deprecated-list{-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased;font-family:Roboto, sans-serif;font-family:var(--mdc-typography-subtitle1-font-family, var(--mdc-typography-font-family, Roboto, sans-serif));font-size:1rem;font-size:var(--mdc-typography-subtitle1-font-size, 1rem);line-height:1.75rem;line-height:var(--mdc-typography-subtitle1-line-height, 1.75rem);font-weight:400;font-weight:var(--mdc-typography-subtitle1-font-weight, 400);letter-spacing:0.009375em;letter-spacing:var(--mdc-typography-subtitle1-letter-spacing, 0.009375em);text-decoration:inherit;text-decoration:var(--mdc-typography-subtitle1-text-decoration, inherit);text-transform:inherit;text-transform:var(--mdc-typography-subtitle1-text-transform, inherit);line-height:1.5rem;margin:0;padding:8px 0;list-style-type:none;color:rgba(0, 0, 0, 0.87);color:var(--mdc-theme-text-primary-on-background, rgba(0, 0, 0, 0.87));padding:var(--mdc-list-vertical-padding, 8px) 0}.mdc-deprecated-list:focus{outline:none}.mdc-deprecated-list-item{height:48px}.mdc-deprecated-list--dense{padding-top:4px;padding-bottom:4px;font-size:.812rem}.mdc-deprecated-list ::slotted([divider]){height:0;margin:0;border:none;border-bottom-width:1px;border-bottom-style:solid;border-bottom-color:rgba(0, 0, 0, 0.12)}.mdc-deprecated-list ::slotted([divider][padded]){margin:0 var(--mdc-list-side-padding, 16px)}.mdc-deprecated-list ::slotted([divider][inset]){margin-left:var(--mdc-list-inset-margin, 72px);margin-right:0;width:calc( 100% - var(--mdc-list-inset-margin, 72px) )}[dir=rtl] .mdc-deprecated-list ::slotted([divider][inset]),.mdc-deprecated-list ::slotted([divider][inset])[dir=rtl]{margin-left:0;margin-right:var(--mdc-list-inset-margin, 72px)}.mdc-deprecated-list ::slotted([divider][inset][padded]){width:calc( 100% - var(--mdc-list-inset-margin, 72px) - var(--mdc-list-side-padding, 16px) )}.mdc-deprecated-list--dense ::slotted([mwc-list-item]){height:40px}.mdc-deprecated-list--dense ::slotted([mwc-list]){--mdc-list-item-graphic-size: 20px}.mdc-deprecated-list--two-line.mdc-deprecated-list--dense ::slotted([mwc-list-item]),.mdc-deprecated-list--avatar-list.mdc-deprecated-list--dense ::slotted([mwc-list-item]){height:60px}.mdc-deprecated-list--avatar-list.mdc-deprecated-list--dense ::slotted([mwc-list]){--mdc-list-item-graphic-size: 36px}:host([noninteractive]){pointer-events:none;cursor:default}.mdc-deprecated-list--dense ::slotted(.mdc-deprecated-list-item__primary-text){display:block;margin-top:0;line-height:normal;margin-bottom:-20px}.mdc-deprecated-list--dense ::slotted(.mdc-deprecated-list-item__primary-text)::before{display:inline-block;width:0;height:24px;content:"";vertical-align:0}.mdc-deprecated-list--dense ::slotted(.mdc-deprecated-list-item__primary-text)::after{display:inline-block;width:0;height:20px;content:"";vertical-align:-20px}`;
+
+/**
+@license
+Copyright 2020 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+let List = class List extends ListBase {
+};
+List.styles = style$3;
+List = __decorate([
+    customElement('mwc-list')
+], List);
+
+/**
+ * @license
+ * Copyright 2018 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+var cssClasses$3 = {
+    ANCHOR: 'mdc-menu-surface--anchor',
+    ANIMATING_CLOSED: 'mdc-menu-surface--animating-closed',
+    ANIMATING_OPEN: 'mdc-menu-surface--animating-open',
+    FIXED: 'mdc-menu-surface--fixed',
+    IS_OPEN_BELOW: 'mdc-menu-surface--is-open-below',
+    OPEN: 'mdc-menu-surface--open',
+    ROOT: 'mdc-menu-surface',
+};
+// tslint:disable:object-literal-sort-keys
+var strings$3 = {
+    CLOSED_EVENT: 'MDCMenuSurface:closed',
+    CLOSING_EVENT: 'MDCMenuSurface:closing',
+    OPENED_EVENT: 'MDCMenuSurface:opened',
+    FOCUSABLE_ELEMENTS: [
+        'button:not(:disabled)',
+        '[href]:not([aria-disabled="true"])',
+        'input:not(:disabled)',
+        'select:not(:disabled)',
+        'textarea:not(:disabled)',
+        '[tabindex]:not([tabindex="-1"]):not([aria-disabled="true"])',
+    ].join(', '),
+};
+// tslint:enable:object-literal-sort-keys
+var numbers$3 = {
+    /** Total duration of menu-surface open animation. */
+    TRANSITION_OPEN_DURATION: 120,
+    /** Total duration of menu-surface close animation. */
+    TRANSITION_CLOSE_DURATION: 75,
+    /** Margin left to the edge of the viewport when menu-surface is at maximum possible height. Also used as a viewport margin. */
+    MARGIN_TO_EDGE: 32,
+    /** Ratio of anchor width to menu-surface width for switching from corner positioning to center positioning. */
+    ANCHOR_TO_MENU_SURFACE_WIDTH_RATIO: 0.67,
+};
+/**
+ * Enum for bits in the {@see Corner) bitmap.
+ */
+var CornerBit;
+(function (CornerBit) {
+    CornerBit[CornerBit["BOTTOM"] = 1] = "BOTTOM";
+    CornerBit[CornerBit["CENTER"] = 2] = "CENTER";
+    CornerBit[CornerBit["RIGHT"] = 4] = "RIGHT";
+    CornerBit[CornerBit["FLIP_RTL"] = 8] = "FLIP_RTL";
+})(CornerBit || (CornerBit = {}));
+/**
+ * Enum for representing an element corner for positioning the menu-surface.
+ *
+ * The START constants map to LEFT if element directionality is left
+ * to right and RIGHT if the directionality is right to left.
+ * Likewise END maps to RIGHT or LEFT depending on the directionality.
+ */
+var Corner;
+(function (Corner) {
+    Corner[Corner["TOP_LEFT"] = 0] = "TOP_LEFT";
+    Corner[Corner["TOP_RIGHT"] = 4] = "TOP_RIGHT";
+    Corner[Corner["BOTTOM_LEFT"] = 1] = "BOTTOM_LEFT";
+    Corner[Corner["BOTTOM_RIGHT"] = 5] = "BOTTOM_RIGHT";
+    Corner[Corner["TOP_START"] = 8] = "TOP_START";
+    Corner[Corner["TOP_END"] = 12] = "TOP_END";
+    Corner[Corner["BOTTOM_START"] = 9] = "BOTTOM_START";
+    Corner[Corner["BOTTOM_END"] = 13] = "BOTTOM_END";
+})(Corner || (Corner = {}));
+
+/**
+ * @license
+ * Copyright 2018 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+var MDCMenuSurfaceFoundation = /** @class */ (function (_super) {
+    __extends(MDCMenuSurfaceFoundation, _super);
+    function MDCMenuSurfaceFoundation(adapter) {
+        var _this = _super.call(this, __assign(__assign({}, MDCMenuSurfaceFoundation.defaultAdapter), adapter)) || this;
+        _this.isSurfaceOpen = false;
+        _this.isQuickOpen = false;
+        _this.isHoistedElement = false;
+        _this.isFixedPosition = false;
+        _this.isHorizontallyCenteredOnViewport = false;
+        _this.maxHeight = 0;
+        _this.openAnimationEndTimerId = 0;
+        _this.closeAnimationEndTimerId = 0;
+        _this.animationRequestId = 0;
+        _this.anchorCorner = Corner.TOP_START;
+        /**
+         * Corner of the menu surface to which menu surface is attached to anchor.
+         *
+         *  Anchor corner --->+----------+
+         *                    |  ANCHOR  |
+         *                    +----------+
+         *  Origin corner --->+--------------+
+         *                    |              |
+         *                    |              |
+         *                    | MENU SURFACE |
+         *                    |              |
+         *                    |              |
+         *                    +--------------+
+         */
+        _this.originCorner = Corner.TOP_START;
+        _this.anchorMargin = { top: 0, right: 0, bottom: 0, left: 0 };
+        _this.position = { x: 0, y: 0 };
+        return _this;
+    }
+    Object.defineProperty(MDCMenuSurfaceFoundation, "cssClasses", {
+        get: function () {
+            return cssClasses$3;
+        },
+        enumerable: false,
+        configurable: true
+    });
+    Object.defineProperty(MDCMenuSurfaceFoundation, "strings", {
+        get: function () {
+            return strings$3;
+        },
+        enumerable: false,
+        configurable: true
+    });
+    Object.defineProperty(MDCMenuSurfaceFoundation, "numbers", {
+        get: function () {
+            return numbers$3;
+        },
+        enumerable: false,
+        configurable: true
+    });
+    Object.defineProperty(MDCMenuSurfaceFoundation, "Corner", {
+        get: function () {
+            return Corner;
+        },
+        enumerable: false,
+        configurable: true
+    });
+    Object.defineProperty(MDCMenuSurfaceFoundation, "defaultAdapter", {
+        /**
+         * @see {@link MDCMenuSurfaceAdapter} for typing information on parameters and return types.
+         */
+        get: function () {
+            // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
+            return {
+                addClass: function () { return undefined; },
+                removeClass: function () { return undefined; },
+                hasClass: function () { return false; },
+                hasAnchor: function () { return false; },
+                isElementInContainer: function () { return false; },
+                isFocused: function () { return false; },
+                isRtl: function () { return false; },
+                getInnerDimensions: function () { return ({ height: 0, width: 0 }); },
+                getAnchorDimensions: function () { return null; },
+                getWindowDimensions: function () { return ({ height: 0, width: 0 }); },
+                getBodyDimensions: function () { return ({ height: 0, width: 0 }); },
+                getWindowScroll: function () { return ({ x: 0, y: 0 }); },
+                setPosition: function () { return undefined; },
+                setMaxHeight: function () { return undefined; },
+                setTransformOrigin: function () { return undefined; },
+                saveFocus: function () { return undefined; },
+                restoreFocus: function () { return undefined; },
+                notifyClose: function () { return undefined; },
+                notifyOpen: function () { return undefined; },
+                notifyClosing: function () { return undefined; },
+            };
+            // tslint:enable:object-literal-sort-keys
+        },
+        enumerable: false,
+        configurable: true
+    });
+    MDCMenuSurfaceFoundation.prototype.init = function () {
+        var _a = MDCMenuSurfaceFoundation.cssClasses, ROOT = _a.ROOT, OPEN = _a.OPEN;
+        if (!this.adapter.hasClass(ROOT)) {
+            throw new Error(ROOT + " class required in root element.");
+        }
+        if (this.adapter.hasClass(OPEN)) {
+            this.isSurfaceOpen = true;
+        }
+    };
+    MDCMenuSurfaceFoundation.prototype.destroy = function () {
+        clearTimeout(this.openAnimationEndTimerId);
+        clearTimeout(this.closeAnimationEndTimerId);
+        // Cancel any currently running animations.
+        cancelAnimationFrame(this.animationRequestId);
+    };
+    /**
+     * @param corner Default anchor corner alignment of top-left menu surface corner.
+     */
+    MDCMenuSurfaceFoundation.prototype.setAnchorCorner = function (corner) {
+        this.anchorCorner = corner;
+    };
+    /**
+     * Flip menu corner horizontally.
+     */
+    MDCMenuSurfaceFoundation.prototype.flipCornerHorizontally = function () {
+        this.originCorner = this.originCorner ^ CornerBit.RIGHT;
+    };
+    /**
+     * @param margin Set of margin values from anchor.
+     */
+    MDCMenuSurfaceFoundation.prototype.setAnchorMargin = function (margin) {
+        this.anchorMargin.top = margin.top || 0;
+        this.anchorMargin.right = margin.right || 0;
+        this.anchorMargin.bottom = margin.bottom || 0;
+        this.anchorMargin.left = margin.left || 0;
+    };
+    /** Used to indicate if the menu-surface is hoisted to the body. */
+    MDCMenuSurfaceFoundation.prototype.setIsHoisted = function (isHoisted) {
+        this.isHoistedElement = isHoisted;
+    };
+    /** Used to set the menu-surface calculations based on a fixed position menu. */
+    MDCMenuSurfaceFoundation.prototype.setFixedPosition = function (isFixedPosition) {
+        this.isFixedPosition = isFixedPosition;
+    };
+    /** Sets the menu-surface position on the page. */
+    MDCMenuSurfaceFoundation.prototype.setAbsolutePosition = function (x, y) {
+        this.position.x = this.isFinite(x) ? x : 0;
+        this.position.y = this.isFinite(y) ? y : 0;
+    };
+    /** Sets whether menu-surface should be horizontally centered to viewport. */
+    MDCMenuSurfaceFoundation.prototype.setIsHorizontallyCenteredOnViewport = function (isCentered) {
+        this.isHorizontallyCenteredOnViewport = isCentered;
+    };
+    MDCMenuSurfaceFoundation.prototype.setQuickOpen = function (quickOpen) {
+        this.isQuickOpen = quickOpen;
+    };
+    /**
+     * Sets maximum menu-surface height on open.
+     * @param maxHeight The desired max-height. Set to 0 (default) to
+     *     automatically calculate max height based on available viewport space.
+     */
+    MDCMenuSurfaceFoundation.prototype.setMaxHeight = function (maxHeight) {
+        this.maxHeight = maxHeight;
+    };
+    MDCMenuSurfaceFoundation.prototype.isOpen = function () {
+        return this.isSurfaceOpen;
+    };
+    /**
+     * Open the menu surface.
+     */
+    MDCMenuSurfaceFoundation.prototype.open = function () {
+        var _this = this;
+        if (this.isSurfaceOpen) {
+            return;
+        }
+        this.adapter.saveFocus();
+        if (this.isQuickOpen) {
+            this.isSurfaceOpen = true;
+            this.adapter.addClass(MDCMenuSurfaceFoundation.cssClasses.OPEN);
+            this.dimensions = this.adapter.getInnerDimensions();
+            this.autoposition();
+            this.adapter.notifyOpen();
+        }
+        else {
+            this.adapter.addClass(MDCMenuSurfaceFoundation.cssClasses.ANIMATING_OPEN);
+            this.animationRequestId = requestAnimationFrame(function () {
+                _this.adapter.addClass(MDCMenuSurfaceFoundation.cssClasses.OPEN);
+                _this.dimensions = _this.adapter.getInnerDimensions();
+                _this.autoposition();
+                _this.openAnimationEndTimerId = setTimeout(function () {
+                    _this.openAnimationEndTimerId = 0;
+                    _this.adapter.removeClass(MDCMenuSurfaceFoundation.cssClasses.ANIMATING_OPEN);
+                    _this.adapter.notifyOpen();
+                }, numbers$3.TRANSITION_OPEN_DURATION);
+            });
+            this.isSurfaceOpen = true;
+        }
+    };
+    /**
+     * Closes the menu surface.
+     */
+    MDCMenuSurfaceFoundation.prototype.close = function (skipRestoreFocus) {
+        var _this = this;
+        if (skipRestoreFocus === void 0) { skipRestoreFocus = false; }
+        if (!this.isSurfaceOpen) {
+            return;
+        }
+        this.adapter.notifyClosing();
+        if (this.isQuickOpen) {
+            this.isSurfaceOpen = false;
+            if (!skipRestoreFocus) {
+                this.maybeRestoreFocus();
+            }
+            this.adapter.removeClass(MDCMenuSurfaceFoundation.cssClasses.OPEN);
+            this.adapter.removeClass(MDCMenuSurfaceFoundation.cssClasses.IS_OPEN_BELOW);
+            this.adapter.notifyClose();
+            return;
+        }
+        this.adapter.addClass(MDCMenuSurfaceFoundation.cssClasses.ANIMATING_CLOSED);
+        requestAnimationFrame(function () {
+            _this.adapter.removeClass(MDCMenuSurfaceFoundation.cssClasses.OPEN);
+            _this.adapter.removeClass(MDCMenuSurfaceFoundation.cssClasses.IS_OPEN_BELOW);
+            _this.closeAnimationEndTimerId = setTimeout(function () {
+                _this.closeAnimationEndTimerId = 0;
+                _this.adapter.removeClass(MDCMenuSurfaceFoundation.cssClasses.ANIMATING_CLOSED);
+                _this.adapter.notifyClose();
+            }, numbers$3.TRANSITION_CLOSE_DURATION);
+        });
+        this.isSurfaceOpen = false;
+        if (!skipRestoreFocus) {
+            this.maybeRestoreFocus();
+        }
+    };
+    /** Handle clicks and close if not within menu-surface element. */
+    MDCMenuSurfaceFoundation.prototype.handleBodyClick = function (evt) {
+        var el = evt.target;
+        if (this.adapter.isElementInContainer(el)) {
+            return;
+        }
+        this.close();
+    };
+    /** Handle keys that close the surface. */
+    MDCMenuSurfaceFoundation.prototype.handleKeydown = function (evt) {
+        var keyCode = evt.keyCode, key = evt.key;
+        var isEscape = key === 'Escape' || keyCode === 27;
+        if (isEscape) {
+            this.close();
+        }
+    };
+    MDCMenuSurfaceFoundation.prototype.autoposition = function () {
+        var _a;
+        // Compute measurements for autoposition methods reuse.
+        this.measurements = this.getAutoLayoutmeasurements();
+        var corner = this.getoriginCorner();
+        var maxMenuSurfaceHeight = this.getMenuSurfaceMaxHeight(corner);
+        var verticalAlignment = this.hasBit(corner, CornerBit.BOTTOM) ? 'bottom' : 'top';
+        var horizontalAlignment = this.hasBit(corner, CornerBit.RIGHT) ? 'right' : 'left';
+        var horizontalOffset = this.getHorizontalOriginOffset(corner);
+        var verticalOffset = this.getVerticalOriginOffset(corner);
+        var _b = this.measurements, anchorSize = _b.anchorSize, surfaceSize = _b.surfaceSize;
+        var position = (_a = {},
+            _a[horizontalAlignment] = horizontalOffset,
+            _a[verticalAlignment] = verticalOffset,
+            _a);
+        // Center align when anchor width is comparable or greater than menu surface, otherwise keep corner.
+        if (anchorSize.width / surfaceSize.width > numbers$3.ANCHOR_TO_MENU_SURFACE_WIDTH_RATIO) {
+            horizontalAlignment = 'center';
+        }
+        // If the menu-surface has been hoisted to the body, it's no longer relative to the anchor element
+        if (this.isHoistedElement || this.isFixedPosition) {
+            this.adjustPositionForHoistedElement(position);
+        }
+        this.adapter.setTransformOrigin(horizontalAlignment + " " + verticalAlignment);
+        this.adapter.setPosition(position);
+        this.adapter.setMaxHeight(maxMenuSurfaceHeight ? maxMenuSurfaceHeight + 'px' : '');
+        // If it is opened from the top then add is-open-below class
+        if (!this.hasBit(corner, CornerBit.BOTTOM)) {
+            this.adapter.addClass(MDCMenuSurfaceFoundation.cssClasses.IS_OPEN_BELOW);
+        }
+    };
+    /**
+     * @return Measurements used to position menu surface popup.
+     */
+    MDCMenuSurfaceFoundation.prototype.getAutoLayoutmeasurements = function () {
+        var anchorRect = this.adapter.getAnchorDimensions();
+        var bodySize = this.adapter.getBodyDimensions();
+        var viewportSize = this.adapter.getWindowDimensions();
+        var windowScroll = this.adapter.getWindowScroll();
+        if (!anchorRect) {
+            // tslint:disable:object-literal-sort-keys Positional properties are more readable when they're grouped together
+            anchorRect = {
+                top: this.position.y,
+                right: this.position.x,
+                bottom: this.position.y,
+                left: this.position.x,
+                width: 0,
+                height: 0,
+            };
+            // tslint:enable:object-literal-sort-keys
+        }
+        return {
+            anchorSize: anchorRect,
+            bodySize: bodySize,
+            surfaceSize: this.dimensions,
+            viewportDistance: {
+                // tslint:disable:object-literal-sort-keys Positional properties are more readable when they're grouped together
+                top: anchorRect.top,
+                right: viewportSize.width - anchorRect.right,
+                bottom: viewportSize.height - anchorRect.bottom,
+                left: anchorRect.left,
+                // tslint:enable:object-literal-sort-keys
+            },
+            viewportSize: viewportSize,
+            windowScroll: windowScroll,
+        };
+    };
+    /**
+     * Computes the corner of the anchor from which to animate and position the
+     * menu surface.
+     *
+     * Only LEFT or RIGHT bit is used to position the menu surface ignoring RTL
+     * context. E.g., menu surface will be positioned from right side on TOP_END.
+     */
+    MDCMenuSurfaceFoundation.prototype.getoriginCorner = function () {
+        var corner = this.originCorner;
+        var _a = this.measurements, viewportDistance = _a.viewportDistance, anchorSize = _a.anchorSize, surfaceSize = _a.surfaceSize;
+        var MARGIN_TO_EDGE = MDCMenuSurfaceFoundation.numbers.MARGIN_TO_EDGE;
+        var isAnchoredToBottom = this.hasBit(this.anchorCorner, CornerBit.BOTTOM);
+        var availableTop;
+        var availableBottom;
+        if (isAnchoredToBottom) {
+            availableTop =
+                viewportDistance.top - MARGIN_TO_EDGE + this.anchorMargin.bottom;
+            availableBottom =
+                viewportDistance.bottom - MARGIN_TO_EDGE - this.anchorMargin.bottom;
+        }
+        else {
+            availableTop =
+                viewportDistance.top - MARGIN_TO_EDGE + this.anchorMargin.top;
+            availableBottom = viewportDistance.bottom - MARGIN_TO_EDGE +
+                anchorSize.height - this.anchorMargin.top;
+        }
+        var isAvailableBottom = availableBottom - surfaceSize.height > 0;
+        if (!isAvailableBottom && availableTop > availableBottom) {
+            // Attach bottom side of surface to the anchor.
+            corner = this.setBit(corner, CornerBit.BOTTOM);
+        }
+        var isRtl = this.adapter.isRtl();
+        var isFlipRtl = this.hasBit(this.anchorCorner, CornerBit.FLIP_RTL);
+        var hasRightBit = this.hasBit(this.anchorCorner, CornerBit.RIGHT) ||
+            this.hasBit(corner, CornerBit.RIGHT);
+        // Whether surface attached to right side of anchor element.
+        var isAnchoredToRight = false;
+        // Anchored to start
+        if (isRtl && isFlipRtl) {
+            isAnchoredToRight = !hasRightBit;
+        }
+        else {
+            // Anchored to right
+            isAnchoredToRight = hasRightBit;
+        }
+        var availableLeft;
+        var availableRight;
+        if (isAnchoredToRight) {
+            availableLeft =
+                viewportDistance.left + anchorSize.width + this.anchorMargin.right;
+            availableRight = viewportDistance.right - this.anchorMargin.right;
+        }
+        else {
+            availableLeft = viewportDistance.left + this.anchorMargin.left;
+            availableRight =
+                viewportDistance.right + anchorSize.width - this.anchorMargin.left;
+        }
+        var isAvailableLeft = availableLeft - surfaceSize.width > 0;
+        var isAvailableRight = availableRight - surfaceSize.width > 0;
+        var isOriginCornerAlignedToEnd = this.hasBit(corner, CornerBit.FLIP_RTL) &&
+            this.hasBit(corner, CornerBit.RIGHT);
+        if (isAvailableRight && isOriginCornerAlignedToEnd && isRtl ||
+            !isAvailableLeft && isOriginCornerAlignedToEnd) {
+            // Attach left side of surface to the anchor.
+            corner = this.unsetBit(corner, CornerBit.RIGHT);
+        }
+        else if (isAvailableLeft && isAnchoredToRight && isRtl ||
+            (isAvailableLeft && !isAnchoredToRight && hasRightBit) ||
+            (!isAvailableRight && availableLeft >= availableRight)) {
+            // Attach right side of surface to the anchor.
+            corner = this.setBit(corner, CornerBit.RIGHT);
+        }
+        return corner;
+    };
+    /**
+     * @param corner Origin corner of the menu surface.
+     * @return Maximum height of the menu surface, based on available space. 0 indicates should not be set.
+     */
+    MDCMenuSurfaceFoundation.prototype.getMenuSurfaceMaxHeight = function (corner) {
+        if (this.maxHeight > 0) {
+            return this.maxHeight;
+        }
+        var viewportDistance = this.measurements.viewportDistance;
+        var maxHeight = 0;
+        var isBottomAligned = this.hasBit(corner, CornerBit.BOTTOM);
+        var isBottomAnchored = this.hasBit(this.anchorCorner, CornerBit.BOTTOM);
+        var MARGIN_TO_EDGE = MDCMenuSurfaceFoundation.numbers.MARGIN_TO_EDGE;
+        // When maximum height is not specified, it is handled from CSS.
+        if (isBottomAligned) {
+            maxHeight = viewportDistance.top + this.anchorMargin.top - MARGIN_TO_EDGE;
+            if (!isBottomAnchored) {
+                maxHeight += this.measurements.anchorSize.height;
+            }
+        }
+        else {
+            maxHeight = viewportDistance.bottom - this.anchorMargin.bottom +
+                this.measurements.anchorSize.height - MARGIN_TO_EDGE;
+            if (isBottomAnchored) {
+                maxHeight -= this.measurements.anchorSize.height;
+            }
+        }
+        return maxHeight;
+    };
+    /**
+     * @param corner Origin corner of the menu surface.
+     * @return Horizontal offset of menu surface origin corner from corresponding anchor corner.
+     */
+    MDCMenuSurfaceFoundation.prototype.getHorizontalOriginOffset = function (corner) {
+        var anchorSize = this.measurements.anchorSize;
+        // isRightAligned corresponds to using the 'right' property on the surface.
+        var isRightAligned = this.hasBit(corner, CornerBit.RIGHT);
+        var avoidHorizontalOverlap = this.hasBit(this.anchorCorner, CornerBit.RIGHT);
+        if (isRightAligned) {
+            var rightOffset = avoidHorizontalOverlap ?
+                anchorSize.width - this.anchorMargin.left :
+                this.anchorMargin.right;
+            // For hoisted or fixed elements, adjust the offset by the difference
+            // between viewport width and body width so when we calculate the right
+            // value (`adjustPositionForHoistedElement`) based on the element
+            // position, the right property is correct.
+            if (this.isHoistedElement || this.isFixedPosition) {
+                return rightOffset -
+                    (this.measurements.viewportSize.width -
+                        this.measurements.bodySize.width);
+            }
+            return rightOffset;
+        }
+        return avoidHorizontalOverlap ? anchorSize.width - this.anchorMargin.right :
+            this.anchorMargin.left;
+    };
+    /**
+     * @param corner Origin corner of the menu surface.
+     * @return Vertical offset of menu surface origin corner from corresponding anchor corner.
+     */
+    MDCMenuSurfaceFoundation.prototype.getVerticalOriginOffset = function (corner) {
+        var anchorSize = this.measurements.anchorSize;
+        var isBottomAligned = this.hasBit(corner, CornerBit.BOTTOM);
+        var avoidVerticalOverlap = this.hasBit(this.anchorCorner, CornerBit.BOTTOM);
+        var y = 0;
+        if (isBottomAligned) {
+            y = avoidVerticalOverlap ? anchorSize.height - this.anchorMargin.top :
+                -this.anchorMargin.bottom;
+        }
+        else {
+            y = avoidVerticalOverlap ?
+                (anchorSize.height + this.anchorMargin.bottom) :
+                this.anchorMargin.top;
+        }
+        return y;
+    };
+    /** Calculates the offsets for positioning the menu-surface when the menu-surface has been hoisted to the body. */
+    MDCMenuSurfaceFoundation.prototype.adjustPositionForHoistedElement = function (position) {
+        var e_1, _a;
+        var _b = this.measurements, windowScroll = _b.windowScroll, viewportDistance = _b.viewportDistance, surfaceSize = _b.surfaceSize, viewportSize = _b.viewportSize;
+        var props = Object.keys(position);
+        try {
+            for (var props_1 = __values(props), props_1_1 = props_1.next(); !props_1_1.done; props_1_1 = props_1.next()) {
+                var prop = props_1_1.value;
+                var value = position[prop] || 0;
+                if (this.isHorizontallyCenteredOnViewport &&
+                    (prop === 'left' || prop === 'right')) {
+                    position[prop] = (viewportSize.width - surfaceSize.width) / 2;
+                    continue;
+                }
+                // Hoisted surfaces need to have the anchor elements location on the page added to the
+                // position properties for proper alignment on the body.
+                value += viewportDistance[prop];
+                // Surfaces that are absolutely positioned need to have additional calculations for scroll
+                // and bottom positioning.
+                if (!this.isFixedPosition) {
+                    if (prop === 'top') {
+                        value += windowScroll.y;
+                    }
+                    else if (prop === 'bottom') {
+                        value -= windowScroll.y;
+                    }
+                    else if (prop === 'left') {
+                        value += windowScroll.x;
+                    }
+                    else { // prop === 'right'
+                        value -= windowScroll.x;
+                    }
+                }
+                position[prop] = value;
+            }
+        }
+        catch (e_1_1) { e_1 = { error: e_1_1 }; }
+        finally {
+            try {
+                if (props_1_1 && !props_1_1.done && (_a = props_1.return)) _a.call(props_1);
+            }
+            finally { if (e_1) throw e_1.error; }
+        }
+    };
+    /**
+     * The last focused element when the menu surface was opened should regain focus, if the user is
+     * focused on or within the menu surface when it is closed.
+     */
+    MDCMenuSurfaceFoundation.prototype.maybeRestoreFocus = function () {
+        var isRootFocused = this.adapter.isFocused();
+        var childHasFocus = document.activeElement &&
+            this.adapter.isElementInContainer(document.activeElement);
+        if (isRootFocused || childHasFocus) {
+            this.adapter.restoreFocus();
+        }
+    };
+    MDCMenuSurfaceFoundation.prototype.hasBit = function (corner, bit) {
+        return Boolean(corner & bit); // tslint:disable-line:no-bitwise
+    };
+    MDCMenuSurfaceFoundation.prototype.setBit = function (corner, bit) {
+        return corner | bit; // tslint:disable-line:no-bitwise
+    };
+    MDCMenuSurfaceFoundation.prototype.unsetBit = function (corner, bit) {
+        return corner ^ bit;
+    };
+    /**
+     * isFinite that doesn't force conversion to number type.
+     * Equivalent to Number.isFinite in ES2015, which is not supported in IE.
+     */
+    MDCMenuSurfaceFoundation.prototype.isFinite = function (num) {
+        return typeof num === 'number' && isFinite(num);
+    };
+    return MDCMenuSurfaceFoundation;
+}(MDCFoundation$1));
+
+// tslint:disable:no-bitwise
+// required for closure compiler
+const stringToCorner = {
+    'TOP_LEFT': Corner.TOP_LEFT,
+    'TOP_RIGHT': Corner.TOP_RIGHT,
+    'BOTTOM_LEFT': Corner.BOTTOM_LEFT,
+    'BOTTOM_RIGHT': Corner.BOTTOM_RIGHT,
+    'TOP_START': Corner.TOP_START,
+    'TOP_END': Corner.TOP_END,
+    'BOTTOM_START': Corner.BOTTOM_START,
+    'BOTTOM_END': Corner.BOTTOM_END,
+};
+/**
+ * @fires opened
+ * @fires closed
+ */
+class MenuSurfaceBase extends BaseElement$1 {
+    constructor() {
+        super(...arguments);
+        this.mdcFoundationClass = MDCMenuSurfaceFoundation;
+        this.absolute = false;
+        this.fullwidth = false;
+        this.fixed = false;
+        this.x = null;
+        this.y = null;
+        // must be defined before open or else race condition in foundation occurs.
+        this.quick = false;
+        this.open = false;
+        this.stayOpenOnBodyClick = false;
+        this.bitwiseCorner = Corner.TOP_START;
+        this.previousMenuCorner = null;
+        // must be defined before observer of anchor corner for initialization
+        this.menuCorner = 'START';
+        this.corner = 'TOP_START';
+        this.styleTop = '';
+        this.styleLeft = '';
+        this.styleRight = '';
+        this.styleBottom = '';
+        this.styleMaxHeight = '';
+        this.styleTransformOrigin = '';
+        this.anchor = null;
+        this.previouslyFocused = null;
+        this.previousAnchor = null;
+        this.onBodyClickBound = () => undefined;
+    }
+    render() {
+        const classes = {
+            'mdc-menu-surface--fixed': this.fixed,
+            'mdc-menu-surface--fullwidth': this.fullwidth,
+        };
+        const styles = {
+            'top': this.styleTop,
+            'left': this.styleLeft,
+            'right': this.styleRight,
+            'bottom': this.styleBottom,
+            'max-height': this.styleMaxHeight,
+            'transform-origin': this.styleTransformOrigin,
+        };
+        return html `
+      <div
+          class="mdc-menu-surface ${classMap(classes)}"
+          style="${styleMap(styles)}"
+          @keydown=${this.onKeydown}
+          @opened=${this.registerBodyClick}
+          @closed=${this.deregisterBodyClick}>
+        <slot></slot>
+      </div>`;
+    }
+    createAdapter() {
+        return Object.assign(Object.assign({}, addHasRemoveClass(this.mdcRoot)), { hasAnchor: () => {
+                return !!this.anchor;
+            }, notifyClose: () => {
+                const init = { bubbles: true, composed: true };
+                const ev = new CustomEvent('closed', init);
+                this.open = false;
+                this.mdcRoot.dispatchEvent(ev);
+            }, notifyClosing: () => {
+                const init = { bubbles: true, composed: true };
+                const ev = new CustomEvent('closing', init);
+                this.mdcRoot.dispatchEvent(ev);
+            }, notifyOpen: () => {
+                const init = { bubbles: true, composed: true };
+                const ev = new CustomEvent('opened', init);
+                this.open = true;
+                this.mdcRoot.dispatchEvent(ev);
+            }, isElementInContainer: () => false, isRtl: () => {
+                if (this.mdcRoot) {
+                    return getComputedStyle(this.mdcRoot).direction === 'rtl';
+                }
+                return false;
+            }, setTransformOrigin: (origin) => {
+                const root = this.mdcRoot;
+                if (!root) {
+                    return;
+                }
+                this.styleTransformOrigin = origin;
+            }, isFocused: () => {
+                return doesElementContainFocus(this);
+            }, saveFocus: () => {
+                const activeElementPath = deepActiveElementPath();
+                const pathLength = activeElementPath.length;
+                if (!pathLength) {
+                    this.previouslyFocused = null;
+                }
+                this.previouslyFocused = activeElementPath[pathLength - 1];
+            }, restoreFocus: () => {
+                if (!this.previouslyFocused) {
+                    return;
+                }
+                if ('focus' in this.previouslyFocused) {
+                    this.previouslyFocused.focus();
+                }
+            }, getInnerDimensions: () => {
+                const mdcRoot = this.mdcRoot;
+                if (!mdcRoot) {
+                    return { width: 0, height: 0 };
+                }
+                return { width: mdcRoot.offsetWidth, height: mdcRoot.offsetHeight };
+            }, getAnchorDimensions: () => {
+                const anchorElement = this.anchor;
+                return anchorElement ? anchorElement.getBoundingClientRect() : null;
+            }, getBodyDimensions: () => {
+                return {
+                    width: document.body.clientWidth,
+                    height: document.body.clientHeight,
+                };
+            }, getWindowDimensions: () => {
+                return {
+                    width: window.innerWidth,
+                    height: window.innerHeight,
+                };
+            }, getWindowScroll: () => {
+                return {
+                    x: window.pageXOffset,
+                    y: window.pageYOffset,
+                };
+            }, setPosition: (position) => {
+                const mdcRoot = this.mdcRoot;
+                if (!mdcRoot) {
+                    return;
+                }
+                this.styleLeft = 'left' in position ? `${position.left}px` : '';
+                this.styleRight = 'right' in position ? `${position.right}px` : '';
+                this.styleTop = 'top' in position ? `${position.top}px` : '';
+                this.styleBottom = 'bottom' in position ? `${position.bottom}px` : '';
+            }, setMaxHeight: async (height) => {
+                const mdcRoot = this.mdcRoot;
+                if (!mdcRoot) {
+                    return;
+                }
+                // must set both for IE support as IE will not set a var
+                this.styleMaxHeight = height;
+                await this.updateComplete;
+                this.styleMaxHeight = `var(--mdc-menu-max-height, ${height})`;
+            } });
+    }
+    onKeydown(evt) {
+        if (this.mdcFoundation) {
+            this.mdcFoundation.handleKeydown(evt);
+        }
+    }
+    onBodyClick(evt) {
+        if (this.stayOpenOnBodyClick) {
+            return;
+        }
+        const path = evt.composedPath();
+        if (path.indexOf(this) === -1) {
+            this.close();
+        }
+    }
+    registerBodyClick() {
+        this.onBodyClickBound = this.onBodyClick.bind(this);
+        // capture otherwise listener closes menu after quick menu opens
+        document.body.addEventListener('click', this.onBodyClickBound, { passive: true, capture: true });
+    }
+    deregisterBodyClick() {
+        document.body.removeEventListener('click', this.onBodyClickBound, { capture: true });
+    }
+    close() {
+        this.open = false;
+    }
+    show() {
+        this.open = true;
+    }
+}
+__decorate([
+    query('.mdc-menu-surface')
+], MenuSurfaceBase.prototype, "mdcRoot", void 0);
+__decorate([
+    query('slot')
+], MenuSurfaceBase.prototype, "slotElement", void 0);
+__decorate([
+    property({ type: Boolean }),
+    observer(function (isAbsolute) {
+        if (this.mdcFoundation && !this.fixed) {
+            this.mdcFoundation.setIsHoisted(isAbsolute);
+        }
+    })
+], MenuSurfaceBase.prototype, "absolute", void 0);
+__decorate([
+    property({ type: Boolean })
+], MenuSurfaceBase.prototype, "fullwidth", void 0);
+__decorate([
+    property({ type: Boolean }),
+    observer(function (isFixed) {
+        if (this.mdcFoundation && !this.absolute) {
+            this.mdcFoundation.setFixedPosition(isFixed);
+        }
+    })
+], MenuSurfaceBase.prototype, "fixed", void 0);
+__decorate([
+    property({ type: Number }),
+    observer(function (value) {
+        if (this.mdcFoundation && this.y !== null && value !== null) {
+            this.mdcFoundation.setAbsolutePosition(value, this.y);
+            this.mdcFoundation.setAnchorMargin({ left: value, top: this.y, right: -value, bottom: this.y });
+        }
+    })
+], MenuSurfaceBase.prototype, "x", void 0);
+__decorate([
+    property({ type: Number }),
+    observer(function (value) {
+        if (this.mdcFoundation && this.x !== null && value !== null) {
+            this.mdcFoundation.setAbsolutePosition(this.x, value);
+            this.mdcFoundation.setAnchorMargin({ left: this.x, top: value, right: -this.x, bottom: value });
+        }
+    })
+], MenuSurfaceBase.prototype, "y", void 0);
+__decorate([
+    property({ type: Boolean }),
+    observer(function (value) {
+        if (this.mdcFoundation) {
+            this.mdcFoundation.setQuickOpen(value);
+        }
+    })
+], MenuSurfaceBase.prototype, "quick", void 0);
+__decorate([
+    property({ type: Boolean, reflect: true }),
+    observer(function (isOpen, wasOpen) {
+        if (this.mdcFoundation) {
+            if (isOpen) {
+                this.mdcFoundation.open();
+                // wasOpen helps with first render (when it is `undefined`) perf
+            }
+            else if (wasOpen !== undefined) {
+                this.mdcFoundation.close();
+            }
+        }
+    })
+], MenuSurfaceBase.prototype, "open", void 0);
+__decorate([
+    property({ type: Boolean })
+], MenuSurfaceBase.prototype, "stayOpenOnBodyClick", void 0);
+__decorate([
+    internalProperty(),
+    observer(function (value) {
+        if (this.mdcFoundation) {
+            if (value) {
+                this.mdcFoundation.setAnchorCorner(value);
+            }
+            else {
+                this.mdcFoundation.setAnchorCorner(value);
+            }
+        }
+    })
+], MenuSurfaceBase.prototype, "bitwiseCorner", void 0);
+__decorate([
+    property({ type: String }),
+    observer(function (value) {
+        if (this.mdcFoundation) {
+            const isValidValue = value === 'START' || value === 'END';
+            const isFirstTimeSet = this.previousMenuCorner === null;
+            const cornerChanged = !isFirstTimeSet && value !== this.previousMenuCorner;
+            const initiallySetToEnd = isFirstTimeSet && value === 'END';
+            if (isValidValue && (cornerChanged || initiallySetToEnd)) {
+                this.bitwiseCorner = this.bitwiseCorner ^ CornerBit.RIGHT;
+                this.mdcFoundation.flipCornerHorizontally();
+                this.previousMenuCorner = value;
+            }
+        }
+    })
+], MenuSurfaceBase.prototype, "menuCorner", void 0);
+__decorate([
+    property({ type: String }),
+    observer(function (value) {
+        if (this.mdcFoundation) {
+            if (value) {
+                let newCorner = stringToCorner[value];
+                if (this.menuCorner === 'END') {
+                    newCorner = newCorner ^ CornerBit.RIGHT;
+                }
+                this.bitwiseCorner = newCorner;
+            }
+        }
+    })
+], MenuSurfaceBase.prototype, "corner", void 0);
+__decorate([
+    internalProperty()
+], MenuSurfaceBase.prototype, "styleTop", void 0);
+__decorate([
+    internalProperty()
+], MenuSurfaceBase.prototype, "styleLeft", void 0);
+__decorate([
+    internalProperty()
+], MenuSurfaceBase.prototype, "styleRight", void 0);
+__decorate([
+    internalProperty()
+], MenuSurfaceBase.prototype, "styleBottom", void 0);
+__decorate([
+    internalProperty()
+], MenuSurfaceBase.prototype, "styleMaxHeight", void 0);
+__decorate([
+    internalProperty()
+], MenuSurfaceBase.prototype, "styleTransformOrigin", void 0);
+
+/**
+@license
+Copyright 2018 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+const style$4 = css `.mdc-menu-surface{display:none;position:absolute;box-sizing:border-box;max-width:calc(100vw - 32px);max-width:var(--mdc-menu-max-width, calc(100vw - 32px));max-height:calc(100vh - 32px);max-height:var(--mdc-menu-max-height, calc(100vh - 32px));margin:0;padding:0;transform:scale(1);transform-origin:top left;opacity:0;overflow:auto;will-change:transform,opacity;z-index:8;transition:opacity .03s linear,transform .12s cubic-bezier(0, 0, 0.2, 1),height 250ms cubic-bezier(0, 0, 0.2, 1);box-shadow:0px 5px 5px -3px rgba(0, 0, 0, 0.2),0px 8px 10px 1px rgba(0, 0, 0, 0.14),0px 3px 14px 2px rgba(0,0,0,.12);background-color:#fff;background-color:var(--mdc-theme-surface, #fff);color:#000;color:var(--mdc-theme-on-surface, #000);border-radius:4px;border-radius:var(--mdc-shape-medium, 4px);transform-origin-left:top left;transform-origin-right:top right}.mdc-menu-surface:focus{outline:none}.mdc-menu-surface--open{display:inline-block;transform:scale(1);opacity:1}.mdc-menu-surface--animating-open{display:inline-block;transform:scale(0.8);opacity:0}.mdc-menu-surface--animating-closed{display:inline-block;opacity:0;transition:opacity .075s linear}[dir=rtl] .mdc-menu-surface,.mdc-menu-surface[dir=rtl]{transform-origin-left:top right;transform-origin-right:top left}.mdc-menu-surface--anchor{position:relative;overflow:visible}.mdc-menu-surface--fixed{position:fixed}.mdc-menu-surface--fullwidth{width:100%}:host(:not([open])){display:none}.mdc-menu-surface{z-index:8;z-index:var(--mdc-menu-z-index, 8);min-width:112px;min-width:var(--mdc-menu-min-width, 112px)}`;
+
+/**
+@license
+Copyright 2020 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+let MenuSurface = class MenuSurface extends MenuSurfaceBase {
+};
+MenuSurface.styles = style$4;
+MenuSurface = __decorate([
+    customElement('mwc-menu-surface')
+], MenuSurface);
+
+/**
+ * @license
+ * Copyright 2018 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+var cssClasses$4 = {
+    MENU_SELECTED_LIST_ITEM: 'mdc-menu-item--selected',
+    MENU_SELECTION_GROUP: 'mdc-menu__selection-group',
+    ROOT: 'mdc-menu',
+};
+var strings$4 = {
+    ARIA_CHECKED_ATTR: 'aria-checked',
+    ARIA_DISABLED_ATTR: 'aria-disabled',
+    CHECKBOX_SELECTOR: 'input[type="checkbox"]',
+    LIST_SELECTOR: '.mdc-list,.mdc-deprecated-list',
+    SELECTED_EVENT: 'MDCMenu:selected',
+};
+var numbers$4 = {
+    FOCUS_ROOT_INDEX: -1,
+};
+var DefaultFocusState;
+(function (DefaultFocusState) {
+    DefaultFocusState[DefaultFocusState["NONE"] = 0] = "NONE";
+    DefaultFocusState[DefaultFocusState["LIST_ROOT"] = 1] = "LIST_ROOT";
+    DefaultFocusState[DefaultFocusState["FIRST_ITEM"] = 2] = "FIRST_ITEM";
+    DefaultFocusState[DefaultFocusState["LAST_ITEM"] = 3] = "LAST_ITEM";
+})(DefaultFocusState || (DefaultFocusState = {}));
+
+/**
+ * @license
+ * Copyright 2018 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+var MDCMenuFoundation = /** @class */ (function (_super) {
+    __extends(MDCMenuFoundation, _super);
+    function MDCMenuFoundation(adapter) {
+        var _this = _super.call(this, __assign(__assign({}, MDCMenuFoundation.defaultAdapter), adapter)) || this;
+        _this.closeAnimationEndTimerId_ = 0;
+        _this.defaultFocusState_ = DefaultFocusState.LIST_ROOT;
+        return _this;
+    }
+    Object.defineProperty(MDCMenuFoundation, "cssClasses", {
+        get: function () {
+            return cssClasses$4;
+        },
+        enumerable: false,
+        configurable: true
+    });
+    Object.defineProperty(MDCMenuFoundation, "strings", {
+        get: function () {
+            return strings$4;
+        },
+        enumerable: false,
+        configurable: true
+    });
+    Object.defineProperty(MDCMenuFoundation, "numbers", {
+        get: function () {
+            return numbers$4;
+        },
+        enumerable: false,
+        configurable: true
+    });
+    Object.defineProperty(MDCMenuFoundation, "defaultAdapter", {
+        /**
+         * @see {@link MDCMenuAdapter} for typing information on parameters and return types.
+         */
+        get: function () {
+            // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
+            return {
+                addClassToElementAtIndex: function () { return undefined; },
+                removeClassFromElementAtIndex: function () { return undefined; },
+                addAttributeToElementAtIndex: function () { return undefined; },
+                removeAttributeFromElementAtIndex: function () { return undefined; },
+                elementContainsClass: function () { return false; },
+                closeSurface: function () { return undefined; },
+                getElementIndex: function () { return -1; },
+                notifySelected: function () { return undefined; },
+                getMenuItemCount: function () { return 0; },
+                focusItemAtIndex: function () { return undefined; },
+                focusListRoot: function () { return undefined; },
+                getSelectedSiblingOfItemAtIndex: function () { return -1; },
+                isSelectableItemAtIndex: function () { return false; },
+            };
+            // tslint:enable:object-literal-sort-keys
+        },
+        enumerable: false,
+        configurable: true
+    });
+    MDCMenuFoundation.prototype.destroy = function () {
+        if (this.closeAnimationEndTimerId_) {
+            clearTimeout(this.closeAnimationEndTimerId_);
+        }
+        this.adapter.closeSurface();
+    };
+    MDCMenuFoundation.prototype.handleKeydown = function (evt) {
+        var key = evt.key, keyCode = evt.keyCode;
+        var isTab = key === 'Tab' || keyCode === 9;
+        if (isTab) {
+            this.adapter.closeSurface(/** skipRestoreFocus */ true);
+        }
+    };
+    MDCMenuFoundation.prototype.handleItemAction = function (listItem) {
+        var _this = this;
+        var index = this.adapter.getElementIndex(listItem);
+        if (index < 0) {
+            return;
+        }
+        this.adapter.notifySelected({ index: index });
+        this.adapter.closeSurface();
+        // Wait for the menu to close before adding/removing classes that affect styles.
+        this.closeAnimationEndTimerId_ = setTimeout(function () {
+            // Recompute the index in case the menu contents have changed.
+            var recomputedIndex = _this.adapter.getElementIndex(listItem);
+            if (recomputedIndex >= 0 &&
+                _this.adapter.isSelectableItemAtIndex(recomputedIndex)) {
+                _this.setSelectedIndex(recomputedIndex);
+            }
+        }, MDCMenuSurfaceFoundation.numbers.TRANSITION_CLOSE_DURATION);
+    };
+    MDCMenuFoundation.prototype.handleMenuSurfaceOpened = function () {
+        switch (this.defaultFocusState_) {
+            case DefaultFocusState.FIRST_ITEM:
+                this.adapter.focusItemAtIndex(0);
+                break;
+            case DefaultFocusState.LAST_ITEM:
+                this.adapter.focusItemAtIndex(this.adapter.getMenuItemCount() - 1);
+                break;
+            case DefaultFocusState.NONE:
+                // Do nothing.
+                break;
+            default:
+                this.adapter.focusListRoot();
+                break;
+        }
+    };
+    /**
+     * Sets default focus state where the menu should focus every time when menu
+     * is opened. Focuses the list root (`DefaultFocusState.LIST_ROOT`) element by
+     * default.
+     */
+    MDCMenuFoundation.prototype.setDefaultFocusState = function (focusState) {
+        this.defaultFocusState_ = focusState;
+    };
+    /**
+     * Selects the list item at `index` within the menu.
+     * @param index Index of list item within the menu.
+     */
+    MDCMenuFoundation.prototype.setSelectedIndex = function (index) {
+        this.validatedIndex_(index);
+        if (!this.adapter.isSelectableItemAtIndex(index)) {
+            throw new Error('MDCMenuFoundation: No selection group at specified index.');
+        }
+        var prevSelectedIndex = this.adapter.getSelectedSiblingOfItemAtIndex(index);
+        if (prevSelectedIndex >= 0) {
+            this.adapter.removeAttributeFromElementAtIndex(prevSelectedIndex, strings$4.ARIA_CHECKED_ATTR);
+            this.adapter.removeClassFromElementAtIndex(prevSelectedIndex, cssClasses$4.MENU_SELECTED_LIST_ITEM);
+        }
+        this.adapter.addClassToElementAtIndex(index, cssClasses$4.MENU_SELECTED_LIST_ITEM);
+        this.adapter.addAttributeToElementAtIndex(index, strings$4.ARIA_CHECKED_ATTR, 'true');
+    };
+    /**
+     * Sets the enabled state to isEnabled for the menu item at the given index.
+     * @param index Index of the menu item
+     * @param isEnabled The desired enabled state of the menu item.
+     */
+    MDCMenuFoundation.prototype.setEnabled = function (index, isEnabled) {
+        this.validatedIndex_(index);
+        if (isEnabled) {
+            this.adapter.removeClassFromElementAtIndex(index, cssClasses$2.LIST_ITEM_DISABLED_CLASS);
+            this.adapter.addAttributeToElementAtIndex(index, strings$4.ARIA_DISABLED_ATTR, 'false');
+        }
+        else {
+            this.adapter.addClassToElementAtIndex(index, cssClasses$2.LIST_ITEM_DISABLED_CLASS);
+            this.adapter.addAttributeToElementAtIndex(index, strings$4.ARIA_DISABLED_ATTR, 'true');
+        }
+    };
+    MDCMenuFoundation.prototype.validatedIndex_ = function (index) {
+        var menuSize = this.adapter.getMenuItemCount();
+        var isIndexInRange = index >= 0 && index < menuSize;
+        if (!isIndexInRange) {
+            throw new Error('MDCMenuFoundation: No list item at specified index.');
+        }
+    };
+    return MDCMenuFoundation;
+}(MDCFoundation$1));
+
+/**
+ * @fires selected {SelectedDetail}
+ * @fires action {ActionDetail}
+ * @fires items-updated
+ * @fires opened
+ * @fires closed
+ */
+class MenuBase extends BaseElement$1 {
+    constructor() {
+        super(...arguments);
+        this.mdcFoundationClass = MDCMenuFoundation;
+        this.listElement_ = null;
+        this.anchor = null;
+        this.open = false;
+        this.quick = false;
+        this.wrapFocus = false;
+        this.innerRole = 'menu';
+        this.corner = 'TOP_START';
+        this.x = null;
+        this.y = null;
+        this.absolute = false;
+        this.multi = false;
+        this.activatable = false;
+        this.fixed = false;
+        this.forceGroupSelection = false;
+        this.fullwidth = false;
+        this.menuCorner = 'START';
+        this.stayOpenOnBodyClick = false;
+        this.defaultFocus = 'LIST_ROOT';
+        this._listUpdateComplete = null;
+    }
+    get listElement() {
+        if (!this.listElement_) {
+            this.listElement_ = this.renderRoot.querySelector('mwc-list');
+            return this.listElement_;
+        }
+        return this.listElement_;
+    }
+    get items() {
+        const listElement = this.listElement;
+        if (listElement) {
+            return listElement.items;
+        }
+        return [];
+    }
+    get index() {
+        const listElement = this.listElement;
+        if (listElement) {
+            return listElement.index;
+        }
+        return -1;
+    }
+    get selected() {
+        const listElement = this.listElement;
+        if (listElement) {
+            return listElement.selected;
+        }
+        return null;
+    }
+    render() {
+        const itemRoles = this.innerRole === 'menu' ? 'menuitem' : 'option';
+        return html `
+      <mwc-menu-surface
+          ?hidden=${!this.open}
+          .anchor=${this.anchor}
+          .open=${this.open}
+          .quick=${this.quick}
+          .corner=${this.corner}
+          .x=${this.x}
+          .y=${this.y}
+          .absolute=${this.absolute}
+          .fixed=${this.fixed}
+          .fullwidth=${this.fullwidth}
+          .menuCorner=${this.menuCorner}
+          ?stayOpenOnBodyClick=${this.stayOpenOnBodyClick}
+          class="mdc-menu mdc-menu-surface"
+          @closed=${this.onClosed}
+          @opened=${this.onOpened}
+          @keydown=${this.onKeydown}>
+        <mwc-list
+          rootTabbable
+          .innerRole=${this.innerRole}
+          .multi=${this.multi}
+          class="mdc-deprecated-list"
+          .itemRoles=${itemRoles}
+          .wrapFocus=${this.wrapFocus}
+          .activatable=${this.activatable}
+          @action=${this.onAction}>
+        <slot></slot>
+      </mwc-list>
+    </mwc-menu-surface>`;
+    }
+    createAdapter() {
+        return {
+            addClassToElementAtIndex: (index, className) => {
+                const listElement = this.listElement;
+                if (!listElement) {
+                    return;
+                }
+                const element = listElement.items[index];
+                if (!element) {
+                    return;
+                }
+                if (className === 'mdc-menu-item--selected') {
+                    if (this.forceGroupSelection && !element.selected) {
+                        listElement.toggle(index, true);
+                    }
+                }
+                else {
+                    element.classList.add(className);
+                }
+            },
+            removeClassFromElementAtIndex: (index, className) => {
+                const listElement = this.listElement;
+                if (!listElement) {
+                    return;
+                }
+                const element = listElement.items[index];
+                if (!element) {
+                    return;
+                }
+                if (className === 'mdc-menu-item--selected') {
+                    if (element.selected) {
+                        listElement.toggle(index, false);
+                    }
+                }
+                else {
+                    element.classList.remove(className);
+                }
+            },
+            addAttributeToElementAtIndex: (index, attr, value) => {
+                const listElement = this.listElement;
+                if (!listElement) {
+                    return;
+                }
+                const element = listElement.items[index];
+                if (!element) {
+                    return;
+                }
+                element.setAttribute(attr, value);
+            },
+            removeAttributeFromElementAtIndex: (index, attr) => {
+                const listElement = this.listElement;
+                if (!listElement) {
+                    return;
+                }
+                const element = listElement.items[index];
+                if (!element) {
+                    return;
+                }
+                element.removeAttribute(attr);
+            },
+            elementContainsClass: (element, className) => element.classList.contains(className),
+            closeSurface: () => {
+                this.open = false;
+            },
+            getElementIndex: (element) => {
+                const listElement = this.listElement;
+                if (listElement) {
+                    return listElement.items.indexOf(element);
+                }
+                return -1;
+            },
+            notifySelected: () => { },
+            getMenuItemCount: () => {
+                const listElement = this.listElement;
+                if (!listElement) {
+                    return 0;
+                }
+                return listElement.items.length;
+            },
+            focusItemAtIndex: (index) => {
+                const listElement = this.listElement;
+                if (!listElement) {
+                    return;
+                }
+                const element = listElement.items[index];
+                if (element) {
+                    element.focus();
+                }
+            },
+            focusListRoot: () => {
+                if (this.listElement) {
+                    this.listElement.focus();
+                }
+            },
+            getSelectedSiblingOfItemAtIndex: (index) => {
+                const listElement = this.listElement;
+                if (!listElement) {
+                    return -1;
+                }
+                const elementAtIndex = listElement.items[index];
+                if (!elementAtIndex || !elementAtIndex.group) {
+                    return -1;
+                }
+                for (let i = 0; i < listElement.items.length; i++) {
+                    if (i === index) {
+                        continue;
+                    }
+                    const current = listElement.items[i];
+                    if (current.selected && current.group === elementAtIndex.group) {
+                        return i;
+                    }
+                }
+                return -1;
+            },
+            isSelectableItemAtIndex: (index) => {
+                const listElement = this.listElement;
+                if (!listElement) {
+                    return false;
+                }
+                const elementAtIndex = listElement.items[index];
+                if (!elementAtIndex) {
+                    return false;
+                }
+                return elementAtIndex.hasAttribute('group');
+            },
+        };
+    }
+    onKeydown(evt) {
+        if (this.mdcFoundation) {
+            this.mdcFoundation.handleKeydown(evt);
+        }
+    }
+    onAction(evt) {
+        const listElement = this.listElement;
+        if (this.mdcFoundation && listElement) {
+            const index = evt.detail.index;
+            const el = listElement.items[index];
+            if (el) {
+                this.mdcFoundation.handleItemAction(el);
+            }
+        }
+    }
+    onOpened() {
+        this.open = true;
+        if (this.mdcFoundation) {
+            this.mdcFoundation.handleMenuSurfaceOpened();
+        }
+    }
+    onClosed() {
+        this.open = false;
+    }
+    // tslint:disable:ban-ts-ignore
+    async _getUpdateComplete() {
+        let result = false;
+        await this._listUpdateComplete;
+        // @ts-ignore
+        if (super._getUpdateComplete) {
+            // @ts-ignore
+            await super._getUpdateComplete();
+        }
+        else {
+            // @ts-ignore
+            result = await super.getUpdateComplete();
+        }
+        return result;
+    }
+    // tslint:enable:ban-ts-ignore
+    getUpdateComplete() {
+        return this._getUpdateComplete();
+    }
+    async firstUpdated() {
+        super.firstUpdated();
+        const listElement = this.listElement;
+        if (listElement) {
+            this._listUpdateComplete = listElement.updateComplete;
+            await this._listUpdateComplete;
+        }
+    }
+    select(index) {
+        const listElement = this.listElement;
+        if (listElement) {
+            listElement.select(index);
+        }
+    }
+    close() {
+        this.open = false;
+    }
+    show() {
+        this.open = true;
+    }
+    getFocusedItemIndex() {
+        const listElement = this.listElement;
+        if (listElement) {
+            return listElement.getFocusedItemIndex();
+        }
+        return -1;
+    }
+    focusItemAtIndex(index) {
+        const listElement = this.listElement;
+        if (listElement) {
+            listElement.focusItemAtIndex(index);
+        }
+    }
+    layout(updateItems = true) {
+        const listElement = this.listElement;
+        if (listElement) {
+            listElement.layout(updateItems);
+        }
+    }
+}
+__decorate([
+    query('.mdc-menu')
+], MenuBase.prototype, "mdcRoot", void 0);
+__decorate([
+    query('slot')
+], MenuBase.prototype, "slotElement", void 0);
+__decorate([
+    property({ type: Object })
+], MenuBase.prototype, "anchor", void 0);
+__decorate([
+    property({ type: Boolean, reflect: true })
+], MenuBase.prototype, "open", void 0);
+__decorate([
+    property({ type: Boolean })
+], MenuBase.prototype, "quick", void 0);
+__decorate([
+    property({ type: Boolean })
+], MenuBase.prototype, "wrapFocus", void 0);
+__decorate([
+    property({ type: String })
+], MenuBase.prototype, "innerRole", void 0);
+__decorate([
+    property({ type: String })
+], MenuBase.prototype, "corner", void 0);
+__decorate([
+    property({ type: Number })
+], MenuBase.prototype, "x", void 0);
+__decorate([
+    property({ type: Number })
+], MenuBase.prototype, "y", void 0);
+__decorate([
+    property({ type: Boolean })
+], MenuBase.prototype, "absolute", void 0);
+__decorate([
+    property({ type: Boolean })
+], MenuBase.prototype, "multi", void 0);
+__decorate([
+    property({ type: Boolean })
+], MenuBase.prototype, "activatable", void 0);
+__decorate([
+    property({ type: Boolean })
+], MenuBase.prototype, "fixed", void 0);
+__decorate([
+    property({ type: Boolean })
+], MenuBase.prototype, "forceGroupSelection", void 0);
+__decorate([
+    property({ type: Boolean })
+], MenuBase.prototype, "fullwidth", void 0);
+__decorate([
+    property({ type: String })
+], MenuBase.prototype, "menuCorner", void 0);
+__decorate([
+    property({ type: Boolean })
+], MenuBase.prototype, "stayOpenOnBodyClick", void 0);
+__decorate([
+    property({ type: String }),
+    observer(function (value) {
+        if (this.mdcFoundation) {
+            this.mdcFoundation.setDefaultFocusState(DefaultFocusState[value]);
+        }
+    })
+], MenuBase.prototype, "defaultFocus", void 0);
+
+/**
+@license
+Copyright 2018 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+const style$5 = css `mwc-list ::slotted([mwc-list-item]:not([twoline])){height:var(--mdc-menu-item-height, 48px)}`;
+
+/**
+@license
+Copyright 2020 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+let Menu = class Menu extends MenuBase {
+};
+Menu.styles = style$5;
+Menu = __decorate([
+    customElement('mwc-menu')
+], Menu);
+
+/**
+@license
+Copyright 2018 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+const style$6 = css `:host{font-family:var(--mdc-icon-font, "Material Icons");font-weight:normal;font-style:normal;font-size:var(--mdc-icon-size, 24px);line-height:1;letter-spacing:normal;text-transform:none;display:inline-block;white-space:nowrap;word-wrap:normal;direction:ltr;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;-moz-osx-font-smoothing:grayscale;font-feature-settings:"liga"}`;
+
+/** @soyCompatible */
+let Icon = class Icon extends LitElement {
+    /** @soyTemplate */
+    render() {
+        return html `<slot></slot>`;
+    }
+};
+Icon.styles = style$6;
+Icon = __decorate([
+    customElement('mwc-icon')
+], Icon);
+
+/**
+ * @license
+ * Copyright 2020 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+var ELEMENTS_KEY_ALLOWED_IN$1 = ['input', 'button', 'textarea', 'select'];
+/**
+ * Ensures that preventDefault is only called if the containing element
+ * doesn't consume the event, and it will cause an unintended scroll.
+ *
+ * @param evt keyboard event to be prevented.
+ */
+var preventDefaultEvent = function (evt) {
+    var target = evt.target;
+    if (!target) {
+        return;
+    }
+    var tagName = ("" + target.tagName).toLowerCase();
+    if (ELEMENTS_KEY_ALLOWED_IN$1.indexOf(tagName) === -1) {
+        evt.preventDefault();
+    }
+};
+
+/**
+ * @license
+ * Copyright 2020 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+/**
+ * Initializes a state object for typeahead. Use the same reference for calls to
+ * typeahead functions.
+ *
+ * @return The current state of the typeahead process. Each state reference
+ *     represents a typeahead instance as the reference is typically mutated
+ *     in-place.
+ */
+function initState() {
+    var state = {
+        bufferClearTimeout: 0,
+        currentFirstChar: '',
+        sortedIndexCursor: 0,
+        typeaheadBuffer: '',
+    };
+    return state;
+}
+/**
+ * Initializes typeahead state by indexing the current list items by primary
+ * text into the sortedIndexByFirstChar data structure.
+ *
+ * @param listItemCount numer of items in the list
+ * @param getPrimaryTextByItemIndex function that returns the primary text at a
+ *     given index
+ *
+ * @return Map that maps the first character of the primary text to the full
+ *     list text and it's index
+ */
+function initSortedIndex(listItemCount, getPrimaryTextByItemIndex) {
+    var sortedIndexByFirstChar = new Map();
+    // Aggregate item text to index mapping
+    for (var i = 0; i < listItemCount; i++) {
+        var primaryText = getPrimaryTextByItemIndex(i).trim();
+        if (!primaryText) {
+            continue;
+        }
+        var firstChar = primaryText[0].toLowerCase();
+        if (!sortedIndexByFirstChar.has(firstChar)) {
+            sortedIndexByFirstChar.set(firstChar, []);
+        }
+        sortedIndexByFirstChar.get(firstChar).push({ text: primaryText.toLowerCase(), index: i });
+    }
+    // Sort the mapping
+    // TODO(b/157162694): Investigate replacing forEach with Map.values()
+    sortedIndexByFirstChar.forEach(function (values) {
+        values.sort(function (first, second) {
+            return first.index - second.index;
+        });
+    });
+    return sortedIndexByFirstChar;
+}
+/**
+ * Given the next desired character from the user, it attempts to find the next
+ * list option matching the buffer. Wraps around if at the end of options.
+ *
+ * @param opts Options and accessors
+ *   - nextChar - the next character to match against items
+ *   - sortedIndexByFirstChar - output of `initSortedIndex(...)`
+ *   - focusedItemIndex - the index of the currently focused item
+ *   - focusItemAtIndex - function that focuses a list item at given index
+ *   - skipFocus - whether or not to focus the matched item
+ *   - isItemAtIndexDisabled - function that determines whether an item at a
+ *        given index is disabled
+ * @param state The typeahead state instance. See `initState`.
+ *
+ * @return The index of the matched item, or -1 if no match.
+ */
+function matchItem(opts, state) {
+    var nextChar = opts.nextChar, focusItemAtIndex = opts.focusItemAtIndex, sortedIndexByFirstChar = opts.sortedIndexByFirstChar, focusedItemIndex = opts.focusedItemIndex, skipFocus = opts.skipFocus, isItemAtIndexDisabled = opts.isItemAtIndexDisabled;
+    clearTimeout(state.bufferClearTimeout);
+    state.bufferClearTimeout = setTimeout(function () {
+        clearBuffer(state);
+    }, numbers$2.TYPEAHEAD_BUFFER_CLEAR_TIMEOUT_MS);
+    state.typeaheadBuffer = state.typeaheadBuffer + nextChar;
+    var index;
+    if (state.typeaheadBuffer.length === 1) {
+        index = matchFirstChar(sortedIndexByFirstChar, focusedItemIndex, isItemAtIndexDisabled, state);
+    }
+    else {
+        index = matchAllChars(sortedIndexByFirstChar, isItemAtIndexDisabled, state);
+    }
+    if (index !== -1 && !skipFocus) {
+        focusItemAtIndex(index);
+    }
+    return index;
+}
+/**
+ * Matches the user's single input character in the buffer to the
+ * next option that begins with such character. Wraps around if at
+ * end of options. Returns -1 if no match is found.
+ */
+function matchFirstChar(sortedIndexByFirstChar, focusedItemIndex, isItemAtIndexDisabled, state) {
+    var firstChar = state.typeaheadBuffer[0];
+    var itemsMatchingFirstChar = sortedIndexByFirstChar.get(firstChar);
+    if (!itemsMatchingFirstChar) {
+        return -1;
+    }
+    // Has the same firstChar been recently matched?
+    // Also, did starting index remain the same between key presses?
+    // If both hold true, simply increment index.
+    if (firstChar === state.currentFirstChar &&
+        itemsMatchingFirstChar[state.sortedIndexCursor].index ===
+            focusedItemIndex) {
+        state.sortedIndexCursor =
+            (state.sortedIndexCursor + 1) % itemsMatchingFirstChar.length;
+        var newIndex = itemsMatchingFirstChar[state.sortedIndexCursor].index;
+        if (!isItemAtIndexDisabled(newIndex)) {
+            return newIndex;
+        }
+    }
+    // If we're here, it means one of the following happened:
+    // - either firstChar or startingIndex has changed, invalidating the
+    // cursor.
+    // - The next item of typeahead is disabled, so we have to look further.
+    state.currentFirstChar = firstChar;
+    var newCursorPosition = -1;
+    var cursorPosition;
+    // Find the first non-disabled item as a fallback.
+    for (cursorPosition = 0; cursorPosition < itemsMatchingFirstChar.length; cursorPosition++) {
+        if (!isItemAtIndexDisabled(itemsMatchingFirstChar[cursorPosition].index)) {
+            newCursorPosition = cursorPosition;
+            break;
+        }
+    }
+    // Advance cursor to first item matching the firstChar that is positioned
+    // after starting item. Cursor is unchanged from fallback if there's no
+    // such item.
+    for (; cursorPosition < itemsMatchingFirstChar.length; cursorPosition++) {
+        if (itemsMatchingFirstChar[cursorPosition].index > focusedItemIndex &&
+            !isItemAtIndexDisabled(itemsMatchingFirstChar[cursorPosition].index)) {
+            newCursorPosition = cursorPosition;
+            break;
+        }
+    }
+    if (newCursorPosition !== -1) {
+        state.sortedIndexCursor = newCursorPosition;
+        return itemsMatchingFirstChar[state.sortedIndexCursor].index;
+    }
+    return -1;
+}
+/**
+ * Attempts to find the next item that matches all of the typeahead buffer.
+ * Wraps around if at end of options. Returns -1 if no match is found.
+ */
+function matchAllChars(sortedIndexByFirstChar, isItemAtIndexDisabled, state) {
+    var firstChar = state.typeaheadBuffer[0];
+    var itemsMatchingFirstChar = sortedIndexByFirstChar.get(firstChar);
+    if (!itemsMatchingFirstChar) {
+        return -1;
+    }
+    // Do nothing if text already matches
+    var startingItem = itemsMatchingFirstChar[state.sortedIndexCursor];
+    if (startingItem.text.lastIndexOf(state.typeaheadBuffer, 0) === 0 &&
+        !isItemAtIndexDisabled(startingItem.index)) {
+        return startingItem.index;
+    }
+    // Find next item that matches completely; if no match, we'll eventually
+    // loop around to same position
+    var cursorPosition = (state.sortedIndexCursor + 1) % itemsMatchingFirstChar.length;
+    var nextCursorPosition = -1;
+    while (cursorPosition !== state.sortedIndexCursor) {
+        var currentItem = itemsMatchingFirstChar[cursorPosition];
+        var matches = currentItem.text.lastIndexOf(state.typeaheadBuffer, 0) === 0;
+        var isEnabled = !isItemAtIndexDisabled(currentItem.index);
+        if (matches && isEnabled) {
+            nextCursorPosition = cursorPosition;
+            break;
+        }
+        cursorPosition = (cursorPosition + 1) % itemsMatchingFirstChar.length;
+    }
+    if (nextCursorPosition !== -1) {
+        state.sortedIndexCursor = nextCursorPosition;
+        return itemsMatchingFirstChar[state.sortedIndexCursor].index;
+    }
+    return -1;
+}
+/**
+ * Whether or not the given typeahead instaance state is currently typing.
+ *
+ * @param state The typeahead state instance. See `initState`.
+ */
+function isTypingInProgress(state) {
+    return state.typeaheadBuffer.length > 0;
+}
+/**
+ * Clears the typeahaed buffer so that it resets item matching to the first
+ * character.
+ *
+ * @param state The typeahead state instance. See `initState`.
+ */
+function clearBuffer(state) {
+    state.typeaheadBuffer = '';
+}
+/**
+ * Given a keydown event, it calculates whether or not to automatically focus a
+ * list item depending on what was typed mimicing the typeahead functionality of
+ * a standard <select> element that is open.
+ *
+ * @param opts Options and accessors
+ *   - event - the KeyboardEvent to handle and parse
+ *   - sortedIndexByFirstChar - output of `initSortedIndex(...)`
+ *   - focusedItemIndex - the index of the currently focused item
+ *   - focusItemAtIndex - function that focuses a list item at given index
+ *   - isItemAtFocusedIndexDisabled - whether or not the currently focused item
+ *      is disabled
+ *   - isTargetListItem - whether or not the event target is a list item
+ * @param state The typeahead state instance. See `initState`.
+ *
+ * @returns index of the item matched by the keydown. -1 if not matched.
+ */
+function handleKeydown(opts, state) {
+    var event = opts.event, isTargetListItem = opts.isTargetListItem, focusedItemIndex = opts.focusedItemIndex, focusItemAtIndex = opts.focusItemAtIndex, sortedIndexByFirstChar = opts.sortedIndexByFirstChar, isItemAtIndexDisabled = opts.isItemAtIndexDisabled;
+    var isArrowLeft = normalizeKey(event) === 'ArrowLeft';
+    var isArrowUp = normalizeKey(event) === 'ArrowUp';
+    var isArrowRight = normalizeKey(event) === 'ArrowRight';
+    var isArrowDown = normalizeKey(event) === 'ArrowDown';
+    var isHome = normalizeKey(event) === 'Home';
+    var isEnd = normalizeKey(event) === 'End';
+    var isEnter = normalizeKey(event) === 'Enter';
+    var isSpace = normalizeKey(event) === 'Spacebar';
+    if (event.ctrlKey || event.metaKey || isArrowLeft || isArrowUp ||
+        isArrowRight || isArrowDown || isHome || isEnd || isEnter) {
+        return -1;
+    }
+    var isCharacterKey = !isSpace && event.key.length === 1;
+    if (isCharacterKey) {
+        preventDefaultEvent(event);
+        var matchItemOpts = {
+            focusItemAtIndex: focusItemAtIndex,
+            focusedItemIndex: focusedItemIndex,
+            nextChar: event.key.toLowerCase(),
+            sortedIndexByFirstChar: sortedIndexByFirstChar,
+            skipFocus: false,
+            isItemAtIndexDisabled: isItemAtIndexDisabled,
+        };
+        return matchItem(matchItemOpts, state);
+    }
+    if (!isSpace) {
+        return -1;
+    }
+    if (isTargetListItem) {
+        preventDefaultEvent(event);
+    }
+    var typeaheadOnListItem = isTargetListItem && isTypingInProgress(state);
+    if (typeaheadOnListItem) {
+        var matchItemOpts = {
+            focusItemAtIndex: focusItemAtIndex,
+            focusedItemIndex: focusedItemIndex,
+            nextChar: ' ',
+            sortedIndexByFirstChar: sortedIndexByFirstChar,
+            skipFocus: false,
+            isItemAtIndexDisabled: isItemAtIndexDisabled,
+        };
+        // space participates in typeahead matching if in rapid typing mode
+        return matchItem(matchItemOpts, state);
+    }
+    return -1;
+}
+
+/**
+@license
+Copyright 2018 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/** @soyCompatible */
+class FormElement extends BaseElement$1 {
+    createRenderRoot() {
+        return this.attachShadow({ mode: 'open', delegatesFocus: true });
+    }
+    click() {
+        if (this.formElement) {
+            this.formElement.focus();
+            this.formElement.click();
+        }
+    }
+    setAriaLabel(label) {
+        if (this.formElement) {
+            this.formElement.setAttribute('aria-label', label);
+        }
+    }
+    firstUpdated() {
+        super.firstUpdated();
+        if (this.shadowRoot) {
+            this.mdcRoot.addEventListener('change', (e) => {
+                this.dispatchEvent(new Event('change', e));
+            });
+        }
+    }
+}
+
+/*! *****************************************************************************
+Copyright (c) Microsoft Corporation.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+***************************************************************************** */
+/* global Reflect, Promise */
+
+var extendStatics$2 = function(d, b) {
+    extendStatics$2 = Object.setPrototypeOf ||
+        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+        function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+    return extendStatics$2(d, b);
+};
+
+function __extends$2(d, b) {
+    if (typeof b !== "function" && b !== null)
+        throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+    extendStatics$2(d, b);
+    function __() { this.constructor = d; }
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+}
+
+var __assign$2 = function() {
+    __assign$2 = Object.assign || function __assign(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign$2.apply(this, arguments);
+};
+
+/**
+ * @license
+ * Copyright 2016 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+var MDCFoundation$2 = /** @class */ (function () {
+    function MDCFoundation(adapter) {
+        if (adapter === void 0) { adapter = {}; }
+        this.adapter = adapter;
+    }
+    Object.defineProperty(MDCFoundation, "cssClasses", {
+        get: function () {
+            // Classes extending MDCFoundation should implement this method to return an object which exports every
+            // CSS class the foundation class needs as a property. e.g. {ACTIVE: 'mdc-component--active'}
+            return {};
+        },
+        enumerable: false,
+        configurable: true
+    });
+    Object.defineProperty(MDCFoundation, "strings", {
+        get: function () {
+            // Classes extending MDCFoundation should implement this method to return an object which exports all
+            // semantic strings as constants. e.g. {ARIA_ROLE: 'tablist'}
+            return {};
+        },
+        enumerable: false,
+        configurable: true
+    });
+    Object.defineProperty(MDCFoundation, "numbers", {
+        get: function () {
+            // Classes extending MDCFoundation should implement this method to return an object which exports all
+            // of its semantic numbers as constants. e.g. {ANIMATION_DELAY_MS: 350}
+            return {};
+        },
+        enumerable: false,
+        configurable: true
+    });
+    Object.defineProperty(MDCFoundation, "defaultAdapter", {
+        get: function () {
+            // Classes extending MDCFoundation may choose to implement this getter in order to provide a convenient
+            // way of viewing the necessary methods of an adapter. In the future, this could also be used for adapter
+            // validation.
+            return {};
+        },
+        enumerable: false,
+        configurable: true
+    });
+    MDCFoundation.prototype.init = function () {
+        // Subclasses should override this method to perform initialization routines (registering events, etc.)
+    };
+    MDCFoundation.prototype.destroy = function () {
+        // Subclasses should override this method to perform de-initialization routines (de-registering events, etc.)
+    };
+    return MDCFoundation;
+}());
+
+/**
+ * @license
+ * Copyright 2016 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+var cssClasses$5 = {
+    LABEL_FLOAT_ABOVE: 'mdc-floating-label--float-above',
+    LABEL_REQUIRED: 'mdc-floating-label--required',
+    LABEL_SHAKE: 'mdc-floating-label--shake',
+    ROOT: 'mdc-floating-label',
+};
+
+/**
+ * @license
+ * Copyright 2016 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+var MDCFloatingLabelFoundation = /** @class */ (function (_super) {
+    __extends$2(MDCFloatingLabelFoundation, _super);
+    function MDCFloatingLabelFoundation(adapter) {
+        var _this = _super.call(this, __assign$2(__assign$2({}, MDCFloatingLabelFoundation.defaultAdapter), adapter)) || this;
+        _this.shakeAnimationEndHandler_ = function () { return _this.handleShakeAnimationEnd_(); };
+        return _this;
+    }
+    Object.defineProperty(MDCFloatingLabelFoundation, "cssClasses", {
+        get: function () {
+            return cssClasses$5;
+        },
+        enumerable: false,
+        configurable: true
+    });
+    Object.defineProperty(MDCFloatingLabelFoundation, "defaultAdapter", {
+        /**
+         * See {@link MDCFloatingLabelAdapter} for typing information on parameters and return types.
+         */
+        get: function () {
+            // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
+            return {
+                addClass: function () { return undefined; },
+                removeClass: function () { return undefined; },
+                getWidth: function () { return 0; },
+                registerInteractionHandler: function () { return undefined; },
+                deregisterInteractionHandler: function () { return undefined; },
+            };
+            // tslint:enable:object-literal-sort-keys
+        },
+        enumerable: false,
+        configurable: true
+    });
+    MDCFloatingLabelFoundation.prototype.init = function () {
+        this.adapter.registerInteractionHandler('animationend', this.shakeAnimationEndHandler_);
+    };
+    MDCFloatingLabelFoundation.prototype.destroy = function () {
+        this.adapter.deregisterInteractionHandler('animationend', this.shakeAnimationEndHandler_);
+    };
+    /**
+     * Returns the width of the label element.
+     */
+    MDCFloatingLabelFoundation.prototype.getWidth = function () {
+        return this.adapter.getWidth();
+    };
+    /**
+     * Styles the label to produce a shake animation to indicate an error.
+     * @param shouldShake If true, adds the shake CSS class; otherwise, removes shake class.
+     */
+    MDCFloatingLabelFoundation.prototype.shake = function (shouldShake) {
+        var LABEL_SHAKE = MDCFloatingLabelFoundation.cssClasses.LABEL_SHAKE;
+        if (shouldShake) {
+            this.adapter.addClass(LABEL_SHAKE);
+        }
+        else {
+            this.adapter.removeClass(LABEL_SHAKE);
+        }
+    };
+    /**
+     * Styles the label to float or dock.
+     * @param shouldFloat If true, adds the float CSS class; otherwise, removes float and shake classes to dock the label.
+     */
+    MDCFloatingLabelFoundation.prototype.float = function (shouldFloat) {
+        var _a = MDCFloatingLabelFoundation.cssClasses, LABEL_FLOAT_ABOVE = _a.LABEL_FLOAT_ABOVE, LABEL_SHAKE = _a.LABEL_SHAKE;
+        if (shouldFloat) {
+            this.adapter.addClass(LABEL_FLOAT_ABOVE);
+        }
+        else {
+            this.adapter.removeClass(LABEL_FLOAT_ABOVE);
+            this.adapter.removeClass(LABEL_SHAKE);
+        }
+    };
+    /**
+     * Styles the label as required.
+     * @param isRequired If true, adds an asterisk to the label, indicating that it is required.
+     */
+    MDCFloatingLabelFoundation.prototype.setRequired = function (isRequired) {
+        var LABEL_REQUIRED = MDCFloatingLabelFoundation.cssClasses.LABEL_REQUIRED;
+        if (isRequired) {
+            this.adapter.addClass(LABEL_REQUIRED);
+        }
+        else {
+            this.adapter.removeClass(LABEL_REQUIRED);
+        }
+    };
+    MDCFloatingLabelFoundation.prototype.handleShakeAnimationEnd_ = function () {
+        var LABEL_SHAKE = MDCFloatingLabelFoundation.cssClasses.LABEL_SHAKE;
+        this.adapter.removeClass(LABEL_SHAKE);
+    };
+    return MDCFloatingLabelFoundation;
+}(MDCFoundation$2));
+
+const createAdapter = (labelElement) => {
+    return {
+        addClass: (className) => labelElement.classList.add(className),
+        removeClass: (className) => labelElement.classList.remove(className),
+        getWidth: () => labelElement.scrollWidth,
+        registerInteractionHandler: (evtType, handler) => {
+            labelElement.addEventListener(evtType, handler);
+        },
+        deregisterInteractionHandler: (evtType, handler) => {
+            labelElement.removeEventListener(evtType, handler);
+        },
+    };
+};
+const partToFoundationMap = new WeakMap();
+const floatingLabel = directive((label) => (part) => {
+    const lastFoundation = partToFoundationMap.get(part);
+    if (!lastFoundation) {
+        const labelElement = part.committer.element;
+        labelElement.classList.add('mdc-floating-label');
+        const adapter = createAdapter(labelElement);
+        const foundation = new MDCFloatingLabelFoundation(adapter);
+        foundation.init();
+        part.setValue(foundation);
+        partToFoundationMap.set(part, { label, foundation });
+    }
+});
+
+/*! *****************************************************************************
+Copyright (c) Microsoft Corporation.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+***************************************************************************** */
+/* global Reflect, Promise */
+
+var extendStatics$3 = function(d, b) {
+    extendStatics$3 = Object.setPrototypeOf ||
+        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+        function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+    return extendStatics$3(d, b);
+};
+
+function __extends$3(d, b) {
+    if (typeof b !== "function" && b !== null)
+        throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+    extendStatics$3(d, b);
+    function __() { this.constructor = d; }
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+}
+
+var __assign$3 = function() {
+    __assign$3 = Object.assign || function __assign(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign$3.apply(this, arguments);
+};
+
+/**
+ * @license
+ * Copyright 2016 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+var MDCFoundation$3 = /** @class */ (function () {
+    function MDCFoundation(adapter) {
+        if (adapter === void 0) { adapter = {}; }
+        this.adapter = adapter;
+    }
+    Object.defineProperty(MDCFoundation, "cssClasses", {
+        get: function () {
+            // Classes extending MDCFoundation should implement this method to return an object which exports every
+            // CSS class the foundation class needs as a property. e.g. {ACTIVE: 'mdc-component--active'}
+            return {};
+        },
+        enumerable: false,
+        configurable: true
+    });
+    Object.defineProperty(MDCFoundation, "strings", {
+        get: function () {
+            // Classes extending MDCFoundation should implement this method to return an object which exports all
+            // semantic strings as constants. e.g. {ARIA_ROLE: 'tablist'}
+            return {};
+        },
+        enumerable: false,
+        configurable: true
+    });
+    Object.defineProperty(MDCFoundation, "numbers", {
+        get: function () {
+            // Classes extending MDCFoundation should implement this method to return an object which exports all
+            // of its semantic numbers as constants. e.g. {ANIMATION_DELAY_MS: 350}
+            return {};
+        },
+        enumerable: false,
+        configurable: true
+    });
+    Object.defineProperty(MDCFoundation, "defaultAdapter", {
+        get: function () {
+            // Classes extending MDCFoundation may choose to implement this getter in order to provide a convenient
+            // way of viewing the necessary methods of an adapter. In the future, this could also be used for adapter
+            // validation.
+            return {};
+        },
+        enumerable: false,
+        configurable: true
+    });
+    MDCFoundation.prototype.init = function () {
+        // Subclasses should override this method to perform initialization routines (registering events, etc.)
+    };
+    MDCFoundation.prototype.destroy = function () {
+        // Subclasses should override this method to perform de-initialization routines (de-registering events, etc.)
+    };
+    return MDCFoundation;
+}());
+
+/**
+ * @license
+ * Copyright 2018 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+var cssClasses$6 = {
+    LINE_RIPPLE_ACTIVE: 'mdc-line-ripple--active',
+    LINE_RIPPLE_DEACTIVATING: 'mdc-line-ripple--deactivating',
+};
+
+/**
+ * @license
+ * Copyright 2018 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+var MDCLineRippleFoundation = /** @class */ (function (_super) {
+    __extends$3(MDCLineRippleFoundation, _super);
+    function MDCLineRippleFoundation(adapter) {
+        var _this = _super.call(this, __assign$3(__assign$3({}, MDCLineRippleFoundation.defaultAdapter), adapter)) || this;
+        _this.transitionEndHandler_ = function (evt) { return _this.handleTransitionEnd(evt); };
+        return _this;
+    }
+    Object.defineProperty(MDCLineRippleFoundation, "cssClasses", {
+        get: function () {
+            return cssClasses$6;
+        },
+        enumerable: false,
+        configurable: true
+    });
+    Object.defineProperty(MDCLineRippleFoundation, "defaultAdapter", {
+        /**
+         * See {@link MDCLineRippleAdapter} for typing information on parameters and return types.
+         */
+        get: function () {
+            // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
+            return {
+                addClass: function () { return undefined; },
+                removeClass: function () { return undefined; },
+                hasClass: function () { return false; },
+                setStyle: function () { return undefined; },
+                registerEventHandler: function () { return undefined; },
+                deregisterEventHandler: function () { return undefined; },
+            };
+            // tslint:enable:object-literal-sort-keys
+        },
+        enumerable: false,
+        configurable: true
+    });
+    MDCLineRippleFoundation.prototype.init = function () {
+        this.adapter.registerEventHandler('transitionend', this.transitionEndHandler_);
+    };
+    MDCLineRippleFoundation.prototype.destroy = function () {
+        this.adapter.deregisterEventHandler('transitionend', this.transitionEndHandler_);
+    };
+    MDCLineRippleFoundation.prototype.activate = function () {
+        this.adapter.removeClass(cssClasses$6.LINE_RIPPLE_DEACTIVATING);
+        this.adapter.addClass(cssClasses$6.LINE_RIPPLE_ACTIVE);
+    };
+    MDCLineRippleFoundation.prototype.setRippleCenter = function (xCoordinate) {
+        this.adapter.setStyle('transform-origin', xCoordinate + "px center");
+    };
+    MDCLineRippleFoundation.prototype.deactivate = function () {
+        this.adapter.addClass(cssClasses$6.LINE_RIPPLE_DEACTIVATING);
+    };
+    MDCLineRippleFoundation.prototype.handleTransitionEnd = function (evt) {
+        // Wait for the line ripple to be either transparent or opaque
+        // before emitting the animation end event
+        var isDeactivating = this.adapter.hasClass(cssClasses$6.LINE_RIPPLE_DEACTIVATING);
+        if (evt.propertyName === 'opacity') {
+            if (isDeactivating) {
+                this.adapter.removeClass(cssClasses$6.LINE_RIPPLE_ACTIVE);
+                this.adapter.removeClass(cssClasses$6.LINE_RIPPLE_DEACTIVATING);
+            }
+        }
+    };
+    return MDCLineRippleFoundation;
+}(MDCFoundation$3));
+
+const createAdapter$1 = (lineElement) => {
+    return {
+        addClass: (className) => lineElement.classList.add(className),
+        removeClass: (className) => lineElement.classList.remove(className),
+        hasClass: (className) => lineElement.classList.contains(className),
+        setStyle: (propertyName, value) => lineElement.style.setProperty(propertyName, value),
+        registerEventHandler: (evtType, handler) => {
+            lineElement.addEventListener(evtType, handler);
+        },
+        deregisterEventHandler: (evtType, handler) => {
+            lineElement.removeEventListener(evtType, handler);
+        },
+    };
+};
+const partToFoundationMap$1 = new WeakMap();
+const lineRipple = directive(() => (part) => {
+    const lastFoundation = partToFoundationMap$1.get(part);
+    if (!lastFoundation) {
+        const lineElement = part.committer.element;
+        lineElement.classList.add('mdc-line-ripple');
+        const adapter = createAdapter$1(lineElement);
+        const foundation = new MDCLineRippleFoundation(adapter);
+        foundation.init();
+        part.setValue(foundation);
+        partToFoundationMap$1.set(part, foundation);
+    }
+});
+
+/*! *****************************************************************************
+Copyright (c) Microsoft Corporation.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+***************************************************************************** */
+/* global Reflect, Promise */
+
+var extendStatics$4 = function(d, b) {
+    extendStatics$4 = Object.setPrototypeOf ||
+        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+        function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+    return extendStatics$4(d, b);
+};
+
+function __extends$4(d, b) {
+    if (typeof b !== "function" && b !== null)
+        throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+    extendStatics$4(d, b);
+    function __() { this.constructor = d; }
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+}
+
+var __assign$4 = function() {
+    __assign$4 = Object.assign || function __assign(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign$4.apply(this, arguments);
+};
+
+/**
+ * @license
+ * Copyright 2016 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+var MDCFoundation$4 = /** @class */ (function () {
+    function MDCFoundation(adapter) {
+        if (adapter === void 0) { adapter = {}; }
+        this.adapter = adapter;
+    }
+    Object.defineProperty(MDCFoundation, "cssClasses", {
+        get: function () {
+            // Classes extending MDCFoundation should implement this method to return an object which exports every
+            // CSS class the foundation class needs as a property. e.g. {ACTIVE: 'mdc-component--active'}
+            return {};
+        },
+        enumerable: false,
+        configurable: true
+    });
+    Object.defineProperty(MDCFoundation, "strings", {
+        get: function () {
+            // Classes extending MDCFoundation should implement this method to return an object which exports all
+            // semantic strings as constants. e.g. {ARIA_ROLE: 'tablist'}
+            return {};
+        },
+        enumerable: false,
+        configurable: true
+    });
+    Object.defineProperty(MDCFoundation, "numbers", {
+        get: function () {
+            // Classes extending MDCFoundation should implement this method to return an object which exports all
+            // of its semantic numbers as constants. e.g. {ANIMATION_DELAY_MS: 350}
+            return {};
+        },
+        enumerable: false,
+        configurable: true
+    });
+    Object.defineProperty(MDCFoundation, "defaultAdapter", {
+        get: function () {
+            // Classes extending MDCFoundation may choose to implement this getter in order to provide a convenient
+            // way of viewing the necessary methods of an adapter. In the future, this could also be used for adapter
+            // validation.
+            return {};
+        },
+        enumerable: false,
+        configurable: true
+    });
+    MDCFoundation.prototype.init = function () {
+        // Subclasses should override this method to perform initialization routines (registering events, etc.)
+    };
+    MDCFoundation.prototype.destroy = function () {
+        // Subclasses should override this method to perform de-initialization routines (de-registering events, etc.)
+    };
+    return MDCFoundation;
+}());
+
+/**
+ * @license
+ * Copyright 2020 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+/**
+ * KEY provides normalized string values for keys.
+ */
+var KEY$1 = {
+    UNKNOWN: 'Unknown',
+    BACKSPACE: 'Backspace',
+    ENTER: 'Enter',
+    SPACEBAR: 'Spacebar',
+    PAGE_UP: 'PageUp',
+    PAGE_DOWN: 'PageDown',
+    END: 'End',
+    HOME: 'Home',
+    ARROW_LEFT: 'ArrowLeft',
+    ARROW_UP: 'ArrowUp',
+    ARROW_RIGHT: 'ArrowRight',
+    ARROW_DOWN: 'ArrowDown',
+    DELETE: 'Delete',
+    ESCAPE: 'Escape',
+    TAB: 'Tab',
+};
+var normalizedKeys$1 = new Set();
+// IE11 has no support for new Map with iterable so we need to initialize this
+// by hand.
+normalizedKeys$1.add(KEY$1.BACKSPACE);
+normalizedKeys$1.add(KEY$1.ENTER);
+normalizedKeys$1.add(KEY$1.SPACEBAR);
+normalizedKeys$1.add(KEY$1.PAGE_UP);
+normalizedKeys$1.add(KEY$1.PAGE_DOWN);
+normalizedKeys$1.add(KEY$1.END);
+normalizedKeys$1.add(KEY$1.HOME);
+normalizedKeys$1.add(KEY$1.ARROW_LEFT);
+normalizedKeys$1.add(KEY$1.ARROW_UP);
+normalizedKeys$1.add(KEY$1.ARROW_RIGHT);
+normalizedKeys$1.add(KEY$1.ARROW_DOWN);
+normalizedKeys$1.add(KEY$1.DELETE);
+normalizedKeys$1.add(KEY$1.ESCAPE);
+normalizedKeys$1.add(KEY$1.TAB);
+var KEY_CODE$1 = {
+    BACKSPACE: 8,
+    ENTER: 13,
+    SPACEBAR: 32,
+    PAGE_UP: 33,
+    PAGE_DOWN: 34,
+    END: 35,
+    HOME: 36,
+    ARROW_LEFT: 37,
+    ARROW_UP: 38,
+    ARROW_RIGHT: 39,
+    ARROW_DOWN: 40,
+    DELETE: 46,
+    ESCAPE: 27,
+    TAB: 9,
+};
+var mappedKeyCodes$1 = new Map();
+// IE11 has no support for new Map with iterable so we need to initialize this
+// by hand.
+mappedKeyCodes$1.set(KEY_CODE$1.BACKSPACE, KEY$1.BACKSPACE);
+mappedKeyCodes$1.set(KEY_CODE$1.ENTER, KEY$1.ENTER);
+mappedKeyCodes$1.set(KEY_CODE$1.SPACEBAR, KEY$1.SPACEBAR);
+mappedKeyCodes$1.set(KEY_CODE$1.PAGE_UP, KEY$1.PAGE_UP);
+mappedKeyCodes$1.set(KEY_CODE$1.PAGE_DOWN, KEY$1.PAGE_DOWN);
+mappedKeyCodes$1.set(KEY_CODE$1.END, KEY$1.END);
+mappedKeyCodes$1.set(KEY_CODE$1.HOME, KEY$1.HOME);
+mappedKeyCodes$1.set(KEY_CODE$1.ARROW_LEFT, KEY$1.ARROW_LEFT);
+mappedKeyCodes$1.set(KEY_CODE$1.ARROW_UP, KEY$1.ARROW_UP);
+mappedKeyCodes$1.set(KEY_CODE$1.ARROW_RIGHT, KEY$1.ARROW_RIGHT);
+mappedKeyCodes$1.set(KEY_CODE$1.ARROW_DOWN, KEY$1.ARROW_DOWN);
+mappedKeyCodes$1.set(KEY_CODE$1.DELETE, KEY$1.DELETE);
+mappedKeyCodes$1.set(KEY_CODE$1.ESCAPE, KEY$1.ESCAPE);
+mappedKeyCodes$1.set(KEY_CODE$1.TAB, KEY$1.TAB);
+var navigationKeys$1 = new Set();
+// IE11 has no support for new Set with iterable so we need to initialize this
+// by hand.
+navigationKeys$1.add(KEY$1.PAGE_UP);
+navigationKeys$1.add(KEY$1.PAGE_DOWN);
+navigationKeys$1.add(KEY$1.END);
+navigationKeys$1.add(KEY$1.HOME);
+navigationKeys$1.add(KEY$1.ARROW_LEFT);
+navigationKeys$1.add(KEY$1.ARROW_UP);
+navigationKeys$1.add(KEY$1.ARROW_RIGHT);
+navigationKeys$1.add(KEY$1.ARROW_DOWN);
+/**
+ * normalizeKey returns the normalized string for a navigational action.
+ */
+function normalizeKey$1(evt) {
+    var key = evt.key;
+    // If the event already has a normalized key, return it
+    if (normalizedKeys$1.has(key)) {
+        return key;
+    }
+    // tslint:disable-next-line:deprecation
+    var mappedKey = mappedKeyCodes$1.get(evt.keyCode);
+    if (mappedKey) {
+        return mappedKey;
+    }
+    return KEY$1.UNKNOWN;
+}
+
+/**
+ * @license
+ * Copyright 2018 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+/**
+ * Enum for bits in the {@see Corner) bitmap.
+ */
+var CornerBit$1;
+(function (CornerBit) {
+    CornerBit[CornerBit["BOTTOM"] = 1] = "BOTTOM";
+    CornerBit[CornerBit["CENTER"] = 2] = "CENTER";
+    CornerBit[CornerBit["RIGHT"] = 4] = "RIGHT";
+    CornerBit[CornerBit["FLIP_RTL"] = 8] = "FLIP_RTL";
+})(CornerBit$1 || (CornerBit$1 = {}));
+/**
+ * Enum for representing an element corner for positioning the menu-surface.
+ *
+ * The START constants map to LEFT if element directionality is left
+ * to right and RIGHT if the directionality is right to left.
+ * Likewise END maps to RIGHT or LEFT depending on the directionality.
+ */
+var Corner$1;
+(function (Corner) {
+    Corner[Corner["TOP_LEFT"] = 0] = "TOP_LEFT";
+    Corner[Corner["TOP_RIGHT"] = 4] = "TOP_RIGHT";
+    Corner[Corner["BOTTOM_LEFT"] = 1] = "BOTTOM_LEFT";
+    Corner[Corner["BOTTOM_RIGHT"] = 5] = "BOTTOM_RIGHT";
+    Corner[Corner["TOP_START"] = 8] = "TOP_START";
+    Corner[Corner["TOP_END"] = 12] = "TOP_END";
+    Corner[Corner["BOTTOM_START"] = 9] = "BOTTOM_START";
+    Corner[Corner["BOTTOM_END"] = 13] = "BOTTOM_END";
+})(Corner$1 || (Corner$1 = {}));
+
+/**
+ * @license
+ * Copyright 2016 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+var cssClasses$7 = {
+    ACTIVATED: 'mdc-select--activated',
+    DISABLED: 'mdc-select--disabled',
+    FOCUSED: 'mdc-select--focused',
+    INVALID: 'mdc-select--invalid',
+    MENU_INVALID: 'mdc-select__menu--invalid',
+    OUTLINED: 'mdc-select--outlined',
+    REQUIRED: 'mdc-select--required',
+    ROOT: 'mdc-select',
+    WITH_LEADING_ICON: 'mdc-select--with-leading-icon',
+};
+var strings$5 = {
+    ARIA_CONTROLS: 'aria-controls',
+    ARIA_DESCRIBEDBY: 'aria-describedby',
+    ARIA_SELECTED_ATTR: 'aria-selected',
+    CHANGE_EVENT: 'MDCSelect:change',
+    HIDDEN_INPUT_SELECTOR: 'input[type="hidden"]',
+    LABEL_SELECTOR: '.mdc-floating-label',
+    LEADING_ICON_SELECTOR: '.mdc-select__icon',
+    LINE_RIPPLE_SELECTOR: '.mdc-line-ripple',
+    MENU_SELECTOR: '.mdc-select__menu',
+    OUTLINE_SELECTOR: '.mdc-notched-outline',
+    SELECTED_TEXT_SELECTOR: '.mdc-select__selected-text',
+    SELECT_ANCHOR_SELECTOR: '.mdc-select__anchor',
+    VALUE_ATTR: 'data-value',
+};
+var numbers$5 = {
+    LABEL_SCALE: 0.75,
+    UNSET_INDEX: -1,
+    CLICK_DEBOUNCE_TIMEOUT_MS: 330,
+};
+
+/**
+ * @license
+ * Copyright 2016 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+var MDCSelectFoundation = /** @class */ (function (_super) {
+    __extends$4(MDCSelectFoundation, _super);
+    /* istanbul ignore next: optional argument is not a branch statement */
+    /**
+     * @param adapter
+     * @param foundationMap Map from subcomponent names to their subfoundations.
+     */
+    function MDCSelectFoundation(adapter, foundationMap) {
+        if (foundationMap === void 0) { foundationMap = {}; }
+        var _this = _super.call(this, __assign$4(__assign$4({}, MDCSelectFoundation.defaultAdapter), adapter)) || this;
+        // Disabled state
+        _this.disabled = false;
+        // isMenuOpen is used to track the state of the menu by listening to the
+        // MDCMenuSurface:closed event For reference, menu.open will return false if
+        // the menu is still closing, but isMenuOpen returns false only after the menu
+        // has closed
+        _this.isMenuOpen = false;
+        // By default, select is invalid if it is required but no value is selected.
+        _this.useDefaultValidation = true;
+        _this.customValidity = true;
+        _this.lastSelectedIndex = numbers$5.UNSET_INDEX;
+        _this.clickDebounceTimeout = 0;
+        _this.recentlyClicked = false;
+        _this.leadingIcon = foundationMap.leadingIcon;
+        _this.helperText = foundationMap.helperText;
+        return _this;
+    }
+    Object.defineProperty(MDCSelectFoundation, "cssClasses", {
+        get: function () {
+            return cssClasses$7;
+        },
+        enumerable: false,
+        configurable: true
+    });
+    Object.defineProperty(MDCSelectFoundation, "numbers", {
+        get: function () {
+            return numbers$5;
+        },
+        enumerable: false,
+        configurable: true
+    });
+    Object.defineProperty(MDCSelectFoundation, "strings", {
+        get: function () {
+            return strings$5;
+        },
+        enumerable: false,
+        configurable: true
+    });
+    Object.defineProperty(MDCSelectFoundation, "defaultAdapter", {
+        /**
+         * See {@link MDCSelectAdapter} for typing information on parameters and return types.
+         */
+        get: function () {
+            // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
+            return {
+                addClass: function () { return undefined; },
+                removeClass: function () { return undefined; },
+                hasClass: function () { return false; },
+                activateBottomLine: function () { return undefined; },
+                deactivateBottomLine: function () { return undefined; },
+                getSelectedIndex: function () { return -1; },
+                setSelectedIndex: function () { return undefined; },
+                hasLabel: function () { return false; },
+                floatLabel: function () { return undefined; },
+                getLabelWidth: function () { return 0; },
+                setLabelRequired: function () { return undefined; },
+                hasOutline: function () { return false; },
+                notchOutline: function () { return undefined; },
+                closeOutline: function () { return undefined; },
+                setRippleCenter: function () { return undefined; },
+                notifyChange: function () { return undefined; },
+                setSelectedText: function () { return undefined; },
+                isSelectAnchorFocused: function () { return false; },
+                getSelectAnchorAttr: function () { return ''; },
+                setSelectAnchorAttr: function () { return undefined; },
+                removeSelectAnchorAttr: function () { return undefined; },
+                addMenuClass: function () { return undefined; },
+                removeMenuClass: function () { return undefined; },
+                openMenu: function () { return undefined; },
+                closeMenu: function () { return undefined; },
+                getAnchorElement: function () { return null; },
+                setMenuAnchorElement: function () { return undefined; },
+                setMenuAnchorCorner: function () { return undefined; },
+                setMenuWrapFocus: function () { return undefined; },
+                focusMenuItemAtIndex: function () { return undefined; },
+                getMenuItemCount: function () { return 0; },
+                getMenuItemValues: function () { return []; },
+                getMenuItemTextAtIndex: function () { return ''; },
+                isTypeaheadInProgress: function () { return false; },
+                typeaheadMatchItem: function () { return -1; },
+            };
+            // tslint:enable:object-literal-sort-keys
+        },
+        enumerable: false,
+        configurable: true
+    });
+    /** Returns the index of the currently selected menu item, or -1 if none. */
+    MDCSelectFoundation.prototype.getSelectedIndex = function () {
+        return this.adapter.getSelectedIndex();
+    };
+    MDCSelectFoundation.prototype.setSelectedIndex = function (index, closeMenu, skipNotify) {
+        if (closeMenu === void 0) { closeMenu = false; }
+        if (skipNotify === void 0) { skipNotify = false; }
+        if (index >= this.adapter.getMenuItemCount()) {
+            return;
+        }
+        if (index === numbers$5.UNSET_INDEX) {
+            this.adapter.setSelectedText('');
+        }
+        else {
+            this.adapter.setSelectedText(this.adapter.getMenuItemTextAtIndex(index).trim());
+        }
+        this.adapter.setSelectedIndex(index);
+        if (closeMenu) {
+            this.adapter.closeMenu();
+        }
+        if (!skipNotify && this.lastSelectedIndex !== index) {
+            this.handleChange();
+        }
+        this.lastSelectedIndex = index;
+    };
+    MDCSelectFoundation.prototype.setValue = function (value, skipNotify) {
+        if (skipNotify === void 0) { skipNotify = false; }
+        var index = this.adapter.getMenuItemValues().indexOf(value);
+        this.setSelectedIndex(index, /** closeMenu */ false, skipNotify);
+    };
+    MDCSelectFoundation.prototype.getValue = function () {
+        var index = this.adapter.getSelectedIndex();
+        var menuItemValues = this.adapter.getMenuItemValues();
+        return index !== numbers$5.UNSET_INDEX ? menuItemValues[index] : '';
+    };
+    MDCSelectFoundation.prototype.getDisabled = function () {
+        return this.disabled;
+    };
+    MDCSelectFoundation.prototype.setDisabled = function (isDisabled) {
+        this.disabled = isDisabled;
+        if (this.disabled) {
+            this.adapter.addClass(cssClasses$7.DISABLED);
+            this.adapter.closeMenu();
+        }
+        else {
+            this.adapter.removeClass(cssClasses$7.DISABLED);
+        }
+        if (this.leadingIcon) {
+            this.leadingIcon.setDisabled(this.disabled);
+        }
+        if (this.disabled) {
+            // Prevent click events from focusing select. Simply pointer-events: none
+            // is not enough since screenreader clicks may bypass this.
+            this.adapter.removeSelectAnchorAttr('tabindex');
+        }
+        else {
+            this.adapter.setSelectAnchorAttr('tabindex', '0');
+        }
+        this.adapter.setSelectAnchorAttr('aria-disabled', this.disabled.toString());
+    };
+    /** Opens the menu. */
+    MDCSelectFoundation.prototype.openMenu = function () {
+        this.adapter.addClass(cssClasses$7.ACTIVATED);
+        this.adapter.openMenu();
+        this.isMenuOpen = true;
+        this.adapter.setSelectAnchorAttr('aria-expanded', 'true');
+    };
+    /**
+     * @param content Sets the content of the helper text.
+     */
+    MDCSelectFoundation.prototype.setHelperTextContent = function (content) {
+        if (this.helperText) {
+            this.helperText.setContent(content);
+        }
+    };
+    /**
+     * Re-calculates if the notched outline should be notched and if the label
+     * should float.
+     */
+    MDCSelectFoundation.prototype.layout = function () {
+        if (this.adapter.hasLabel()) {
+            var optionHasValue = this.getValue().length > 0;
+            var isFocused = this.adapter.hasClass(cssClasses$7.FOCUSED);
+            var shouldFloatAndNotch = optionHasValue || isFocused;
+            var isRequired = this.adapter.hasClass(cssClasses$7.REQUIRED);
+            this.notchOutline(shouldFloatAndNotch);
+            this.adapter.floatLabel(shouldFloatAndNotch);
+            this.adapter.setLabelRequired(isRequired);
+        }
+    };
+    /**
+     * Synchronizes the list of options with the state of the foundation. Call
+     * this whenever menu options are dynamically updated.
+     */
+    MDCSelectFoundation.prototype.layoutOptions = function () {
+        var menuItemValues = this.adapter.getMenuItemValues();
+        var selectedIndex = menuItemValues.indexOf(this.getValue());
+        this.setSelectedIndex(selectedIndex, /** closeMenu */ false, /** skipNotify */ true);
+    };
+    MDCSelectFoundation.prototype.handleMenuOpened = function () {
+        if (this.adapter.getMenuItemValues().length === 0) {
+            return;
+        }
+        // Menu should open to the last selected element, should open to first menu item otherwise.
+        var selectedIndex = this.getSelectedIndex();
+        var focusItemIndex = selectedIndex >= 0 ? selectedIndex : 0;
+        this.adapter.focusMenuItemAtIndex(focusItemIndex);
+    };
+    MDCSelectFoundation.prototype.handleMenuClosing = function () {
+        this.adapter.setSelectAnchorAttr('aria-expanded', 'false');
+    };
+    MDCSelectFoundation.prototype.handleMenuClosed = function () {
+        this.adapter.removeClass(cssClasses$7.ACTIVATED);
+        this.isMenuOpen = false;
+        // Unfocus the select if menu is closed without a selection
+        if (!this.adapter.isSelectAnchorFocused()) {
+            this.blur();
+        }
+    };
+    /**
+     * Handles value changes, via change event or programmatic updates.
+     */
+    MDCSelectFoundation.prototype.handleChange = function () {
+        this.layout();
+        this.adapter.notifyChange(this.getValue());
+        var isRequired = this.adapter.hasClass(cssClasses$7.REQUIRED);
+        if (isRequired && this.useDefaultValidation) {
+            this.setValid(this.isValid());
+        }
+    };
+    MDCSelectFoundation.prototype.handleMenuItemAction = function (index) {
+        this.setSelectedIndex(index, /** closeMenu */ true);
+    };
+    /**
+     * Handles focus events from select element.
+     */
+    MDCSelectFoundation.prototype.handleFocus = function () {
+        this.adapter.addClass(cssClasses$7.FOCUSED);
+        this.layout();
+        this.adapter.activateBottomLine();
+    };
+    /**
+     * Handles blur events from select element.
+     */
+    MDCSelectFoundation.prototype.handleBlur = function () {
+        if (this.isMenuOpen) {
+            return;
+        }
+        this.blur();
+    };
+    MDCSelectFoundation.prototype.handleClick = function (normalizedX) {
+        if (this.disabled || this.recentlyClicked) {
+            return;
+        }
+        this.setClickDebounceTimeout();
+        if (this.isMenuOpen) {
+            this.adapter.closeMenu();
+            return;
+        }
+        this.adapter.setRippleCenter(normalizedX);
+        this.openMenu();
+    };
+    /**
+     * Handles keydown events on select element. Depending on the type of
+     * character typed, does typeahead matching or opens menu.
+     */
+    MDCSelectFoundation.prototype.handleKeydown = function (event) {
+        if (this.isMenuOpen || !this.adapter.hasClass(cssClasses$7.FOCUSED)) {
+            return;
+        }
+        var isEnter = normalizeKey$1(event) === KEY$1.ENTER;
+        var isSpace = normalizeKey$1(event) === KEY$1.SPACEBAR;
+        var arrowUp = normalizeKey$1(event) === KEY$1.ARROW_UP;
+        var arrowDown = normalizeKey$1(event) === KEY$1.ARROW_DOWN;
+        var isModifier = event.ctrlKey || event.metaKey;
+        // Typeahead
+        if (!isModifier &&
+            (!isSpace && event.key && event.key.length === 1 ||
+                isSpace && this.adapter.isTypeaheadInProgress())) {
+            var key = isSpace ? ' ' : event.key;
+            var typeaheadNextIndex = this.adapter.typeaheadMatchItem(key, this.getSelectedIndex());
+            if (typeaheadNextIndex >= 0) {
+                this.setSelectedIndex(typeaheadNextIndex);
+            }
+            event.preventDefault();
+            return;
+        }
+        if (!isEnter && !isSpace && !arrowUp && !arrowDown) {
+            return;
+        }
+        // Increment/decrement index as necessary and open menu.
+        if (arrowUp && this.getSelectedIndex() > 0) {
+            this.setSelectedIndex(this.getSelectedIndex() - 1);
+        }
+        else if (arrowDown &&
+            this.getSelectedIndex() < this.adapter.getMenuItemCount() - 1) {
+            this.setSelectedIndex(this.getSelectedIndex() + 1);
+        }
+        this.openMenu();
+        event.preventDefault();
+    };
+    /**
+     * Opens/closes the notched outline.
+     */
+    MDCSelectFoundation.prototype.notchOutline = function (openNotch) {
+        if (!this.adapter.hasOutline()) {
+            return;
+        }
+        var isFocused = this.adapter.hasClass(cssClasses$7.FOCUSED);
+        if (openNotch) {
+            var labelScale = numbers$5.LABEL_SCALE;
+            var labelWidth = this.adapter.getLabelWidth() * labelScale;
+            this.adapter.notchOutline(labelWidth);
+        }
+        else if (!isFocused) {
+            this.adapter.closeOutline();
+        }
+    };
+    /**
+     * Sets the aria label of the leading icon.
+     */
+    MDCSelectFoundation.prototype.setLeadingIconAriaLabel = function (label) {
+        if (this.leadingIcon) {
+            this.leadingIcon.setAriaLabel(label);
+        }
+    };
+    /**
+     * Sets the text content of the leading icon.
+     */
+    MDCSelectFoundation.prototype.setLeadingIconContent = function (content) {
+        if (this.leadingIcon) {
+            this.leadingIcon.setContent(content);
+        }
+    };
+    MDCSelectFoundation.prototype.setUseDefaultValidation = function (useDefaultValidation) {
+        this.useDefaultValidation = useDefaultValidation;
+    };
+    MDCSelectFoundation.prototype.setValid = function (isValid) {
+        if (!this.useDefaultValidation) {
+            this.customValidity = isValid;
+        }
+        this.adapter.setSelectAnchorAttr('aria-invalid', (!isValid).toString());
+        if (isValid) {
+            this.adapter.removeClass(cssClasses$7.INVALID);
+            this.adapter.removeMenuClass(cssClasses$7.MENU_INVALID);
+        }
+        else {
+            this.adapter.addClass(cssClasses$7.INVALID);
+            this.adapter.addMenuClass(cssClasses$7.MENU_INVALID);
+        }
+        this.syncHelperTextValidity(isValid);
+    };
+    MDCSelectFoundation.prototype.isValid = function () {
+        if (this.useDefaultValidation &&
+            this.adapter.hasClass(cssClasses$7.REQUIRED) &&
+            !this.adapter.hasClass(cssClasses$7.DISABLED)) {
+            // See notes for required attribute under https://www.w3.org/TR/html52/sec-forms.html#the-select-element
+            // TL;DR: Invalid if no index is selected, or if the first index is selected and has an empty value.
+            return this.getSelectedIndex() !== numbers$5.UNSET_INDEX &&
+                (this.getSelectedIndex() !== 0 || Boolean(this.getValue()));
+        }
+        return this.customValidity;
+    };
+    MDCSelectFoundation.prototype.setRequired = function (isRequired) {
+        if (isRequired) {
+            this.adapter.addClass(cssClasses$7.REQUIRED);
+        }
+        else {
+            this.adapter.removeClass(cssClasses$7.REQUIRED);
+        }
+        this.adapter.setSelectAnchorAttr('aria-required', isRequired.toString());
+        this.adapter.setLabelRequired(isRequired);
+    };
+    MDCSelectFoundation.prototype.getRequired = function () {
+        return this.adapter.getSelectAnchorAttr('aria-required') === 'true';
+    };
+    MDCSelectFoundation.prototype.init = function () {
+        var anchorEl = this.adapter.getAnchorElement();
+        if (anchorEl) {
+            this.adapter.setMenuAnchorElement(anchorEl);
+            this.adapter.setMenuAnchorCorner(Corner$1.BOTTOM_START);
+        }
+        this.adapter.setMenuWrapFocus(false);
+        this.setDisabled(this.adapter.hasClass(cssClasses$7.DISABLED));
+        this.syncHelperTextValidity(!this.adapter.hasClass(cssClasses$7.INVALID));
+        this.layout();
+        this.layoutOptions();
+    };
+    /**
+     * Unfocuses the select component.
+     */
+    MDCSelectFoundation.prototype.blur = function () {
+        this.adapter.removeClass(cssClasses$7.FOCUSED);
+        this.layout();
+        this.adapter.deactivateBottomLine();
+        var isRequired = this.adapter.hasClass(cssClasses$7.REQUIRED);
+        if (isRequired && this.useDefaultValidation) {
+            this.setValid(this.isValid());
+        }
+    };
+    MDCSelectFoundation.prototype.syncHelperTextValidity = function (isValid) {
+        if (!this.helperText) {
+            return;
+        }
+        this.helperText.setValidity(isValid);
+        var helperTextVisible = this.helperText.isVisible();
+        var helperTextId = this.helperText.getId();
+        if (helperTextVisible && helperTextId) {
+            this.adapter.setSelectAnchorAttr(strings$5.ARIA_DESCRIBEDBY, helperTextId);
+        }
+        else {
+            // Needed because screenreaders will read labels pointed to by
+            // `aria-describedby` even if they are `aria-hidden`.
+            this.adapter.removeSelectAnchorAttr(strings$5.ARIA_DESCRIBEDBY);
+        }
+    };
+    MDCSelectFoundation.prototype.setClickDebounceTimeout = function () {
+        var _this = this;
+        clearTimeout(this.clickDebounceTimeout);
+        this.clickDebounceTimeout = setTimeout(function () {
+            _this.recentlyClicked = false;
+        }, numbers$5.CLICK_DEBOUNCE_TIMEOUT_MS);
+        this.recentlyClicked = true;
+    };
+    return MDCSelectFoundation;
+}(MDCFoundation$4));
+
+const createValidityObj = (customValidity = {}) => {
+    /*
+     * We need to make ValidityState an object because it is readonly and
+     * we cannot use the spread operator. Also, we don't export
+     * `CustomValidityState` because it is a leaky implementation and the user
+     * already has access to `ValidityState` in lib.dom.ts. Also an interface
+     * {a: Type} can be casted to {readonly a: Type} so passing any object
+     * should be fine.
+     */
+    const objectifiedCustomValidity = {};
+    // eslint-disable-next-line guard-for-in
+    for (const propName in customValidity) {
+        /*
+         * Casting is needed because ValidityState's props are all readonly and
+         * thus cannot be set on `onjectifiedCustomValidity`. In the end, the
+         * interface is the same as ValidityState (but not readonly), but the
+         * function signature casts the output to ValidityState (thus readonly).
+         */
+        objectifiedCustomValidity[propName] =
+            customValidity[propName];
+    }
+    return Object.assign({ badInput: false, customError: false, patternMismatch: false, rangeOverflow: false, rangeUnderflow: false, stepMismatch: false, tooLong: false, tooShort: false, typeMismatch: false, valid: true, valueMissing: false }, objectifiedCustomValidity);
+};
+/**
+ * @fires selected {SelectedDetail}
+ * @fires action {ActionDetail}
+ * @fires opened
+ * @fires closed
+ * @fires change
+ * @fires invalid
+ */
+class SelectBase extends FormElement {
+    constructor() {
+        super(...arguments);
+        this.mdcFoundationClass = MDCSelectFoundation;
+        this.disabled = false;
+        this.outlined = false;
+        this.label = '';
+        this.outlineOpen = false;
+        this.outlineWidth = 0;
+        this.value = '';
+        this.selectedText = '';
+        this.icon = '';
+        this.menuOpen = false;
+        this.helper = '';
+        this.validateOnInitialRender = false;
+        this.validationMessage = '';
+        this.required = false;
+        this.naturalMenuWidth = false;
+        this.isUiValid = true;
+        this.fixedMenuPosition = false;
+        // Transiently holds current typeahead prefix from user.
+        this.typeaheadState = initState();
+        this.sortedIndexByFirstChar = new Map();
+        this.menuElement_ = null;
+        this.listeners = [];
+        this.onBodyClickBound = () => undefined;
+        this._menuUpdateComplete = null;
+        this.valueSetDirectly = false;
+        this.validityTransform = null;
+        this._validity = createValidityObj();
+    }
+    get items() {
+        // memoize menuElement to prevent unnecessary querySelector calls.
+        if (!this.menuElement_) {
+            this.menuElement_ = this.menuElement;
+        }
+        if (this.menuElement_) {
+            return this.menuElement_.items;
+        }
+        return [];
+    }
+    get selected() {
+        const menuElement = this.menuElement;
+        if (menuElement) {
+            return menuElement.selected;
+        }
+        return null;
+    }
+    get index() {
+        const menuElement = this.menuElement;
+        if (menuElement) {
+            return menuElement.index;
+        }
+        return -1;
+    }
+    get shouldRenderHelperText() {
+        return !!this.helper || !!this.validationMessage;
+    }
+    get validity() {
+        this._checkValidity(this.value);
+        return this._validity;
+    }
+    render() {
+        const classes = {
+            'mdc-select--disabled': this.disabled,
+            'mdc-select--no-label': !this.label,
+            'mdc-select--filled': !this.outlined,
+            'mdc-select--outlined': this.outlined,
+            'mdc-select--with-leading-icon': !!this.icon,
+            'mdc-select--required': this.required,
+            'mdc-select--invalid': !this.isUiValid,
+        };
+        const menuClasses = {
+            'mdc-select__menu--invalid': !this.isUiValid,
+        };
+        const describedby = this.shouldRenderHelperText ? 'helper-text' : undefined;
+        return html `
+      <div
+          class="mdc-select ${classMap(classes)}">
+        <input
+            class="formElement"
+            .value=${this.value}
+            hidden
+            ?required=${this.required}>
+        <!-- @ts-ignore -->
+        <div class="mdc-select__anchor"
+            aria-autocomplete="none"
+            role="combobox"
+            aria-expanded=${this.menuOpen}
+            aria-invalid=${!this.isUiValid}
+            aria-haspopup="listbox"
+            aria-labelledby="label"
+            aria-required=${this.required}
+            aria-describedby=${ifDefined(describedby)}
+            @click=${this.onClick}
+            @focus=${this.onFocus}
+            @blur=${this.onBlur}
+            @keydown=${this.onKeydown}>
+          ${this.renderRipple()}
+          ${this.outlined ? this.renderOutline() : this.renderLabel()}
+          ${this.renderLeadingIcon()}
+          <span class="mdc-select__selected-text-container">
+            <span class="mdc-select__selected-text">${this.selectedText}</span>
+          </span>
+          <span class="mdc-select__dropdown-icon">
+            <svg
+                class="mdc-select__dropdown-icon-graphic"
+                viewBox="7 10 10 5"
+                focusable="false">
+              <polygon
+                  class="mdc-select__dropdown-icon-inactive"
+                  stroke="none"
+                  fill-rule="evenodd"
+                  points="7 10 12 15 17 10">
+              </polygon>
+              <polygon
+                  class="mdc-select__dropdown-icon-active"
+                  stroke="none"
+                  fill-rule="evenodd"
+                  points="7 15 12 10 17 15">
+              </polygon>
+            </svg>
+          </span>
+          ${this.renderLineRipple()}
+        </div>
+        <mwc-menu
+            innerRole="listbox"
+            wrapFocus
+            class="mdc-select__menu mdc-menu mdc-menu-surface ${classMap(menuClasses)}"
+            activatable
+            .fullwidth=${this.fixedMenuPosition ? false : !this.naturalMenuWidth}
+            .open=${this.menuOpen}
+            .anchor=${this.anchorElement}
+            .fixed=${this.fixedMenuPosition}
+            @selected=${this.onSelected}
+            @opened=${this.onOpened}
+            @closed=${this.onClosed}
+            @items-updated=${this.onItemsUpdated}
+            @keydown=${this.handleTypeahead}>
+          <slot></slot>
+        </mwc-menu>
+      </div>
+      ${this.renderHelperText()}`;
+    }
+    renderRipple() {
+        if (this.outlined) {
+            return nothing;
+        }
+        return html `
+      <span class="mdc-select__ripple"></span>
+    `;
+    }
+    renderOutline() {
+        if (!this.outlined) {
+            return nothing;
+        }
+        return html `
+      <mwc-notched-outline
+          .width=${this.outlineWidth}
+          .open=${this.outlineOpen}
+          class="mdc-notched-outline">
+        ${this.renderLabel()}
+      </mwc-notched-outline>`;
+    }
+    renderLabel() {
+        if (!this.label) {
+            return nothing;
+        }
+        return html `
+      <span
+          .floatingLabelFoundation=${floatingLabel(this.label)}
+          id="label">${this.label}</span>
+    `;
+    }
+    renderLeadingIcon() {
+        if (!this.icon) {
+            return nothing;
+        }
+        return html `<mwc-icon class="mdc-select__icon"><div>${this.icon}</div></mwc-icon>`;
+    }
+    renderLineRipple() {
+        if (this.outlined) {
+            return nothing;
+        }
+        return html `
+      <span .lineRippleFoundation=${lineRipple()}></span>
+    `;
+    }
+    renderHelperText() {
+        if (!this.shouldRenderHelperText) {
+            return nothing;
+        }
+        const showValidationMessage = this.validationMessage && !this.isUiValid;
+        const classes = {
+            'mdc-select-helper-text--validation-msg': showValidationMessage,
+        };
+        return html `
+        <p
+          class="mdc-select-helper-text ${classMap(classes)}"
+          id="helper-text">${showValidationMessage ? this.validationMessage : this.helper}</p>`;
+    }
+    createAdapter() {
+        return Object.assign(Object.assign({}, addHasRemoveClass(this.mdcRoot)), { activateBottomLine: () => {
+                if (this.lineRippleElement) {
+                    this.lineRippleElement.lineRippleFoundation.activate();
+                }
+            }, deactivateBottomLine: () => {
+                if (this.lineRippleElement) {
+                    this.lineRippleElement.lineRippleFoundation.deactivate();
+                }
+            }, hasLabel: () => {
+                return !!this.label;
+            }, floatLabel: (shouldFloat) => {
+                if (this.labelElement) {
+                    this.labelElement.floatingLabelFoundation.float(shouldFloat);
+                }
+            }, getLabelWidth: () => {
+                if (this.labelElement) {
+                    return this.labelElement.floatingLabelFoundation.getWidth();
+                }
+                return 0;
+            }, setLabelRequired: (isRequired) => {
+                if (this.labelElement) {
+                    this.labelElement.floatingLabelFoundation.setRequired(isRequired);
+                }
+            }, hasOutline: () => this.outlined, notchOutline: (labelWidth) => {
+                const outlineElement = this.outlineElement;
+                if (outlineElement && !this.outlineOpen) {
+                    this.outlineWidth = labelWidth;
+                    this.outlineOpen = true;
+                }
+            }, closeOutline: () => {
+                if (this.outlineElement) {
+                    this.outlineOpen = false;
+                }
+            }, setRippleCenter: (normalizedX) => {
+                if (this.lineRippleElement) {
+                    const foundation = this.lineRippleElement.lineRippleFoundation;
+                    foundation.setRippleCenter(normalizedX);
+                }
+            }, notifyChange: async (value) => {
+                if (!this.valueSetDirectly && value === this.value) {
+                    return;
+                }
+                this.valueSetDirectly = false;
+                this.value = value;
+                await this.updateComplete;
+                const ev = new Event('change', { bubbles: true });
+                this.dispatchEvent(ev);
+            }, setSelectedText: (value) => this.selectedText = value, isSelectAnchorFocused: () => {
+                const selectAnchorElement = this.anchorElement;
+                if (!selectAnchorElement) {
+                    return false;
+                }
+                const rootNode = selectAnchorElement.getRootNode();
+                return rootNode.activeElement === selectAnchorElement;
+            }, getSelectAnchorAttr: (attr) => {
+                const selectAnchorElement = this.anchorElement;
+                if (!selectAnchorElement) {
+                    return null;
+                }
+                return selectAnchorElement.getAttribute(attr);
+            }, setSelectAnchorAttr: (attr, value) => {
+                const selectAnchorElement = this.anchorElement;
+                if (!selectAnchorElement) {
+                    return;
+                }
+                selectAnchorElement.setAttribute(attr, value);
+            }, removeSelectAnchorAttr: (attr) => {
+                const selectAnchorElement = this.anchorElement;
+                if (!selectAnchorElement) {
+                    return;
+                }
+                selectAnchorElement.removeAttribute(attr);
+            }, openMenu: () => {
+                this.menuOpen = true;
+            }, closeMenu: () => {
+                this.menuOpen = false;
+            }, addMenuClass: () => undefined, removeMenuClass: () => undefined, getAnchorElement: () => this.anchorElement, setMenuAnchorElement: () => {
+                /* Handled by anchor directive */
+            }, setMenuAnchorCorner: () => {
+                const menuElement = this.menuElement;
+                if (menuElement) {
+                    menuElement.corner = 'BOTTOM_START';
+                }
+            }, setMenuWrapFocus: (wrapFocus) => {
+                const menuElement = this.menuElement;
+                if (menuElement) {
+                    menuElement.wrapFocus = wrapFocus;
+                }
+            }, focusMenuItemAtIndex: (index) => {
+                const menuElement = this.menuElement;
+                if (!menuElement) {
+                    return;
+                }
+                const element = menuElement.items[index];
+                if (!element) {
+                    return;
+                }
+                element.focus();
+            }, getMenuItemCount: () => {
+                const menuElement = this.menuElement;
+                if (menuElement) {
+                    return menuElement.items.length;
+                }
+                return 0;
+            }, getMenuItemValues: () => {
+                const menuElement = this.menuElement;
+                if (!menuElement) {
+                    return [];
+                }
+                const items = menuElement.items;
+                return items.map((item) => item.value);
+            }, getMenuItemTextAtIndex: (index) => {
+                const menuElement = this.menuElement;
+                if (!menuElement) {
+                    return '';
+                }
+                const element = menuElement.items[index];
+                if (!element) {
+                    return '';
+                }
+                return element.text;
+            }, getSelectedIndex: () => this.index, setSelectedIndex: () => undefined, isTypeaheadInProgress: () => isTypingInProgress(this.typeaheadState), typeaheadMatchItem: (nextChar, startingIndex) => {
+                if (!this.menuElement) {
+                    return -1;
+                }
+                const opts = {
+                    focusItemAtIndex: (index) => {
+                        this.menuElement.focusItemAtIndex(index);
+                    },
+                    focusedItemIndex: startingIndex ?
+                        startingIndex :
+                        this.menuElement.getFocusedItemIndex(),
+                    nextChar,
+                    sortedIndexByFirstChar: this.sortedIndexByFirstChar,
+                    skipFocus: false,
+                    isItemAtIndexDisabled: (index) => this.items[index].disabled,
+                };
+                const index = matchItem(opts, this.typeaheadState);
+                if (index !== -1) {
+                    this.select(index);
+                }
+                return index;
+            } });
+    }
+    checkValidity() {
+        const isValid = this._checkValidity(this.value);
+        if (!isValid) {
+            const invalidEvent = new Event('invalid', { bubbles: false, cancelable: true });
+            this.dispatchEvent(invalidEvent);
+        }
+        return isValid;
+    }
+    reportValidity() {
+        const isValid = this.checkValidity();
+        this.isUiValid = isValid;
+        return isValid;
+    }
+    _checkValidity(value) {
+        const nativeValidity = this.formElement.validity;
+        let validity = createValidityObj(nativeValidity);
+        if (this.validityTransform) {
+            const customValidity = this.validityTransform(value, validity);
+            validity = Object.assign(Object.assign({}, validity), customValidity);
+        }
+        this._validity = validity;
+        return this._validity.valid;
+    }
+    setCustomValidity(message) {
+        this.validationMessage = message;
+        this.formElement.setCustomValidity(message);
+    }
+    // tslint:disable:ban-ts-ignore
+    async _getUpdateComplete() {
+        let result = false;
+        await this._menuUpdateComplete;
+        // @ts-ignore
+        if (super._getUpdateComplete) {
+            // @ts-ignore
+            await super._getUpdateComplete();
+        }
+        else {
+            // @ts-ignore
+            result = await super.getUpdateComplete();
+        }
+        return result;
+    }
+    // tslint:enable:ban-ts-ignore
+    getUpdateComplete() {
+        return this._getUpdateComplete();
+    }
+    async firstUpdated() {
+        const menuElement = this.menuElement;
+        if (menuElement) {
+            this._menuUpdateComplete = menuElement.updateComplete;
+            await this._menuUpdateComplete;
+        }
+        super.firstUpdated();
+        this.mdcFoundation.isValid = () => true;
+        this.mdcFoundation.setValid = () => undefined;
+        this.mdcFoundation.setDisabled(this.disabled);
+        if (this.validateOnInitialRender) {
+            this.reportValidity();
+        }
+        // Select an option based on init value
+        if (!this.selected) {
+            if (!this.items.length && this.slotElement &&
+                this.slotElement.assignedNodes({ flatten: true }).length) {
+                // Shady DOM initial render fix
+                await new Promise((res) => requestAnimationFrame(res));
+                await this.layout();
+            }
+            const hasEmptyFirstOption = this.items.length && this.items[0].value === '';
+            if (!this.value && hasEmptyFirstOption) {
+                this.select(0);
+                return;
+            }
+            this.selectByValue(this.value);
+        }
+        this.sortedIndexByFirstChar = initSortedIndex(this.items.length, (index) => this.items[index].text);
+    }
+    onItemsUpdated() {
+        this.sortedIndexByFirstChar = initSortedIndex(this.items.length, (index) => this.items[index].text);
+    }
+    select(index) {
+        const menuElement = this.menuElement;
+        if (menuElement) {
+            menuElement.select(index);
+        }
+    }
+    selectByValue(value) {
+        let indexToSelect = -1;
+        for (let i = 0; i < this.items.length; i++) {
+            const item = this.items[i];
+            if (item.value === value) {
+                indexToSelect = i;
+                break;
+            }
+        }
+        this.valueSetDirectly = true;
+        this.select(indexToSelect);
+        this.mdcFoundation.handleChange();
+    }
+    disconnectedCallback() {
+        super.disconnectedCallback();
+        for (const listener of this.listeners) {
+            listener.target.removeEventListener(listener.name, listener.cb);
+        }
+    }
+    focus() {
+        const focusEvt = new CustomEvent('focus');
+        const selectAnchorElement = this.anchorElement;
+        if (selectAnchorElement) {
+            selectAnchorElement.dispatchEvent(focusEvt);
+            selectAnchorElement.focus();
+        }
+    }
+    blur() {
+        const focusEvt = new CustomEvent('blur');
+        const selectAnchorElement = this.anchorElement;
+        if (selectAnchorElement) {
+            selectAnchorElement.dispatchEvent(focusEvt);
+            selectAnchorElement.blur();
+        }
+    }
+    onFocus() {
+        if (this.mdcFoundation) {
+            this.mdcFoundation.handleFocus();
+        }
+    }
+    onBlur() {
+        if (this.mdcFoundation) {
+            this.mdcFoundation.handleBlur();
+        }
+        const menuElement = this.menuElement;
+        if (menuElement && !menuElement.open) {
+            this.reportValidity();
+        }
+    }
+    onClick(evt) {
+        if (this.mdcFoundation) {
+            this.focus();
+            const targetClientRect = evt.target.getBoundingClientRect();
+            let xCoord = 0;
+            if ('touches' in evt) {
+                xCoord = evt.touches[0].clientX;
+            }
+            else {
+                xCoord = evt.clientX;
+            }
+            const normalizedX = xCoord - targetClientRect.left;
+            this.mdcFoundation.handleClick(normalizedX);
+        }
+    }
+    onKeydown(evt) {
+        const arrowUp = normalizeKey(evt) === KEY.ARROW_UP;
+        const arrowDown = normalizeKey(evt) === KEY.ARROW_DOWN;
+        if (arrowDown || arrowUp) {
+            const shouldSelectNextItem = arrowUp && this.index > 0;
+            const shouldSelectPrevItem = arrowDown && this.index < this.items.length - 1;
+            if (shouldSelectNextItem) {
+                this.select(this.index - 1);
+            }
+            else if (shouldSelectPrevItem) {
+                this.select(this.index + 1);
+            }
+            evt.preventDefault();
+            this.mdcFoundation.openMenu();
+            return;
+        }
+        this.mdcFoundation.handleKeydown(evt);
+    }
+    // must capture to run before list foundation captures event
+    handleTypeahead(event) {
+        if (!this.menuElement) {
+            return;
+        }
+        const focusedItemIndex = this.menuElement.getFocusedItemIndex();
+        const target = isNodeElement(event.target) ?
+            event.target :
+            null;
+        const isTargetListItem = target ? target.hasAttribute('mwc-list-item') : false;
+        const opts = {
+            event,
+            focusItemAtIndex: (index) => {
+                this.menuElement.focusItemAtIndex(index);
+            },
+            focusedItemIndex,
+            isTargetListItem,
+            sortedIndexByFirstChar: this.sortedIndexByFirstChar,
+            isItemAtIndexDisabled: (index) => this.items[index].disabled,
+        };
+        handleKeydown(opts, this.typeaheadState);
+    }
+    async onSelected(event) {
+        if (!this.mdcFoundation) {
+            await this.updateComplete;
+        }
+        this.mdcFoundation.handleMenuItemAction(event.detail.index);
+        const item = this.items[event.detail.index];
+        if (item) {
+            this.value = item.value;
+        }
+    }
+    onOpened() {
+        if (this.mdcFoundation) {
+            this.menuOpen = true;
+            this.mdcFoundation.handleMenuOpened();
+        }
+    }
+    onClosed() {
+        if (this.mdcFoundation) {
+            this.menuOpen = false;
+            this.mdcFoundation.handleMenuClosed();
+        }
+    }
+    async layout(updateItems = true) {
+        if (this.mdcFoundation) {
+            this.mdcFoundation.layout();
+        }
+        await this.updateComplete;
+        const menuElement = this.menuElement;
+        if (menuElement) {
+            menuElement.layout(updateItems);
+        }
+        const labelElement = this.labelElement;
+        if (!labelElement) {
+            this.outlineOpen = false;
+            return;
+        }
+        const shouldFloat = !!this.label && !!this.value;
+        labelElement.floatingLabelFoundation.float(shouldFloat);
+        if (!this.outlined) {
+            return;
+        }
+        this.outlineOpen = shouldFloat;
+        await this.updateComplete;
+        /* When the textfield automatically notches due to a value and label
+         * being defined, the textfield may be set to `display: none` by the user.
+         * this means that the notch is of size 0px. We provide this function so
+         * that the user may manually resize the notch to the floated label's
+         * width.
+         */
+        const labelWidth = labelElement.floatingLabelFoundation.getWidth();
+        if (this.outlineOpen) {
+            this.outlineWidth = labelWidth;
+        }
+    }
+    async layoutOptions() {
+        if (!this.mdcFoundation) {
+            return;
+        }
+        this.mdcFoundation.layoutOptions();
+    }
+}
+__decorate([
+    query('.mdc-select')
+], SelectBase.prototype, "mdcRoot", void 0);
+__decorate([
+    query('.formElement')
+], SelectBase.prototype, "formElement", void 0);
+__decorate([
+    query('slot')
+], SelectBase.prototype, "slotElement", void 0);
+__decorate([
+    query('select')
+], SelectBase.prototype, "nativeSelectElement", void 0);
+__decorate([
+    query('input')
+], SelectBase.prototype, "nativeInputElement", void 0);
+__decorate([
+    query('.mdc-line-ripple')
+], SelectBase.prototype, "lineRippleElement", void 0);
+__decorate([
+    query('.mdc-floating-label')
+], SelectBase.prototype, "labelElement", void 0);
+__decorate([
+    query('mwc-notched-outline')
+], SelectBase.prototype, "outlineElement", void 0);
+__decorate([
+    query('.mdc-menu')
+], SelectBase.prototype, "menuElement", void 0);
+__decorate([
+    query('.mdc-select__anchor')
+], SelectBase.prototype, "anchorElement", void 0);
+__decorate([
+    property({ type: Boolean, attribute: 'disabled', reflect: true }),
+    observer(function (value) {
+        if (this.mdcFoundation) {
+            this.mdcFoundation.setDisabled(value);
+        }
+    })
+], SelectBase.prototype, "disabled", void 0);
+__decorate([
+    property({ type: Boolean }),
+    observer(function (_newVal, oldVal) {
+        if (oldVal !== undefined && this.outlined !== oldVal) {
+            this.layout(false);
+        }
+    })
+], SelectBase.prototype, "outlined", void 0);
+__decorate([
+    property({ type: String }),
+    observer(function (_newVal, oldVal) {
+        if (oldVal !== undefined && this.label !== oldVal) {
+            this.layout(false);
+        }
+    })
+], SelectBase.prototype, "label", void 0);
+__decorate([
+    internalProperty()
+], SelectBase.prototype, "outlineOpen", void 0);
+__decorate([
+    internalProperty()
+], SelectBase.prototype, "outlineWidth", void 0);
+__decorate([
+    property({ type: String }),
+    observer(function (value) {
+        if (this.mdcFoundation) {
+            const initialization = this.selected === null && !!value;
+            const valueSetByUser = this.selected && this.selected.value !== value;
+            if (initialization || valueSetByUser) {
+                this.selectByValue(value);
+            }
+            this.reportValidity();
+        }
+    })
+], SelectBase.prototype, "value", void 0);
+__decorate([
+    internalProperty()
+], SelectBase.prototype, "selectedText", void 0);
+__decorate([
+    property({ type: String })
+], SelectBase.prototype, "icon", void 0);
+__decorate([
+    internalProperty()
+], SelectBase.prototype, "menuOpen", void 0);
+__decorate([
+    property({ type: String })
+], SelectBase.prototype, "helper", void 0);
+__decorate([
+    property({ type: Boolean })
+], SelectBase.prototype, "validateOnInitialRender", void 0);
+__decorate([
+    property({ type: String })
+], SelectBase.prototype, "validationMessage", void 0);
+__decorate([
+    property({ type: Boolean })
+], SelectBase.prototype, "required", void 0);
+__decorate([
+    property({ type: Boolean })
+], SelectBase.prototype, "naturalMenuWidth", void 0);
+__decorate([
+    internalProperty()
+], SelectBase.prototype, "isUiValid", void 0);
+__decorate([
+    property({ type: Boolean })
+], SelectBase.prototype, "fixedMenuPosition", void 0);
+__decorate([
+    eventOptions({ capture: true })
+], SelectBase.prototype, "handleTypeahead", null);
+
+/**
+@license
+Copyright 2018 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+const style$7 = css `.mdc-floating-label{-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased;font-family:Roboto, sans-serif;font-family:var(--mdc-typography-subtitle1-font-family, var(--mdc-typography-font-family, Roboto, sans-serif));font-size:1rem;font-size:var(--mdc-typography-subtitle1-font-size, 1rem);font-weight:400;font-weight:var(--mdc-typography-subtitle1-font-weight, 400);letter-spacing:0.009375em;letter-spacing:var(--mdc-typography-subtitle1-letter-spacing, 0.009375em);text-decoration:inherit;text-decoration:var(--mdc-typography-subtitle1-text-decoration, inherit);text-transform:inherit;text-transform:var(--mdc-typography-subtitle1-text-transform, inherit);position:absolute;left:0;-webkit-transform-origin:left top;transform-origin:left top;line-height:1.15rem;text-align:left;text-overflow:ellipsis;white-space:nowrap;cursor:text;overflow:hidden;will-change:transform;transition:transform 150ms cubic-bezier(0.4, 0, 0.2, 1),color 150ms cubic-bezier(0.4, 0, 0.2, 1)}[dir=rtl] .mdc-floating-label,.mdc-floating-label[dir=rtl]{right:0;left:auto;-webkit-transform-origin:right top;transform-origin:right top;text-align:right}.mdc-floating-label--float-above{cursor:auto}.mdc-floating-label--required::after{margin-left:1px;margin-right:0px;content:"*"}[dir=rtl] .mdc-floating-label--required::after,.mdc-floating-label--required[dir=rtl]::after{margin-left:0;margin-right:1px}.mdc-floating-label--float-above{transform:translateY(-106%) scale(0.75)}.mdc-floating-label--shake{animation:mdc-floating-label-shake-float-above-standard 250ms 1}@keyframes mdc-floating-label-shake-float-above-standard{0%{transform:translateX(calc(0 - 0%)) translateY(-106%) scale(0.75)}33%{animation-timing-function:cubic-bezier(0.5, 0, 0.701732, 0.495819);transform:translateX(calc(4% - 0%)) translateY(-106%) scale(0.75)}66%{animation-timing-function:cubic-bezier(0.302435, 0.381352, 0.55, 0.956352);transform:translateX(calc(-4% - 0%)) translateY(-106%) scale(0.75)}100%{transform:translateX(calc(0 - 0%)) translateY(-106%) scale(0.75)}}@keyframes mdc-ripple-fg-radius-in{from{animation-timing-function:cubic-bezier(0.4, 0, 0.2, 1);transform:translate(var(--mdc-ripple-fg-translate-start, 0)) scale(1)}to{transform:translate(var(--mdc-ripple-fg-translate-end, 0)) scale(var(--mdc-ripple-fg-scale, 1))}}@keyframes mdc-ripple-fg-opacity-in{from{animation-timing-function:linear;opacity:0}to{opacity:var(--mdc-ripple-fg-opacity, 0)}}@keyframes mdc-ripple-fg-opacity-out{from{animation-timing-function:linear;opacity:var(--mdc-ripple-fg-opacity, 0)}to{opacity:0}}.mdc-line-ripple::before,.mdc-line-ripple::after{position:absolute;bottom:0;left:0;width:100%;border-bottom-style:solid;content:""}.mdc-line-ripple::before{border-bottom-width:1px;z-index:1}.mdc-line-ripple::after{transform:scaleX(0);border-bottom-width:2px;opacity:0;z-index:2}.mdc-line-ripple::after{transition:transform 180ms cubic-bezier(0.4, 0, 0.2, 1),opacity 180ms cubic-bezier(0.4, 0, 0.2, 1)}.mdc-line-ripple--active::after{transform:scaleX(1);opacity:1}.mdc-line-ripple--deactivating::after{opacity:0}.mdc-notched-outline{display:flex;position:absolute;top:0;right:0;left:0;box-sizing:border-box;width:100%;max-width:100%;height:100%;text-align:left;pointer-events:none}[dir=rtl] .mdc-notched-outline,.mdc-notched-outline[dir=rtl]{text-align:right}.mdc-notched-outline__leading,.mdc-notched-outline__notch,.mdc-notched-outline__trailing{box-sizing:border-box;height:100%;border-top:1px solid;border-bottom:1px solid;pointer-events:none}.mdc-notched-outline__leading{border-left:1px solid;border-right:none;width:12px}[dir=rtl] .mdc-notched-outline__leading,.mdc-notched-outline__leading[dir=rtl]{border-left:none;border-right:1px solid}.mdc-notched-outline__trailing{border-left:none;border-right:1px solid;flex-grow:1}[dir=rtl] .mdc-notched-outline__trailing,.mdc-notched-outline__trailing[dir=rtl]{border-left:1px solid;border-right:none}.mdc-notched-outline__notch{flex:0 0 auto;width:auto;max-width:calc(100% - 12px * 2)}.mdc-notched-outline .mdc-floating-label{display:inline-block;position:relative;max-width:100%}.mdc-notched-outline .mdc-floating-label--float-above{text-overflow:clip}.mdc-notched-outline--upgraded .mdc-floating-label--float-above{max-width:calc(100% / 0.75)}.mdc-notched-outline--notched .mdc-notched-outline__notch{padding-left:0;padding-right:8px;border-top:none}[dir=rtl] .mdc-notched-outline--notched .mdc-notched-outline__notch,.mdc-notched-outline--notched .mdc-notched-outline__notch[dir=rtl]{padding-left:8px;padding-right:0}.mdc-notched-outline--no-label .mdc-notched-outline__notch{display:none}.mdc-select{display:inline-flex;position:relative}.mdc-select:not(.mdc-select--disabled) .mdc-select__selected-text{color:rgba(0, 0, 0, 0.87)}.mdc-select.mdc-select--disabled .mdc-select__selected-text{color:rgba(0, 0, 0, 0.38)}.mdc-select:not(.mdc-select--disabled) .mdc-floating-label{color:rgba(0, 0, 0, 0.6)}.mdc-select:not(.mdc-select--disabled).mdc-select--focused .mdc-floating-label{color:rgba(98, 0, 238, 0.87)}.mdc-select.mdc-select--disabled .mdc-floating-label{color:rgba(0, 0, 0, 0.38)}.mdc-select:not(.mdc-select--disabled) .mdc-select__dropdown-icon{fill:rgba(0, 0, 0, 0.54)}.mdc-select:not(.mdc-select--disabled).mdc-select--focused .mdc-select__dropdown-icon{fill:#6200ee;fill:var(--mdc-theme-primary, #6200ee)}.mdc-select.mdc-select--disabled .mdc-select__dropdown-icon{fill:rgba(0, 0, 0, 0.38)}.mdc-select:not(.mdc-select--disabled)+.mdc-select-helper-text{color:rgba(0, 0, 0, 0.6)}.mdc-select.mdc-select--disabled+.mdc-select-helper-text{color:rgba(0, 0, 0, 0.38)}.mdc-select:not(.mdc-select--disabled) .mdc-select__icon{color:rgba(0, 0, 0, 0.54)}.mdc-select.mdc-select--disabled .mdc-select__icon{color:rgba(0, 0, 0, 0.38)}@media screen and (-ms-high-contrast: active){.mdc-select.mdc-select--disabled .mdc-select__selected-text{color:GrayText}.mdc-select.mdc-select--disabled .mdc-select__dropdown-icon{fill:red}.mdc-select.mdc-select--disabled .mdc-floating-label{color:GrayText}.mdc-select.mdc-select--disabled .mdc-line-ripple::before{border-bottom-color:GrayText}.mdc-select.mdc-select--disabled .mdc-notched-outline__leading,.mdc-select.mdc-select--disabled .mdc-notched-outline__notch,.mdc-select.mdc-select--disabled .mdc-notched-outline__trailing{border-color:GrayText}.mdc-select.mdc-select--disabled .mdc-select__icon{color:GrayText}.mdc-select.mdc-select--disabled+.mdc-select-helper-text{color:GrayText}}.mdc-select .mdc-floating-label{top:50%;transform:translateY(-50%);pointer-events:none}.mdc-select .mdc-select__anchor{padding-left:16px;padding-right:0}[dir=rtl] .mdc-select .mdc-select__anchor,.mdc-select .mdc-select__anchor[dir=rtl]{padding-left:0;padding-right:16px}.mdc-select.mdc-select--with-leading-icon .mdc-select__anchor{padding-left:0;padding-right:0}[dir=rtl] .mdc-select.mdc-select--with-leading-icon .mdc-select__anchor,.mdc-select.mdc-select--with-leading-icon .mdc-select__anchor[dir=rtl]{padding-left:0;padding-right:0}.mdc-select .mdc-select__icon{width:24px;height:24px;font-size:24px}.mdc-select .mdc-select__dropdown-icon{width:24px;height:24px}.mdc-select .mdc-select__menu .mdc-deprecated-list-item{padding-left:16px;padding-right:16px}[dir=rtl] .mdc-select .mdc-select__menu .mdc-deprecated-list-item,.mdc-select .mdc-select__menu .mdc-deprecated-list-item[dir=rtl]{padding-left:16px;padding-right:16px}.mdc-select .mdc-select__menu .mdc-deprecated-list-item__graphic{margin-left:0;margin-right:12px}[dir=rtl] .mdc-select .mdc-select__menu .mdc-deprecated-list-item__graphic,.mdc-select .mdc-select__menu .mdc-deprecated-list-item__graphic[dir=rtl]{margin-left:12px;margin-right:0}.mdc-select__dropdown-icon{margin-left:12px;margin-right:12px;display:inline-flex;position:relative;align-self:center;align-items:center;justify-content:center;flex-shrink:0;pointer-events:none}.mdc-select__dropdown-icon .mdc-select__dropdown-icon-active,.mdc-select__dropdown-icon .mdc-select__dropdown-icon-inactive{position:absolute;top:0;left:0}.mdc-select__dropdown-icon .mdc-select__dropdown-icon-graphic{width:41.6666666667%;height:20.8333333333%}.mdc-select__dropdown-icon .mdc-select__dropdown-icon-inactive{opacity:1;transition:opacity 75ms linear 75ms}.mdc-select__dropdown-icon .mdc-select__dropdown-icon-active{opacity:0;transition:opacity 75ms linear}[dir=rtl] .mdc-select__dropdown-icon,.mdc-select__dropdown-icon[dir=rtl]{margin-left:12px;margin-right:12px}.mdc-select--activated .mdc-select__dropdown-icon .mdc-select__dropdown-icon-inactive{opacity:0;transition:opacity 49.5ms linear}.mdc-select--activated .mdc-select__dropdown-icon .mdc-select__dropdown-icon-active{opacity:1;transition:opacity 100.5ms linear 49.5ms}.mdc-select__anchor{width:200px;min-width:0;flex:1 1 auto;position:relative;box-sizing:border-box;overflow:hidden;outline:none;cursor:pointer}.mdc-select__anchor .mdc-floating-label--float-above{transform:translateY(-106%) scale(0.75)}.mdc-select__selected-text-container{display:flex;appearance:none;pointer-events:none;box-sizing:border-box;width:auto;min-width:0;flex-grow:1;height:28px;border:none;outline:none;padding:0;background-color:transparent;color:inherit}.mdc-select__selected-text{-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased;font-family:Roboto, sans-serif;font-family:var(--mdc-typography-subtitle1-font-family, var(--mdc-typography-font-family, Roboto, sans-serif));font-size:1rem;font-size:var(--mdc-typography-subtitle1-font-size, 1rem);line-height:1.75rem;line-height:var(--mdc-typography-subtitle1-line-height, 1.75rem);font-weight:400;font-weight:var(--mdc-typography-subtitle1-font-weight, 400);letter-spacing:0.009375em;letter-spacing:var(--mdc-typography-subtitle1-letter-spacing, 0.009375em);text-decoration:inherit;text-decoration:var(--mdc-typography-subtitle1-text-decoration, inherit);text-transform:inherit;text-transform:var(--mdc-typography-subtitle1-text-transform, inherit);text-overflow:ellipsis;white-space:nowrap;overflow:hidden;display:block;width:100%;text-align:left}[dir=rtl] .mdc-select__selected-text,.mdc-select__selected-text[dir=rtl]{text-align:right}.mdc-select--invalid:not(.mdc-select--disabled) .mdc-floating-label{color:#b00020;color:var(--mdc-theme-error, #b00020)}.mdc-select--invalid:not(.mdc-select--disabled).mdc-select--focused .mdc-floating-label{color:#b00020;color:var(--mdc-theme-error, #b00020)}.mdc-select--invalid:not(.mdc-select--disabled).mdc-select--invalid+.mdc-select-helper-text--validation-msg{color:#b00020;color:var(--mdc-theme-error, #b00020)}.mdc-select--invalid:not(.mdc-select--disabled) .mdc-select__dropdown-icon{fill:#b00020;fill:var(--mdc-theme-error, #b00020)}.mdc-select--invalid:not(.mdc-select--disabled).mdc-select--focused .mdc-select__dropdown-icon{fill:#b00020;fill:var(--mdc-theme-error, #b00020)}.mdc-select--disabled{cursor:default;pointer-events:none}.mdc-select--with-leading-icon .mdc-select__menu .mdc-deprecated-list-item{padding-left:12px;padding-right:12px}[dir=rtl] .mdc-select--with-leading-icon .mdc-select__menu .mdc-deprecated-list-item,.mdc-select--with-leading-icon .mdc-select__menu .mdc-deprecated-list-item[dir=rtl]{padding-left:12px;padding-right:12px}.mdc-select__menu .mdc-deprecated-list .mdc-select__icon{margin-left:0;margin-right:0}[dir=rtl] .mdc-select__menu .mdc-deprecated-list .mdc-select__icon,.mdc-select__menu .mdc-deprecated-list .mdc-select__icon[dir=rtl]{margin-left:0;margin-right:0}.mdc-select__menu .mdc-deprecated-list .mdc-deprecated-list-item--selected,.mdc-select__menu .mdc-deprecated-list .mdc-deprecated-list-item--activated{color:#000;color:var(--mdc-theme-on-surface, #000)}.mdc-select__menu .mdc-deprecated-list .mdc-deprecated-list-item--selected .mdc-deprecated-list-item__graphic,.mdc-select__menu .mdc-deprecated-list .mdc-deprecated-list-item--activated .mdc-deprecated-list-item__graphic{color:#000;color:var(--mdc-theme-on-surface, #000)}.mdc-select--filled .mdc-select__anchor{height:56px;display:flex;align-items:baseline}.mdc-select--filled .mdc-select__anchor::before{display:inline-block;width:0;height:40px;content:"";vertical-align:0}.mdc-select--filled.mdc-select--no-label .mdc-select__anchor .mdc-select__selected-text::before{content:"​"}.mdc-select--filled.mdc-select--no-label .mdc-select__anchor .mdc-select__selected-text-container{height:100%;display:inline-flex;align-items:center}.mdc-select--filled.mdc-select--no-label .mdc-select__anchor::before{display:none}.mdc-select--filled .mdc-select__anchor{border-top-left-radius:4px;border-top-left-radius:var(--mdc-shape-small, 4px);border-top-right-radius:4px;border-top-right-radius:var(--mdc-shape-small, 4px);border-bottom-right-radius:0;border-bottom-left-radius:0}.mdc-select--filled:not(.mdc-select--disabled) .mdc-select__anchor{background-color:whitesmoke}.mdc-select--filled.mdc-select--disabled .mdc-select__anchor{background-color:#fafafa}.mdc-select--filled:not(.mdc-select--disabled) .mdc-line-ripple::before{border-bottom-color:rgba(0, 0, 0, 0.42)}.mdc-select--filled:not(.mdc-select--disabled):hover .mdc-line-ripple::before{border-bottom-color:rgba(0, 0, 0, 0.87)}.mdc-select--filled:not(.mdc-select--disabled) .mdc-line-ripple::after{border-bottom-color:#6200ee;border-bottom-color:var(--mdc-theme-primary, #6200ee)}.mdc-select--filled.mdc-select--disabled .mdc-line-ripple::before{border-bottom-color:rgba(0, 0, 0, 0.06)}.mdc-select--filled .mdc-floating-label{max-width:calc(100% - 64px)}.mdc-select--filled .mdc-floating-label--float-above{max-width:calc(100% / 0.75 - 64px / 0.75)}.mdc-select--filled .mdc-menu-surface--is-open-below{border-top-left-radius:0px;border-top-right-radius:0px}.mdc-select--filled.mdc-select--focused.mdc-line-ripple::after{transform:scale(1, 2);opacity:1}.mdc-select--filled .mdc-floating-label{left:16px;right:initial}[dir=rtl] .mdc-select--filled .mdc-floating-label,.mdc-select--filled .mdc-floating-label[dir=rtl]{left:initial;right:16px}.mdc-select--filled.mdc-select--with-leading-icon .mdc-floating-label{left:48px;right:initial}[dir=rtl] .mdc-select--filled.mdc-select--with-leading-icon .mdc-floating-label,.mdc-select--filled.mdc-select--with-leading-icon .mdc-floating-label[dir=rtl]{left:initial;right:48px}.mdc-select--filled.mdc-select--with-leading-icon .mdc-floating-label{max-width:calc(100% - 96px)}.mdc-select--filled.mdc-select--with-leading-icon .mdc-floating-label--float-above{max-width:calc(100% / 0.75 - 96px / 0.75)}.mdc-select--invalid:not(.mdc-select--disabled) .mdc-line-ripple::before{border-bottom-color:#b00020;border-bottom-color:var(--mdc-theme-error, #b00020)}.mdc-select--invalid:not(.mdc-select--disabled):hover .mdc-line-ripple::before{border-bottom-color:#b00020;border-bottom-color:var(--mdc-theme-error, #b00020)}.mdc-select--invalid:not(.mdc-select--disabled) .mdc-line-ripple::after{border-bottom-color:#b00020;border-bottom-color:var(--mdc-theme-error, #b00020)}.mdc-select--outlined{border:none}.mdc-select--outlined .mdc-select__anchor{height:56px}.mdc-select--outlined .mdc-select__anchor .mdc-floating-label--float-above{transform:translateY(-37.25px) scale(1)}.mdc-select--outlined .mdc-select__anchor .mdc-floating-label--float-above{font-size:.75rem}.mdc-select--outlined .mdc-select__anchor.mdc-notched-outline--upgraded .mdc-floating-label--float-above,.mdc-select--outlined .mdc-select__anchor .mdc-notched-outline--upgraded .mdc-floating-label--float-above{transform:translateY(-34.75px) scale(0.75)}.mdc-select--outlined .mdc-select__anchor.mdc-notched-outline--upgraded .mdc-floating-label--float-above,.mdc-select--outlined .mdc-select__anchor .mdc-notched-outline--upgraded .mdc-floating-label--float-above{font-size:1rem}.mdc-select--outlined .mdc-select__anchor .mdc-floating-label--shake{animation:mdc-floating-label-shake-float-above-select-outlined-56px 250ms 1}@keyframes mdc-floating-label-shake-float-above-select-outlined-56px{0%{transform:translateX(calc(0 - 0%)) translateY(-34.75px) scale(0.75)}33%{animation-timing-function:cubic-bezier(0.5, 0, 0.701732, 0.495819);transform:translateX(calc(4% - 0%)) translateY(-34.75px) scale(0.75)}66%{animation-timing-function:cubic-bezier(0.302435, 0.381352, 0.55, 0.956352);transform:translateX(calc(-4% - 0%)) translateY(-34.75px) scale(0.75)}100%{transform:translateX(calc(0 - 0%)) translateY(-34.75px) scale(0.75)}}.mdc-select--outlined .mdc-notched-outline .mdc-notched-outline__leading{border-top-left-radius:4px;border-top-left-radius:var(--mdc-shape-small, 4px);border-top-right-radius:0;border-bottom-right-radius:0;border-bottom-left-radius:4px;border-bottom-left-radius:var(--mdc-shape-small, 4px)}[dir=rtl] .mdc-select--outlined .mdc-notched-outline .mdc-notched-outline__leading,.mdc-select--outlined .mdc-notched-outline .mdc-notched-outline__leading[dir=rtl]{border-top-left-radius:0;border-top-right-radius:4px;border-top-right-radius:var(--mdc-shape-small, 4px);border-bottom-right-radius:4px;border-bottom-right-radius:var(--mdc-shape-small, 4px);border-bottom-left-radius:0}@supports(top: max(0%)){.mdc-select--outlined .mdc-notched-outline .mdc-notched-outline__leading{width:max(12px, var(--mdc-shape-small, 4px))}}@supports(top: max(0%)){.mdc-select--outlined .mdc-notched-outline .mdc-notched-outline__notch{max-width:calc(100% - max(12px, var(--mdc-shape-small, 4px)) * 2)}}.mdc-select--outlined .mdc-notched-outline .mdc-notched-outline__trailing{border-top-left-radius:0;border-top-right-radius:4px;border-top-right-radius:var(--mdc-shape-small, 4px);border-bottom-right-radius:4px;border-bottom-right-radius:var(--mdc-shape-small, 4px);border-bottom-left-radius:0}[dir=rtl] .mdc-select--outlined .mdc-notched-outline .mdc-notched-outline__trailing,.mdc-select--outlined .mdc-notched-outline .mdc-notched-outline__trailing[dir=rtl]{border-top-left-radius:4px;border-top-left-radius:var(--mdc-shape-small, 4px);border-top-right-radius:0;border-bottom-right-radius:0;border-bottom-left-radius:4px;border-bottom-left-radius:var(--mdc-shape-small, 4px)}@supports(top: max(0%)){.mdc-select--outlined .mdc-select__anchor{padding-left:max(16px, calc(var(--mdc-shape-small, 4px) + 4px))}}[dir=rtl] .mdc-select--outlined .mdc-select__anchor,.mdc-select--outlined .mdc-select__anchor[dir=rtl]{padding-left:0}@supports(top: max(0%)){[dir=rtl] .mdc-select--outlined .mdc-select__anchor,.mdc-select--outlined .mdc-select__anchor[dir=rtl]{padding-right:max(16px, calc(var(--mdc-shape-small, 4px) + 4px))}}@supports(top: max(0%)){.mdc-select--outlined+.mdc-select-helper-text{margin-left:max(16px, calc(var(--mdc-shape-small, 4px) + 4px))}}[dir=rtl] .mdc-select--outlined+.mdc-select-helper-text,.mdc-select--outlined+.mdc-select-helper-text[dir=rtl]{margin-left:0}@supports(top: max(0%)){[dir=rtl] .mdc-select--outlined+.mdc-select-helper-text,.mdc-select--outlined+.mdc-select-helper-text[dir=rtl]{margin-right:max(16px, calc(var(--mdc-shape-small, 4px) + 4px))}}.mdc-select--outlined:not(.mdc-select--disabled) .mdc-select__anchor{background-color:transparent}.mdc-select--outlined.mdc-select--disabled .mdc-select__anchor{background-color:transparent}.mdc-select--outlined:not(.mdc-select--disabled) .mdc-notched-outline__leading,.mdc-select--outlined:not(.mdc-select--disabled) .mdc-notched-outline__notch,.mdc-select--outlined:not(.mdc-select--disabled) .mdc-notched-outline__trailing{border-color:rgba(0, 0, 0, 0.38)}.mdc-select--outlined:not(.mdc-select--disabled):not(.mdc-select--focused) .mdc-select__anchor:hover .mdc-notched-outline .mdc-notched-outline__leading,.mdc-select--outlined:not(.mdc-select--disabled):not(.mdc-select--focused) .mdc-select__anchor:hover .mdc-notched-outline .mdc-notched-outline__notch,.mdc-select--outlined:not(.mdc-select--disabled):not(.mdc-select--focused) .mdc-select__anchor:hover .mdc-notched-outline .mdc-notched-outline__trailing{border-color:rgba(0, 0, 0, 0.87)}.mdc-select--outlined:not(.mdc-select--disabled).mdc-select--focused .mdc-notched-outline .mdc-notched-outline__leading,.mdc-select--outlined:not(.mdc-select--disabled).mdc-select--focused .mdc-notched-outline .mdc-notched-outline__notch,.mdc-select--outlined:not(.mdc-select--disabled).mdc-select--focused .mdc-notched-outline .mdc-notched-outline__trailing{border-width:2px}.mdc-select--outlined:not(.mdc-select--disabled).mdc-select--focused .mdc-notched-outline .mdc-notched-outline__leading,.mdc-select--outlined:not(.mdc-select--disabled).mdc-select--focused .mdc-notched-outline .mdc-notched-outline__notch,.mdc-select--outlined:not(.mdc-select--disabled).mdc-select--focused .mdc-notched-outline .mdc-notched-outline__trailing{border-color:#6200ee;border-color:var(--mdc-theme-primary, #6200ee)}.mdc-select--outlined.mdc-select--disabled .mdc-notched-outline__leading,.mdc-select--outlined.mdc-select--disabled .mdc-notched-outline__notch,.mdc-select--outlined.mdc-select--disabled .mdc-notched-outline__trailing{border-color:rgba(0, 0, 0, 0.06)}.mdc-select--outlined .mdc-select__anchor :not(.mdc-notched-outline--notched) .mdc-notched-outline__notch{max-width:calc(100% - 60px)}.mdc-select--outlined .mdc-select__anchor{display:flex;align-items:baseline;overflow:visible}.mdc-select--outlined .mdc-select__anchor .mdc-floating-label--shake{animation:mdc-floating-label-shake-float-above-select-outlined 250ms 1}.mdc-select--outlined .mdc-select__anchor .mdc-floating-label--float-above{transform:translateY(-37.25px) scale(1)}.mdc-select--outlined .mdc-select__anchor .mdc-floating-label--float-above{font-size:.75rem}.mdc-select--outlined .mdc-select__anchor.mdc-notched-outline--upgraded .mdc-floating-label--float-above,.mdc-select--outlined .mdc-select__anchor .mdc-notched-outline--upgraded .mdc-floating-label--float-above{transform:translateY(-34.75px) scale(0.75)}.mdc-select--outlined .mdc-select__anchor.mdc-notched-outline--upgraded .mdc-floating-label--float-above,.mdc-select--outlined .mdc-select__anchor .mdc-notched-outline--upgraded .mdc-floating-label--float-above{font-size:1rem}.mdc-select--outlined .mdc-select__anchor .mdc-notched-outline--notched .mdc-notched-outline__notch{padding-top:1px}.mdc-select--outlined .mdc-select__anchor .mdc-select__selected-text::before{content:"​"}.mdc-select--outlined .mdc-select__anchor .mdc-select__selected-text-container{height:100%;display:inline-flex;align-items:center}.mdc-select--outlined .mdc-select__anchor::before{display:none}.mdc-select--outlined .mdc-select__selected-text-container{display:flex;border:none;z-index:1;background-color:transparent}.mdc-select--outlined .mdc-select__icon{z-index:2}.mdc-select--outlined .mdc-floating-label{line-height:1.15rem;left:4px;right:initial}[dir=rtl] .mdc-select--outlined .mdc-floating-label,.mdc-select--outlined .mdc-floating-label[dir=rtl]{left:initial;right:4px}.mdc-select--outlined.mdc-select--focused .mdc-notched-outline--notched .mdc-notched-outline__notch{padding-top:2px}.mdc-select--outlined.mdc-select--invalid:not(.mdc-select--disabled) .mdc-notched-outline__leading,.mdc-select--outlined.mdc-select--invalid:not(.mdc-select--disabled) .mdc-notched-outline__notch,.mdc-select--outlined.mdc-select--invalid:not(.mdc-select--disabled) .mdc-notched-outline__trailing{border-color:#b00020;border-color:var(--mdc-theme-error, #b00020)}.mdc-select--outlined.mdc-select--invalid:not(.mdc-select--disabled):not(.mdc-select--focused) .mdc-select__anchor:hover .mdc-notched-outline .mdc-notched-outline__leading,.mdc-select--outlined.mdc-select--invalid:not(.mdc-select--disabled):not(.mdc-select--focused) .mdc-select__anchor:hover .mdc-notched-outline .mdc-notched-outline__notch,.mdc-select--outlined.mdc-select--invalid:not(.mdc-select--disabled):not(.mdc-select--focused) .mdc-select__anchor:hover .mdc-notched-outline .mdc-notched-outline__trailing{border-color:#b00020;border-color:var(--mdc-theme-error, #b00020)}.mdc-select--outlined.mdc-select--invalid:not(.mdc-select--disabled).mdc-select--focused .mdc-notched-outline .mdc-notched-outline__leading,.mdc-select--outlined.mdc-select--invalid:not(.mdc-select--disabled).mdc-select--focused .mdc-notched-outline .mdc-notched-outline__notch,.mdc-select--outlined.mdc-select--invalid:not(.mdc-select--disabled).mdc-select--focused .mdc-notched-outline .mdc-notched-outline__trailing{border-width:2px}.mdc-select--outlined.mdc-select--invalid:not(.mdc-select--disabled).mdc-select--focused .mdc-notched-outline .mdc-notched-outline__leading,.mdc-select--outlined.mdc-select--invalid:not(.mdc-select--disabled).mdc-select--focused .mdc-notched-outline .mdc-notched-outline__notch,.mdc-select--outlined.mdc-select--invalid:not(.mdc-select--disabled).mdc-select--focused .mdc-notched-outline .mdc-notched-outline__trailing{border-color:#b00020;border-color:var(--mdc-theme-error, #b00020)}.mdc-select--outlined.mdc-select--with-leading-icon .mdc-floating-label{left:36px;right:initial}[dir=rtl] .mdc-select--outlined.mdc-select--with-leading-icon .mdc-floating-label,.mdc-select--outlined.mdc-select--with-leading-icon .mdc-floating-label[dir=rtl]{left:initial;right:36px}.mdc-select--outlined.mdc-select--with-leading-icon .mdc-floating-label--float-above{transform:translateY(-37.25px) translateX(-32px) scale(1)}[dir=rtl] .mdc-select--outlined.mdc-select--with-leading-icon .mdc-floating-label--float-above,.mdc-select--outlined.mdc-select--with-leading-icon .mdc-floating-label--float-above[dir=rtl]{transform:translateY(-37.25px) translateX(32px) scale(1)}.mdc-select--outlined.mdc-select--with-leading-icon .mdc-floating-label--float-above{font-size:.75rem}.mdc-select--outlined.mdc-select--with-leading-icon.mdc-notched-outline--upgraded .mdc-floating-label--float-above,.mdc-select--outlined.mdc-select--with-leading-icon .mdc-notched-outline--upgraded .mdc-floating-label--float-above{transform:translateY(-34.75px) translateX(-32px) scale(0.75)}[dir=rtl] .mdc-select--outlined.mdc-select--with-leading-icon.mdc-notched-outline--upgraded .mdc-floating-label--float-above,.mdc-select--outlined.mdc-select--with-leading-icon.mdc-notched-outline--upgraded .mdc-floating-label--float-above[dir=rtl],[dir=rtl] .mdc-select--outlined.mdc-select--with-leading-icon .mdc-notched-outline--upgraded .mdc-floating-label--float-above,.mdc-select--outlined.mdc-select--with-leading-icon .mdc-notched-outline--upgraded .mdc-floating-label--float-above[dir=rtl]{transform:translateY(-34.75px) translateX(32px) scale(0.75)}.mdc-select--outlined.mdc-select--with-leading-icon.mdc-notched-outline--upgraded .mdc-floating-label--float-above,.mdc-select--outlined.mdc-select--with-leading-icon .mdc-notched-outline--upgraded .mdc-floating-label--float-above{font-size:1rem}.mdc-select--outlined.mdc-select--with-leading-icon .mdc-floating-label--shake{animation:mdc-floating-label-shake-float-above-select-outlined-leading-icon-56px 250ms 1}@keyframes mdc-floating-label-shake-float-above-select-outlined-leading-icon-56px{0%{transform:translateX(calc(0 - 32px)) translateY(-34.75px) scale(0.75)}33%{animation-timing-function:cubic-bezier(0.5, 0, 0.701732, 0.495819);transform:translateX(calc(4% - 32px)) translateY(-34.75px) scale(0.75)}66%{animation-timing-function:cubic-bezier(0.302435, 0.381352, 0.55, 0.956352);transform:translateX(calc(-4% - 32px)) translateY(-34.75px) scale(0.75)}100%{transform:translateX(calc(0 - 32px)) translateY(-34.75px) scale(0.75)}}[dir=rtl] .mdc-select--outlined.mdc-select--with-leading-icon .mdc-floating-label--shake,.mdc-select--outlined.mdc-select--with-leading-icon[dir=rtl] .mdc-floating-label--shake{animation:mdc-floating-label-shake-float-above-select-outlined-leading-icon-56px 250ms 1}@keyframes mdc-floating-label-shake-float-above-select-outlined-leading-icon-56px-rtl{0%{transform:translateX(calc(0 - -32px)) translateY(-34.75px) scale(0.75)}33%{animation-timing-function:cubic-bezier(0.5, 0, 0.701732, 0.495819);transform:translateX(calc(4% - -32px)) translateY(-34.75px) scale(0.75)}66%{animation-timing-function:cubic-bezier(0.302435, 0.381352, 0.55, 0.956352);transform:translateX(calc(-4% - -32px)) translateY(-34.75px) scale(0.75)}100%{transform:translateX(calc(0 - -32px)) translateY(-34.75px) scale(0.75)}}.mdc-select--outlined.mdc-select--with-leading-icon .mdc-select__anchor :not(.mdc-notched-outline--notched) .mdc-notched-outline__notch{max-width:calc(100% - 96px)}.mdc-select--outlined .mdc-menu-surface{margin-bottom:8px}.mdc-select--outlined.mdc-select--no-label .mdc-menu-surface,.mdc-select--outlined .mdc-menu-surface--is-open-below{margin-bottom:0}.mdc-select__anchor{--mdc-ripple-fg-size: 0;--mdc-ripple-left: 0;--mdc-ripple-top: 0;--mdc-ripple-fg-scale: 1;--mdc-ripple-fg-translate-end: 0;--mdc-ripple-fg-translate-start: 0;-webkit-tap-highlight-color:rgba(0,0,0,0);will-change:transform,opacity}.mdc-select__anchor .mdc-select__ripple::before,.mdc-select__anchor .mdc-select__ripple::after{position:absolute;border-radius:50%;opacity:0;pointer-events:none;content:""}.mdc-select__anchor .mdc-select__ripple::before{transition:opacity 15ms linear,background-color 15ms linear;z-index:1;z-index:var(--mdc-ripple-z-index, 1)}.mdc-select__anchor .mdc-select__ripple::after{z-index:0;z-index:var(--mdc-ripple-z-index, 0)}.mdc-select__anchor.mdc-ripple-upgraded .mdc-select__ripple::before{transform:scale(var(--mdc-ripple-fg-scale, 1))}.mdc-select__anchor.mdc-ripple-upgraded .mdc-select__ripple::after{top:0;left:0;transform:scale(0);transform-origin:center center}.mdc-select__anchor.mdc-ripple-upgraded--unbounded .mdc-select__ripple::after{top:var(--mdc-ripple-top, 0);left:var(--mdc-ripple-left, 0)}.mdc-select__anchor.mdc-ripple-upgraded--foreground-activation .mdc-select__ripple::after{animation:mdc-ripple-fg-radius-in 225ms forwards,mdc-ripple-fg-opacity-in 75ms forwards}.mdc-select__anchor.mdc-ripple-upgraded--foreground-deactivation .mdc-select__ripple::after{animation:mdc-ripple-fg-opacity-out 150ms;transform:translate(var(--mdc-ripple-fg-translate-end, 0)) scale(var(--mdc-ripple-fg-scale, 1))}.mdc-select__anchor .mdc-select__ripple::before,.mdc-select__anchor .mdc-select__ripple::after{top:calc(50% - 100%);left:calc(50% - 100%);width:200%;height:200%}.mdc-select__anchor.mdc-ripple-upgraded .mdc-select__ripple::after{width:var(--mdc-ripple-fg-size, 100%);height:var(--mdc-ripple-fg-size, 100%)}.mdc-select__anchor .mdc-select__ripple::before,.mdc-select__anchor .mdc-select__ripple::after{background-color:rgba(0, 0, 0, 0.87);background-color:var(--mdc-ripple-color, rgba(0, 0, 0, 0.87))}.mdc-select__anchor:hover .mdc-select__ripple::before,.mdc-select__anchor.mdc-ripple-surface--hover .mdc-select__ripple::before{opacity:0.04;opacity:var(--mdc-ripple-hover-opacity, 0.04)}.mdc-select__anchor.mdc-ripple-upgraded--background-focused .mdc-select__ripple::before,.mdc-select__anchor:not(.mdc-ripple-upgraded):focus .mdc-select__ripple::before{transition-duration:75ms;opacity:0.12;opacity:var(--mdc-ripple-focus-opacity, 0.12)}.mdc-select__anchor .mdc-select__ripple{position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none}.mdc-select__menu .mdc-deprecated-list .mdc-deprecated-list-item--selected .mdc-deprecated-list-item__ripple::before,.mdc-select__menu .mdc-deprecated-list .mdc-deprecated-list-item--selected .mdc-deprecated-list-item__ripple::after{background-color:#000;background-color:var(--mdc-ripple-color, var(--mdc-theme-on-surface, #000))}.mdc-select__menu .mdc-deprecated-list .mdc-deprecated-list-item--selected:hover .mdc-deprecated-list-item__ripple::before,.mdc-select__menu .mdc-deprecated-list .mdc-deprecated-list-item--selected.mdc-ripple-surface--hover .mdc-deprecated-list-item__ripple::before{opacity:0.04;opacity:var(--mdc-ripple-hover-opacity, 0.04)}.mdc-select__menu .mdc-deprecated-list .mdc-deprecated-list-item--selected.mdc-ripple-upgraded--background-focused .mdc-deprecated-list-item__ripple::before,.mdc-select__menu .mdc-deprecated-list .mdc-deprecated-list-item--selected:not(.mdc-ripple-upgraded):focus .mdc-deprecated-list-item__ripple::before{transition-duration:75ms;opacity:0.12;opacity:var(--mdc-ripple-focus-opacity, 0.12)}.mdc-select__menu .mdc-deprecated-list .mdc-deprecated-list-item--selected:not(.mdc-ripple-upgraded) .mdc-deprecated-list-item__ripple::after{transition:opacity 150ms linear}.mdc-select__menu .mdc-deprecated-list .mdc-deprecated-list-item--selected:not(.mdc-ripple-upgraded):active .mdc-deprecated-list-item__ripple::after{transition-duration:75ms;opacity:0.12;opacity:var(--mdc-ripple-press-opacity, 0.12)}.mdc-select__menu .mdc-deprecated-list .mdc-deprecated-list-item--selected.mdc-ripple-upgraded{--mdc-ripple-fg-opacity: var(--mdc-ripple-press-opacity, 0.12)}.mdc-select__menu .mdc-deprecated-list .mdc-deprecated-list-item--selected .mdc-list-item__ripple::before,.mdc-select__menu .mdc-deprecated-list .mdc-deprecated-list-item--selected .mdc-list-item__ripple::after{background-color:#000;background-color:var(--mdc-ripple-color, var(--mdc-theme-on-surface, #000))}.mdc-select__menu .mdc-deprecated-list .mdc-deprecated-list-item--selected:hover .mdc-list-item__ripple::before,.mdc-select__menu .mdc-deprecated-list .mdc-deprecated-list-item--selected.mdc-ripple-surface--hover .mdc-list-item__ripple::before{opacity:0.04;opacity:var(--mdc-ripple-hover-opacity, 0.04)}.mdc-select__menu .mdc-deprecated-list .mdc-deprecated-list-item--selected.mdc-ripple-upgraded--background-focused .mdc-list-item__ripple::before,.mdc-select__menu .mdc-deprecated-list .mdc-deprecated-list-item--selected:not(.mdc-ripple-upgraded):focus .mdc-list-item__ripple::before{transition-duration:75ms;opacity:0.12;opacity:var(--mdc-ripple-focus-opacity, 0.12)}.mdc-select__menu .mdc-deprecated-list .mdc-deprecated-list-item--selected:not(.mdc-ripple-upgraded) .mdc-list-item__ripple::after{transition:opacity 150ms linear}.mdc-select__menu .mdc-deprecated-list .mdc-deprecated-list-item--selected:not(.mdc-ripple-upgraded):active .mdc-list-item__ripple::after{transition-duration:75ms;opacity:0.12;opacity:var(--mdc-ripple-press-opacity, 0.12)}.mdc-select__menu .mdc-deprecated-list .mdc-deprecated-list-item--selected.mdc-ripple-upgraded{--mdc-ripple-fg-opacity: var(--mdc-ripple-press-opacity, 0.12)}.mdc-select-helper-text{margin:0;margin-left:16px;margin-right:16px;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased;font-family:Roboto, sans-serif;font-family:var(--mdc-typography-caption-font-family, var(--mdc-typography-font-family, Roboto, sans-serif));font-size:0.75rem;font-size:var(--mdc-typography-caption-font-size, 0.75rem);line-height:1.25rem;line-height:var(--mdc-typography-caption-line-height, 1.25rem);font-weight:400;font-weight:var(--mdc-typography-caption-font-weight, 400);letter-spacing:0.0333333333em;letter-spacing:var(--mdc-typography-caption-letter-spacing, 0.0333333333em);text-decoration:inherit;text-decoration:var(--mdc-typography-caption-text-decoration, inherit);text-transform:inherit;text-transform:var(--mdc-typography-caption-text-transform, inherit);display:block;margin-top:0;line-height:normal}[dir=rtl] .mdc-select-helper-text,.mdc-select-helper-text[dir=rtl]{margin-left:16px;margin-right:16px}.mdc-select-helper-text::before{display:inline-block;width:0;height:16px;content:"";vertical-align:0}.mdc-select-helper-text--validation-msg{opacity:0;transition:opacity 180ms cubic-bezier(0.4, 0, 0.2, 1)}.mdc-select--invalid+.mdc-select-helper-text--validation-msg,.mdc-select-helper-text--validation-msg-persistent{opacity:1}.mdc-select--with-leading-icon .mdc-select__icon{display:inline-block;box-sizing:border-box;border:none;text-decoration:none;cursor:pointer;user-select:none;flex-shrink:0;align-self:center;background-color:transparent;fill:currentColor}.mdc-select--with-leading-icon .mdc-select__icon{margin-left:12px;margin-right:12px}[dir=rtl] .mdc-select--with-leading-icon .mdc-select__icon,.mdc-select--with-leading-icon .mdc-select__icon[dir=rtl]{margin-left:12px;margin-right:12px}.mdc-select__icon:not([tabindex]),.mdc-select__icon[tabindex="-1"]{cursor:default;pointer-events:none}.material-icons{font-family:var(--mdc-icon-font, "Material Icons");font-weight:normal;font-style:normal;font-size:var(--mdc-icon-size, 24px);line-height:1;letter-spacing:normal;text-transform:none;display:inline-block;white-space:nowrap;word-wrap:normal;direction:ltr;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;-moz-osx-font-smoothing:grayscale;font-feature-settings:"liga"}:host{display:inline-block;vertical-align:top;outline:none}.mdc-select{width:100%}[hidden]{display:none}.mdc-select__icon{z-index:2}.mdc-select--with-leading-icon{--mdc-list-item-graphic-margin: calc( 48px - var(--mdc-list-item-graphic-size, 24px) - var(--mdc-list-side-padding, 16px) )}.mdc-select .mdc-select__anchor .mdc-select__selected-text{overflow:hidden}.mdc-select .mdc-select__anchor *{display:inline-flex}.mdc-select .mdc-select__anchor .mdc-floating-label{display:inline-block}mwc-notched-outline{--mdc-notched-outline-border-color: var( --mdc-select-outlined-idle-border-color, rgba(0, 0, 0, 0.38) );--mdc-notched-outline-notch-offset: 1px}:host(:not([disabled]):hover) .mdc-select:not(.mdc-select--invalid):not(.mdc-select--focused) mwc-notched-outline{--mdc-notched-outline-border-color: var( --mdc-select-outlined-hover-border-color, rgba(0, 0, 0, 0.87) )}:host(:not([disabled])) .mdc-select:not(.mdc-select--disabled) .mdc-select__selected-text{color:rgba(0, 0, 0, 0.87);color:var(--mdc-select-ink-color, rgba(0, 0, 0, 0.87))}:host(:not([disabled])) .mdc-select:not(.mdc-select--disabled) .mdc-line-ripple::before{border-bottom-color:rgba(0, 0, 0, 0.42);border-bottom-color:var(--mdc-select-idle-line-color, rgba(0, 0, 0, 0.42))}:host(:not([disabled])) .mdc-select:not(.mdc-select--disabled):hover .mdc-line-ripple::before{border-bottom-color:rgba(0, 0, 0, 0.87);border-bottom-color:var(--mdc-select-hover-line-color, rgba(0, 0, 0, 0.87))}:host(:not([disabled])) .mdc-select:not(.mdc-select--outlined):not(.mdc-select--disabled) .mdc-select__anchor{background-color:whitesmoke;background-color:var(--mdc-select-fill-color, whitesmoke)}:host(:not([disabled])) .mdc-select.mdc-select--invalid .mdc-select__dropdown-icon{fill:var(--mdc-select-error-dropdown-icon-color, var(--mdc-select-error-color, var(--mdc-theme-error, #b00020)))}:host(:not([disabled])) .mdc-select.mdc-select--invalid .mdc-floating-label,:host(:not([disabled])) .mdc-select.mdc-select--invalid .mdc-floating-label::after{color:var(--mdc-select-error-color, var(--mdc-theme-error, #b00020))}:host(:not([disabled])) .mdc-select.mdc-select--invalid mwc-notched-outline{--mdc-notched-outline-border-color: var(--mdc-select-error-color, var(--mdc-theme-error, #b00020))}.mdc-select__menu--invalid{--mdc-theme-primary: var(--mdc-select-error-color, var(--mdc-theme-error, #b00020))}:host(:not([disabled])) .mdc-select:not(.mdc-select--invalid):not(.mdc-select--focused) .mdc-floating-label,:host(:not([disabled])) .mdc-select:not(.mdc-select--invalid):not(.mdc-select--focused) .mdc-floating-label::after{color:rgba(0, 0, 0, 0.6);color:var(--mdc-select-label-ink-color, rgba(0, 0, 0, 0.6))}:host(:not([disabled])) .mdc-select:not(.mdc-select--invalid):not(.mdc-select--focused) .mdc-select__dropdown-icon{fill:rgba(0, 0, 0, 0.54);fill:var(--mdc-select-dropdown-icon-color, rgba(0, 0, 0, 0.54))}:host(:not([disabled])) .mdc-select.mdc-select--focused mwc-notched-outline{--mdc-notched-outline-stroke-width: 2px;--mdc-notched-outline-notch-offset: 2px}:host(:not([disabled])) .mdc-select.mdc-select--focused:not(.mdc-select--invalid) mwc-notched-outline{--mdc-notched-outline-border-color: var( --mdc-select-focused-label-color, var(--mdc-theme-primary, rgba(98, 0, 238, 0.87)) )}:host(:not([disabled])) .mdc-select.mdc-select--focused:not(.mdc-select--invalid) .mdc-select__dropdown-icon{fill:rgba(98,0,238,.87);fill:var(--mdc-select-focused-dropdown-icon-color, var(--mdc-theme-primary, rgba(98, 0, 238, 0.87)))}:host(:not([disabled])) .mdc-select.mdc-select--focused:not(.mdc-select--invalid) .mdc-floating-label{color:#6200ee;color:var(--mdc-theme-primary, #6200ee)}:host(:not([disabled])) .mdc-select.mdc-select--focused:not(.mdc-select--invalid) .mdc-floating-label::after{color:#6200ee;color:var(--mdc-theme-primary, #6200ee)}:host(:not([disabled])) .mdc-select-helper-text:not(.mdc-select-helper-text--validation-msg){color:var(--mdc-select-label-ink-color, rgba(0, 0, 0, 0.6))}:host([disabled]){pointer-events:none}:host([disabled]) .mdc-select:not(.mdc-select--outlined).mdc-select--disabled .mdc-select__anchor{background-color:#fafafa;background-color:var(--mdc-select-disabled-fill-color, #fafafa)}:host([disabled]) .mdc-select.mdc-select--outlined mwc-notched-outline{--mdc-notched-outline-border-color: var( --mdc-select-outlined-disabled-border-color, rgba(0, 0, 0, 0.06) )}:host([disabled]) .mdc-select .mdc-select__dropdown-icon{fill:rgba(0, 0, 0, 0.38);fill:var(--mdc-select-disabled-dropdown-icon-color, rgba(0, 0, 0, 0.38))}:host([disabled]) .mdc-select:not(.mdc-select--invalid):not(.mdc-select--focused) .mdc-floating-label,:host([disabled]) .mdc-select:not(.mdc-select--invalid):not(.mdc-select--focused) .mdc-floating-label::after{color:rgba(0, 0, 0, 0.38);color:var(--mdc-select-disabled-ink-color, rgba(0, 0, 0, 0.38))}:host([disabled]) .mdc-select-helper-text{color:rgba(0, 0, 0, 0.38);color:var(--mdc-select-disabled-ink-color, rgba(0, 0, 0, 0.38))}:host([disabled]) .mdc-select__selected-text{color:rgba(0, 0, 0, 0.38);color:var(--mdc-select-disabled-ink-color, rgba(0, 0, 0, 0.38))}`;
+
+/**
+@license
+Copyright 2020 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+let Select = class Select extends SelectBase {
+};
+Select.styles = style$7;
+Select = __decorate([
+    customElement('mwc-select')
+], Select);
+
+export { Select };

--- a/build/web_modules/common/base-element-787f0cf8.js
+++ b/build/web_modules/common/base-element-787f0cf8.js
@@ -1,0 +1,136 @@
+import { L as LitElement } from './lit-element-58192bd6.js';
+
+/**
+ * @license
+ * Copyright 2018 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+function matches(element, selector) {
+    var nativeMatches = element.matches
+        || element.webkitMatchesSelector
+        || element.msMatchesSelector;
+    return nativeMatches.call(element, selector);
+}
+
+/**
+@license
+Copyright 2018 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/**
+ * Determines whether a node is an element.
+ *
+ * @param node Node to check
+ */
+const isNodeElement = (node) => {
+    return node.nodeType === Node.ELEMENT_NODE;
+};
+function findAssignedElement(slot, selector) {
+    for (const node of slot.assignedNodes({ flatten: true })) {
+        if (isNodeElement(node)) {
+            const el = node;
+            if (matches(el, selector)) {
+                return el;
+            }
+        }
+    }
+    return null;
+}
+function addHasRemoveClass(element) {
+    return {
+        addClass: (className) => {
+            element.classList.add(className);
+        },
+        removeClass: (className) => {
+            element.classList.remove(className);
+        },
+        hasClass: (className) => element.classList.contains(className),
+    };
+}
+let supportsPassive = false;
+const fn = () => { };
+const optionsBlock = {
+    get passive() {
+        supportsPassive = true;
+        return false;
+    }
+};
+document.addEventListener('x', fn, optionsBlock);
+document.removeEventListener('x', fn);
+/**
+ * Do event listeners suport the `passive` option?
+ */
+const supportsPassiveEventListener = supportsPassive;
+
+/**
+@license
+Copyright 2018 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/** @soyCompatible */
+class BaseElement extends LitElement {
+    click() {
+        if (this.mdcRoot) {
+            this.mdcRoot.focus();
+            this.mdcRoot.click();
+            return;
+        }
+        super.click();
+    }
+    /**
+     * Create and attach the MDC Foundation to the instance
+     */
+    createFoundation() {
+        if (this.mdcFoundation !== undefined) {
+            this.mdcFoundation.destroy();
+        }
+        if (this.mdcFoundationClass) {
+            this.mdcFoundation = new this.mdcFoundationClass(this.createAdapter());
+            this.mdcFoundation.init();
+        }
+    }
+    firstUpdated() {
+        this.createFoundation();
+    }
+}
+
+export { BaseElement as B, addHasRemoveClass as a, findAssignedElement as f, matches as m, supportsPassiveEventListener as s };

--- a/build/web_modules/common/class-map-b1acbdf1.js
+++ b/build/web_modules/common/class-map-b1acbdf1.js
@@ -1,0 +1,402 @@
+import { d as directive, A as AttributePart, P as PropertyPart } from './lit-element-58192bd6.js';
+
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+const legacyCustomElement = (tagName, clazz) => {
+    window.customElements.define(tagName, clazz);
+    // Cast as any because TS doesn't recognize the return type as being a
+    // subtype of the decorated class when clazz is typed as
+    // `Constructor<HTMLElement>` for some reason.
+    // `Constructor<HTMLElement>` is helpful to make sure the decorator is
+    // applied to elements however.
+    // tslint:disable-next-line:no-any
+    return clazz;
+};
+const standardCustomElement = (tagName, descriptor) => {
+    const { kind, elements } = descriptor;
+    return {
+        kind,
+        elements,
+        // This callback is called once the class is otherwise fully defined
+        finisher(clazz) {
+            window.customElements.define(tagName, clazz);
+        }
+    };
+};
+/**
+ * Class decorator factory that defines the decorated class as a custom element.
+ *
+ * ```
+ * @customElement('my-element')
+ * class MyElement {
+ *   render() {
+ *     return html``;
+ *   }
+ * }
+ * ```
+ * @category Decorator
+ * @param tagName The name of the custom element to define.
+ */
+const customElement = (tagName) => (classOrDescriptor) => (typeof classOrDescriptor === 'function') ?
+    legacyCustomElement(tagName, classOrDescriptor) :
+    standardCustomElement(tagName, classOrDescriptor);
+const standardProperty = (options, element) => {
+    // When decorating an accessor, pass it through and add property metadata.
+    // Note, the `hasOwnProperty` check in `createProperty` ensures we don't
+    // stomp over the user's accessor.
+    if (element.kind === 'method' && element.descriptor &&
+        !('value' in element.descriptor)) {
+        return Object.assign(Object.assign({}, element), { finisher(clazz) {
+                clazz.createProperty(element.key, options);
+            } });
+    }
+    else {
+        // createProperty() takes care of defining the property, but we still
+        // must return some kind of descriptor, so return a descriptor for an
+        // unused prototype field. The finisher calls createProperty().
+        return {
+            kind: 'field',
+            key: Symbol(),
+            placement: 'own',
+            descriptor: {},
+            // When @babel/plugin-proposal-decorators implements initializers,
+            // do this instead of the initializer below. See:
+            // https://github.com/babel/babel/issues/9260 extras: [
+            //   {
+            //     kind: 'initializer',
+            //     placement: 'own',
+            //     initializer: descriptor.initializer,
+            //   }
+            // ],
+            initializer() {
+                if (typeof element.initializer === 'function') {
+                    this[element.key] = element.initializer.call(this);
+                }
+            },
+            finisher(clazz) {
+                clazz.createProperty(element.key, options);
+            }
+        };
+    }
+};
+const legacyProperty = (options, proto, name) => {
+    proto.constructor
+        .createProperty(name, options);
+};
+/**
+ * A property decorator which creates a LitElement property which reflects a
+ * corresponding attribute value. A [[`PropertyDeclaration`]] may optionally be
+ * supplied to configure property features.
+ *
+ * This decorator should only be used for public fields. Private or protected
+ * fields should use the [[`internalProperty`]] decorator.
+ *
+ * @example
+ * ```ts
+ * class MyElement {
+ *   @property({ type: Boolean })
+ *   clicked = false;
+ * }
+ * ```
+ * @category Decorator
+ * @ExportDecoratedItems
+ */
+function property(options) {
+    // tslint:disable-next-line:no-any decorator
+    return (protoOrDescriptor, name) => (name !== undefined) ?
+        legacyProperty(options, protoOrDescriptor, name) :
+        standardProperty(options, protoOrDescriptor);
+}
+/**
+ * Declares a private or protected property that still triggers updates to the
+ * element when it changes.
+ *
+ * Properties declared this way must not be used from HTML or HTML templating
+ * systems, they're solely for properties internal to the element. These
+ * properties may be renamed by optimization tools like closure compiler.
+ * @category Decorator
+ */
+function internalProperty(options) {
+    return property({ attribute: false, hasChanged: options === null || options === void 0 ? void 0 : options.hasChanged });
+}
+/**
+ * A property decorator that converts a class property into a getter that
+ * executes a querySelector on the element's renderRoot.
+ *
+ * @param selector A DOMString containing one or more selectors to match.
+ * @param cache An optional boolean which when true performs the DOM query only
+ * once and caches the result.
+ *
+ * See: https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector
+ *
+ * @example
+ *
+ * ```ts
+ * class MyElement {
+ *   @query('#first')
+ *   first;
+ *
+ *   render() {
+ *     return html`
+ *       <div id="first"></div>
+ *       <div id="second"></div>
+ *     `;
+ *   }
+ * }
+ * ```
+ * @category Decorator
+ */
+function query(selector, cache) {
+    return (protoOrDescriptor, 
+    // tslint:disable-next-line:no-any decorator
+    name) => {
+        const descriptor = {
+            get() {
+                return this.renderRoot.querySelector(selector);
+            },
+            enumerable: true,
+            configurable: true,
+        };
+        if (cache) {
+            const key = typeof name === 'symbol' ? Symbol() : `__${name}`;
+            descriptor.get = function () {
+                if (this[key] === undefined) {
+                    (this[key] =
+                        this.renderRoot.querySelector(selector));
+                }
+                return this[key];
+            };
+        }
+        return (name !== undefined) ?
+            legacyQuery(descriptor, protoOrDescriptor, name) :
+            standardQuery(descriptor, protoOrDescriptor);
+    };
+}
+// Note, in the future, we may extend this decorator to support the use case
+// where the queried element may need to do work to become ready to interact
+// with (e.g. load some implementation code). If so, we might elect to
+// add a second argument defining a function that can be run to make the
+// queried element loaded/updated/ready.
+/**
+ * A property decorator that converts a class property into a getter that
+ * returns a promise that resolves to the result of a querySelector on the
+ * element's renderRoot done after the element's `updateComplete` promise
+ * resolves. When the queried property may change with element state, this
+ * decorator can be used instead of requiring users to await the
+ * `updateComplete` before accessing the property.
+ *
+ * @param selector A DOMString containing one or more selectors to match.
+ *
+ * See: https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector
+ *
+ * @example
+ * ```ts
+ * class MyElement {
+ *   @queryAsync('#first')
+ *   first;
+ *
+ *   render() {
+ *     return html`
+ *       <div id="first"></div>
+ *       <div id="second"></div>
+ *     `;
+ *   }
+ * }
+ *
+ * // external usage
+ * async doSomethingWithFirst() {
+ *  (await aMyElement.first).doSomething();
+ * }
+ * ```
+ * @category Decorator
+ */
+function queryAsync(selector) {
+    return (protoOrDescriptor, 
+    // tslint:disable-next-line:no-any decorator
+    name) => {
+        const descriptor = {
+            async get() {
+                await this.updateComplete;
+                return this.renderRoot.querySelector(selector);
+            },
+            enumerable: true,
+            configurable: true,
+        };
+        return (name !== undefined) ?
+            legacyQuery(descriptor, protoOrDescriptor, name) :
+            standardQuery(descriptor, protoOrDescriptor);
+    };
+}
+const legacyQuery = (descriptor, proto, name) => {
+    Object.defineProperty(proto, name, descriptor);
+};
+const standardQuery = (descriptor, element) => ({
+    kind: 'method',
+    placement: 'prototype',
+    key: element.key,
+    descriptor,
+});
+const standardEventOptions = (options, element) => {
+    return Object.assign(Object.assign({}, element), { finisher(clazz) {
+            Object.assign(clazz.prototype[element.key], options);
+        } });
+};
+const legacyEventOptions = 
+// tslint:disable-next-line:no-any legacy decorator
+(options, proto, name) => {
+    Object.assign(proto[name], options);
+};
+/**
+ * Adds event listener options to a method used as an event listener in a
+ * lit-html template.
+ *
+ * @param options An object that specifies event listener options as accepted by
+ * `EventTarget#addEventListener` and `EventTarget#removeEventListener`.
+ *
+ * Current browsers support the `capture`, `passive`, and `once` options. See:
+ * https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Parameters
+ *
+ * @example
+ * ```ts
+ * class MyElement {
+ *   clicked = false;
+ *
+ *   render() {
+ *     return html`
+ *       <div @click=${this._onClick}`>
+ *         <button></button>
+ *       </div>
+ *     `;
+ *   }
+ *
+ *   @eventOptions({capture: true})
+ *   _onClick(e) {
+ *     this.clicked = true;
+ *   }
+ * }
+ * ```
+ * @category Decorator
+ */
+function eventOptions(options) {
+    // Return value typed as any to prevent TypeScript from complaining that
+    // standard decorator function signature does not match TypeScript decorator
+    // signature
+    // TODO(kschaaf): unclear why it was only failing on this decorator and not
+    // the others
+    return ((protoOrDescriptor, name) => (name !== undefined) ?
+        legacyEventOptions(options, protoOrDescriptor, name) :
+        standardEventOptions(options, protoOrDescriptor));
+}
+
+/**
+ * @license
+ * Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+// IE11 doesn't support classList on SVG elements, so we emulate it with a Set
+class ClassList {
+    constructor(element) {
+        this.classes = new Set();
+        this.changed = false;
+        this.element = element;
+        const classList = (element.getAttribute('class') || '').split(/\s+/);
+        for (const cls of classList) {
+            this.classes.add(cls);
+        }
+    }
+    add(cls) {
+        this.classes.add(cls);
+        this.changed = true;
+    }
+    remove(cls) {
+        this.classes.delete(cls);
+        this.changed = true;
+    }
+    commit() {
+        if (this.changed) {
+            let classString = '';
+            this.classes.forEach((cls) => classString += cls + ' ');
+            this.element.setAttribute('class', classString);
+        }
+    }
+}
+/**
+ * Stores the ClassInfo object applied to a given AttributePart.
+ * Used to unset existing values when a new ClassInfo object is applied.
+ */
+const previousClassesCache = new WeakMap();
+/**
+ * A directive that applies CSS classes. This must be used in the `class`
+ * attribute and must be the only part used in the attribute. It takes each
+ * property in the `classInfo` argument and adds the property name to the
+ * element's `class` if the property value is truthy; if the property value is
+ * falsey, the property name is removed from the element's `class`. For example
+ * `{foo: bar}` applies the class `foo` if the value of `bar` is truthy.
+ * @param classInfo {ClassInfo}
+ */
+const classMap = directive((classInfo) => (part) => {
+    if (!(part instanceof AttributePart) || (part instanceof PropertyPart) ||
+        part.committer.name !== 'class' || part.committer.parts.length > 1) {
+        throw new Error('The `classMap` directive must be used in the `class` attribute ' +
+            'and must be the only part in the attribute.');
+    }
+    const { committer } = part;
+    const { element } = committer;
+    let previousClasses = previousClassesCache.get(part);
+    if (previousClasses === undefined) {
+        // Write static classes once
+        // Use setAttribute() because className isn't a string on SVG elements
+        element.setAttribute('class', committer.strings.join(' '));
+        previousClassesCache.set(part, previousClasses = new Set());
+    }
+    const classList = (element.classList || new ClassList(element));
+    // Remove old classes that no longer apply
+    // We use forEach() instead of for-of so that re don't require down-level
+    // iteration.
+    previousClasses.forEach((name) => {
+        if (!(name in classInfo)) {
+            classList.remove(name);
+            previousClasses.delete(name);
+        }
+    });
+    // Add or remove classes based on their classMap value
+    for (const name in classInfo) {
+        const value = classInfo[name];
+        if (value != previousClasses.has(name)) {
+            // We explicitly want a loose truthy check of `value` because it seems
+            // more convenient that '' and 0 are skipped.
+            if (value) {
+                classList.add(name);
+                previousClasses.add(name);
+            }
+            else {
+                classList.remove(name);
+                previousClasses.delete(name);
+            }
+        }
+    }
+    if (typeof classList.commit === 'function') {
+        classList.commit();
+    }
+});
+
+export { queryAsync as a, classMap as b, customElement as c, eventOptions as e, internalProperty as i, property as p, query as q };

--- a/build/web_modules/common/form-element-eab9dd3c.js
+++ b/build/web_modules/common/form-element-eab9dd3c.js
@@ -1,0 +1,43 @@
+import { B as BaseElement } from './base-element-787f0cf8.js';
+
+/**
+@license
+Copyright 2018 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/** @soyCompatible */
+class FormElement extends BaseElement {
+    createRenderRoot() {
+        return this.attachShadow({ mode: 'open', delegatesFocus: true });
+    }
+    click() {
+        if (this.formElement) {
+            this.formElement.focus();
+            this.formElement.click();
+        }
+    }
+    setAriaLabel(label) {
+        if (this.formElement) {
+            this.formElement.setAttribute('aria-label', label);
+        }
+    }
+    firstUpdated() {
+        super.firstUpdated();
+        this.mdcRoot.addEventListener('change', (e) => {
+            this.dispatchEvent(new Event('change', e));
+        });
+    }
+}
+
+export { FormElement as F };

--- a/build/web_modules/common/if-defined-f73d3e22.js
+++ b/build/web_modules/common/if-defined-f73d3e22.js
@@ -1,0 +1,39 @@
+import { d as directive, A as AttributePart } from './lit-element-58192bd6.js';
+
+/**
+ * @license
+ * Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+const previousValues = new WeakMap();
+/**
+ * For AttributeParts, sets the attribute if the value is defined and removes
+ * the attribute if the value is undefined.
+ *
+ * For other part types, this directive is a no-op.
+ */
+const ifDefined = directive((value) => (part) => {
+    const previousValue = previousValues.get(part);
+    if (value === undefined && part instanceof AttributePart) {
+        // If the value is undefined, remove the attribute, but only if the value
+        // was previously defined.
+        if (previousValue !== undefined || !previousValues.has(part)) {
+            const name = part.committer.name;
+            part.committer.element.removeAttribute(name);
+        }
+    }
+    else if (value !== previousValue) {
+        part.setValue(value);
+    }
+    previousValues.set(part, value);
+});
+
+export { ifDefined as i };

--- a/build/web_modules/common/lit-element-58192bd6.js
+++ b/build/web_modules/common/lit-element-58192bd6.js
@@ -1,0 +1,2574 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+/**
+ * True if the custom elements polyfill is in use.
+ */
+const isCEPolyfill = typeof window !== 'undefined' &&
+    window.customElements != null &&
+    window.customElements.polyfillWrapFlushCallback !==
+        undefined;
+/**
+ * Removes nodes, starting from `start` (inclusive) to `end` (exclusive), from
+ * `container`.
+ */
+const removeNodes = (container, start, end = null) => {
+    while (start !== end) {
+        const n = start.nextSibling;
+        container.removeChild(start);
+        start = n;
+    }
+};
+
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+/**
+ * An expression marker with embedded unique key to avoid collision with
+ * possible text in templates.
+ */
+const marker = `{{lit-${String(Math.random()).slice(2)}}}`;
+/**
+ * An expression marker used text-positions, multi-binding attributes, and
+ * attributes with markup-like text values.
+ */
+const nodeMarker = `<!--${marker}-->`;
+const markerRegex = new RegExp(`${marker}|${nodeMarker}`);
+/**
+ * Suffix appended to all bound attribute names.
+ */
+const boundAttributeSuffix = '$lit$';
+/**
+ * An updatable Template that tracks the location of dynamic parts.
+ */
+class Template {
+    constructor(result, element) {
+        this.parts = [];
+        this.element = element;
+        const nodesToRemove = [];
+        const stack = [];
+        // Edge needs all 4 parameters present; IE11 needs 3rd parameter to be null
+        const walker = document.createTreeWalker(element.content, 133 /* NodeFilter.SHOW_{ELEMENT|COMMENT|TEXT} */, null, false);
+        // Keeps track of the last index associated with a part. We try to delete
+        // unnecessary nodes, but we never want to associate two different parts
+        // to the same index. They must have a constant node between.
+        let lastPartIndex = 0;
+        let index = -1;
+        let partIndex = 0;
+        const { strings, values: { length } } = result;
+        while (partIndex < length) {
+            const node = walker.nextNode();
+            if (node === null) {
+                // We've exhausted the content inside a nested template element.
+                // Because we still have parts (the outer for-loop), we know:
+                // - There is a template in the stack
+                // - The walker will find a nextNode outside the template
+                walker.currentNode = stack.pop();
+                continue;
+            }
+            index++;
+            if (node.nodeType === 1 /* Node.ELEMENT_NODE */) {
+                if (node.hasAttributes()) {
+                    const attributes = node.attributes;
+                    const { length } = attributes;
+                    // Per
+                    // https://developer.mozilla.org/en-US/docs/Web/API/NamedNodeMap,
+                    // attributes are not guaranteed to be returned in document order.
+                    // In particular, Edge/IE can return them out of order, so we cannot
+                    // assume a correspondence between part index and attribute index.
+                    let count = 0;
+                    for (let i = 0; i < length; i++) {
+                        if (endsWith(attributes[i].name, boundAttributeSuffix)) {
+                            count++;
+                        }
+                    }
+                    while (count-- > 0) {
+                        // Get the template literal section leading up to the first
+                        // expression in this attribute
+                        const stringForPart = strings[partIndex];
+                        // Find the attribute name
+                        const name = lastAttributeNameRegex.exec(stringForPart)[2];
+                        // Find the corresponding attribute
+                        // All bound attributes have had a suffix added in
+                        // TemplateResult#getHTML to opt out of special attribute
+                        // handling. To look up the attribute value we also need to add
+                        // the suffix.
+                        const attributeLookupName = name.toLowerCase() + boundAttributeSuffix;
+                        const attributeValue = node.getAttribute(attributeLookupName);
+                        node.removeAttribute(attributeLookupName);
+                        const statics = attributeValue.split(markerRegex);
+                        this.parts.push({ type: 'attribute', index, name, strings: statics });
+                        partIndex += statics.length - 1;
+                    }
+                }
+                if (node.tagName === 'TEMPLATE') {
+                    stack.push(node);
+                    walker.currentNode = node.content;
+                }
+            }
+            else if (node.nodeType === 3 /* Node.TEXT_NODE */) {
+                const data = node.data;
+                if (data.indexOf(marker) >= 0) {
+                    const parent = node.parentNode;
+                    const strings = data.split(markerRegex);
+                    const lastIndex = strings.length - 1;
+                    // Generate a new text node for each literal section
+                    // These nodes are also used as the markers for node parts
+                    for (let i = 0; i < lastIndex; i++) {
+                        let insert;
+                        let s = strings[i];
+                        if (s === '') {
+                            insert = createMarker();
+                        }
+                        else {
+                            const match = lastAttributeNameRegex.exec(s);
+                            if (match !== null && endsWith(match[2], boundAttributeSuffix)) {
+                                s = s.slice(0, match.index) + match[1] +
+                                    match[2].slice(0, -boundAttributeSuffix.length) + match[3];
+                            }
+                            insert = document.createTextNode(s);
+                        }
+                        parent.insertBefore(insert, node);
+                        this.parts.push({ type: 'node', index: ++index });
+                    }
+                    // If there's no text, we must insert a comment to mark our place.
+                    // Else, we can trust it will stick around after cloning.
+                    if (strings[lastIndex] === '') {
+                        parent.insertBefore(createMarker(), node);
+                        nodesToRemove.push(node);
+                    }
+                    else {
+                        node.data = strings[lastIndex];
+                    }
+                    // We have a part for each match found
+                    partIndex += lastIndex;
+                }
+            }
+            else if (node.nodeType === 8 /* Node.COMMENT_NODE */) {
+                if (node.data === marker) {
+                    const parent = node.parentNode;
+                    // Add a new marker node to be the startNode of the Part if any of
+                    // the following are true:
+                    //  * We don't have a previousSibling
+                    //  * The previousSibling is already the start of a previous part
+                    if (node.previousSibling === null || index === lastPartIndex) {
+                        index++;
+                        parent.insertBefore(createMarker(), node);
+                    }
+                    lastPartIndex = index;
+                    this.parts.push({ type: 'node', index });
+                    // If we don't have a nextSibling, keep this node so we have an end.
+                    // Else, we can remove it to save future costs.
+                    if (node.nextSibling === null) {
+                        node.data = '';
+                    }
+                    else {
+                        nodesToRemove.push(node);
+                        index--;
+                    }
+                    partIndex++;
+                }
+                else {
+                    let i = -1;
+                    while ((i = node.data.indexOf(marker, i + 1)) !== -1) {
+                        // Comment node has a binding marker inside, make an inactive part
+                        // The binding won't work, but subsequent bindings will
+                        // TODO (justinfagnani): consider whether it's even worth it to
+                        // make bindings in comments work
+                        this.parts.push({ type: 'node', index: -1 });
+                        partIndex++;
+                    }
+                }
+            }
+        }
+        // Remove text binding nodes after the walk to not disturb the TreeWalker
+        for (const n of nodesToRemove) {
+            n.parentNode.removeChild(n);
+        }
+    }
+}
+const endsWith = (str, suffix) => {
+    const index = str.length - suffix.length;
+    return index >= 0 && str.slice(index) === suffix;
+};
+const isTemplatePartActive = (part) => part.index !== -1;
+// Allows `document.createComment('')` to be renamed for a
+// small manual size-savings.
+const createMarker = () => document.createComment('');
+/**
+ * This regex extracts the attribute name preceding an attribute-position
+ * expression. It does this by matching the syntax allowed for attributes
+ * against the string literal directly preceding the expression, assuming that
+ * the expression is in an attribute-value position.
+ *
+ * See attributes in the HTML spec:
+ * https://www.w3.org/TR/html5/syntax.html#elements-attributes
+ *
+ * " \x09\x0a\x0c\x0d" are HTML space characters:
+ * https://www.w3.org/TR/html5/infrastructure.html#space-characters
+ *
+ * "\0-\x1F\x7F-\x9F" are Unicode control characters, which includes every
+ * space character except " ".
+ *
+ * So an attribute is:
+ *  * The name: any character except a control character, space character, ('),
+ *    ("), ">", "=", or "/"
+ *  * Followed by zero or more space characters
+ *  * Followed by "="
+ *  * Followed by zero or more space characters
+ *  * Followed by:
+ *    * Any character except space, ('), ("), "<", ">", "=", (`), or
+ *    * (") then any non-("), or
+ *    * (') then any non-(')
+ */
+const lastAttributeNameRegex = 
+// eslint-disable-next-line no-control-regex
+/([ \x09\x0a\x0c\x0d])([^\0-\x1F\x7F-\x9F "'>=/]+)([ \x09\x0a\x0c\x0d]*=[ \x09\x0a\x0c\x0d]*(?:[^ \x09\x0a\x0c\x0d"'`<>=]*|"[^"]*|'[^']*))$/;
+
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+const walkerNodeFilter = 133 /* NodeFilter.SHOW_{ELEMENT|COMMENT|TEXT} */;
+/**
+ * Removes the list of nodes from a Template safely. In addition to removing
+ * nodes from the Template, the Template part indices are updated to match
+ * the mutated Template DOM.
+ *
+ * As the template is walked the removal state is tracked and
+ * part indices are adjusted as needed.
+ *
+ * div
+ *   div#1 (remove) <-- start removing (removing node is div#1)
+ *     div
+ *       div#2 (remove)  <-- continue removing (removing node is still div#1)
+ *         div
+ * div <-- stop removing since previous sibling is the removing node (div#1,
+ * removed 4 nodes)
+ */
+function removeNodesFromTemplate(template, nodesToRemove) {
+    const { element: { content }, parts } = template;
+    const walker = document.createTreeWalker(content, walkerNodeFilter, null, false);
+    let partIndex = nextActiveIndexInTemplateParts(parts);
+    let part = parts[partIndex];
+    let nodeIndex = -1;
+    let removeCount = 0;
+    const nodesToRemoveInTemplate = [];
+    let currentRemovingNode = null;
+    while (walker.nextNode()) {
+        nodeIndex++;
+        const node = walker.currentNode;
+        // End removal if stepped past the removing node
+        if (node.previousSibling === currentRemovingNode) {
+            currentRemovingNode = null;
+        }
+        // A node to remove was found in the template
+        if (nodesToRemove.has(node)) {
+            nodesToRemoveInTemplate.push(node);
+            // Track node we're removing
+            if (currentRemovingNode === null) {
+                currentRemovingNode = node;
+            }
+        }
+        // When removing, increment count by which to adjust subsequent part indices
+        if (currentRemovingNode !== null) {
+            removeCount++;
+        }
+        while (part !== undefined && part.index === nodeIndex) {
+            // If part is in a removed node deactivate it by setting index to -1 or
+            // adjust the index as needed.
+            part.index = currentRemovingNode !== null ? -1 : part.index - removeCount;
+            // go to the next active part.
+            partIndex = nextActiveIndexInTemplateParts(parts, partIndex);
+            part = parts[partIndex];
+        }
+    }
+    nodesToRemoveInTemplate.forEach((n) => n.parentNode.removeChild(n));
+}
+const countNodes = (node) => {
+    let count = (node.nodeType === 11 /* Node.DOCUMENT_FRAGMENT_NODE */) ? 0 : 1;
+    const walker = document.createTreeWalker(node, walkerNodeFilter, null, false);
+    while (walker.nextNode()) {
+        count++;
+    }
+    return count;
+};
+const nextActiveIndexInTemplateParts = (parts, startIndex = -1) => {
+    for (let i = startIndex + 1; i < parts.length; i++) {
+        const part = parts[i];
+        if (isTemplatePartActive(part)) {
+            return i;
+        }
+    }
+    return -1;
+};
+/**
+ * Inserts the given node into the Template, optionally before the given
+ * refNode. In addition to inserting the node into the Template, the Template
+ * part indices are updated to match the mutated Template DOM.
+ */
+function insertNodeIntoTemplate(template, node, refNode = null) {
+    const { element: { content }, parts } = template;
+    // If there's no refNode, then put node at end of template.
+    // No part indices need to be shifted in this case.
+    if (refNode === null || refNode === undefined) {
+        content.appendChild(node);
+        return;
+    }
+    const walker = document.createTreeWalker(content, walkerNodeFilter, null, false);
+    let partIndex = nextActiveIndexInTemplateParts(parts);
+    let insertCount = 0;
+    let walkerIndex = -1;
+    while (walker.nextNode()) {
+        walkerIndex++;
+        const walkerNode = walker.currentNode;
+        if (walkerNode === refNode) {
+            insertCount = countNodes(node);
+            refNode.parentNode.insertBefore(node, refNode);
+        }
+        while (partIndex !== -1 && parts[partIndex].index === walkerIndex) {
+            // If we've inserted the node, simply adjust all subsequent parts
+            if (insertCount > 0) {
+                while (partIndex !== -1) {
+                    parts[partIndex].index += insertCount;
+                    partIndex = nextActiveIndexInTemplateParts(parts, partIndex);
+                }
+                return;
+            }
+            partIndex = nextActiveIndexInTemplateParts(parts, partIndex);
+        }
+    }
+}
+
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+const directives = new WeakMap();
+/**
+ * Brands a function as a directive factory function so that lit-html will call
+ * the function during template rendering, rather than passing as a value.
+ *
+ * A _directive_ is a function that takes a Part as an argument. It has the
+ * signature: `(part: Part) => void`.
+ *
+ * A directive _factory_ is a function that takes arguments for data and
+ * configuration and returns a directive. Users of directive usually refer to
+ * the directive factory as the directive. For example, "The repeat directive".
+ *
+ * Usually a template author will invoke a directive factory in their template
+ * with relevant arguments, which will then return a directive function.
+ *
+ * Here's an example of using the `repeat()` directive factory that takes an
+ * array and a function to render an item:
+ *
+ * ```js
+ * html`<ul><${repeat(items, (item) => html`<li>${item}</li>`)}</ul>`
+ * ```
+ *
+ * When `repeat` is invoked, it returns a directive function that closes over
+ * `items` and the template function. When the outer template is rendered, the
+ * return directive function is called with the Part for the expression.
+ * `repeat` then performs it's custom logic to render multiple items.
+ *
+ * @param f The directive factory function. Must be a function that returns a
+ * function of the signature `(part: Part) => void`. The returned function will
+ * be called with the part object.
+ *
+ * @example
+ *
+ * import {directive, html} from 'lit-html';
+ *
+ * const immutable = directive((v) => (part) => {
+ *   if (part.value !== v) {
+ *     part.setValue(v)
+ *   }
+ * });
+ */
+const directive = (f) => ((...args) => {
+    const d = f(...args);
+    directives.set(d, true);
+    return d;
+});
+const isDirective = (o) => {
+    return typeof o === 'function' && directives.has(o);
+};
+
+/**
+ * @license
+ * Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+/**
+ * A sentinel value that signals that a value was handled by a directive and
+ * should not be written to the DOM.
+ */
+const noChange = {};
+/**
+ * A sentinel value that signals a NodePart to fully clear its content.
+ */
+const nothing = {};
+
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+/**
+ * An instance of a `Template` that can be attached to the DOM and updated
+ * with new values.
+ */
+class TemplateInstance {
+    constructor(template, processor, options) {
+        this.__parts = [];
+        this.template = template;
+        this.processor = processor;
+        this.options = options;
+    }
+    update(values) {
+        let i = 0;
+        for (const part of this.__parts) {
+            if (part !== undefined) {
+                part.setValue(values[i]);
+            }
+            i++;
+        }
+        for (const part of this.__parts) {
+            if (part !== undefined) {
+                part.commit();
+            }
+        }
+    }
+    _clone() {
+        // There are a number of steps in the lifecycle of a template instance's
+        // DOM fragment:
+        //  1. Clone - create the instance fragment
+        //  2. Adopt - adopt into the main document
+        //  3. Process - find part markers and create parts
+        //  4. Upgrade - upgrade custom elements
+        //  5. Update - set node, attribute, property, etc., values
+        //  6. Connect - connect to the document. Optional and outside of this
+        //     method.
+        //
+        // We have a few constraints on the ordering of these steps:
+        //  * We need to upgrade before updating, so that property values will pass
+        //    through any property setters.
+        //  * We would like to process before upgrading so that we're sure that the
+        //    cloned fragment is inert and not disturbed by self-modifying DOM.
+        //  * We want custom elements to upgrade even in disconnected fragments.
+        //
+        // Given these constraints, with full custom elements support we would
+        // prefer the order: Clone, Process, Adopt, Upgrade, Update, Connect
+        //
+        // But Safari does not implement CustomElementRegistry#upgrade, so we
+        // can not implement that order and still have upgrade-before-update and
+        // upgrade disconnected fragments. So we instead sacrifice the
+        // process-before-upgrade constraint, since in Custom Elements v1 elements
+        // must not modify their light DOM in the constructor. We still have issues
+        // when co-existing with CEv0 elements like Polymer 1, and with polyfills
+        // that don't strictly adhere to the no-modification rule because shadow
+        // DOM, which may be created in the constructor, is emulated by being placed
+        // in the light DOM.
+        //
+        // The resulting order is on native is: Clone, Adopt, Upgrade, Process,
+        // Update, Connect. document.importNode() performs Clone, Adopt, and Upgrade
+        // in one step.
+        //
+        // The Custom Elements v1 polyfill supports upgrade(), so the order when
+        // polyfilled is the more ideal: Clone, Process, Adopt, Upgrade, Update,
+        // Connect.
+        const fragment = isCEPolyfill ?
+            this.template.element.content.cloneNode(true) :
+            document.importNode(this.template.element.content, true);
+        const stack = [];
+        const parts = this.template.parts;
+        // Edge needs all 4 parameters present; IE11 needs 3rd parameter to be null
+        const walker = document.createTreeWalker(fragment, 133 /* NodeFilter.SHOW_{ELEMENT|COMMENT|TEXT} */, null, false);
+        let partIndex = 0;
+        let nodeIndex = 0;
+        let part;
+        let node = walker.nextNode();
+        // Loop through all the nodes and parts of a template
+        while (partIndex < parts.length) {
+            part = parts[partIndex];
+            if (!isTemplatePartActive(part)) {
+                this.__parts.push(undefined);
+                partIndex++;
+                continue;
+            }
+            // Progress the tree walker until we find our next part's node.
+            // Note that multiple parts may share the same node (attribute parts
+            // on a single element), so this loop may not run at all.
+            while (nodeIndex < part.index) {
+                nodeIndex++;
+                if (node.nodeName === 'TEMPLATE') {
+                    stack.push(node);
+                    walker.currentNode = node.content;
+                }
+                if ((node = walker.nextNode()) === null) {
+                    // We've exhausted the content inside a nested template element.
+                    // Because we still have parts (the outer for-loop), we know:
+                    // - There is a template in the stack
+                    // - The walker will find a nextNode outside the template
+                    walker.currentNode = stack.pop();
+                    node = walker.nextNode();
+                }
+            }
+            // We've arrived at our part's node.
+            if (part.type === 'node') {
+                const part = this.processor.handleTextExpression(this.options);
+                part.insertAfterNode(node.previousSibling);
+                this.__parts.push(part);
+            }
+            else {
+                this.__parts.push(...this.processor.handleAttributeExpressions(node, part.name, part.strings, this.options));
+            }
+            partIndex++;
+        }
+        if (isCEPolyfill) {
+            document.adoptNode(fragment);
+            customElements.upgrade(fragment);
+        }
+        return fragment;
+    }
+}
+
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+/**
+ * Our TrustedTypePolicy for HTML which is declared using the html template
+ * tag function.
+ *
+ * That HTML is a developer-authored constant, and is parsed with innerHTML
+ * before any untrusted expressions have been mixed in. Therefor it is
+ * considered safe by construction.
+ */
+const policy = window.trustedTypes &&
+    trustedTypes.createPolicy('lit-html', { createHTML: (s) => s });
+const commentMarker = ` ${marker} `;
+/**
+ * The return type of `html`, which holds a Template and the values from
+ * interpolated expressions.
+ */
+class TemplateResult {
+    constructor(strings, values, type, processor) {
+        this.strings = strings;
+        this.values = values;
+        this.type = type;
+        this.processor = processor;
+    }
+    /**
+     * Returns a string of HTML used to create a `<template>` element.
+     */
+    getHTML() {
+        const l = this.strings.length - 1;
+        let html = '';
+        let isCommentBinding = false;
+        for (let i = 0; i < l; i++) {
+            const s = this.strings[i];
+            // For each binding we want to determine the kind of marker to insert
+            // into the template source before it's parsed by the browser's HTML
+            // parser. The marker type is based on whether the expression is in an
+            // attribute, text, or comment position.
+            //   * For node-position bindings we insert a comment with the marker
+            //     sentinel as its text content, like <!--{{lit-guid}}-->.
+            //   * For attribute bindings we insert just the marker sentinel for the
+            //     first binding, so that we support unquoted attribute bindings.
+            //     Subsequent bindings can use a comment marker because multi-binding
+            //     attributes must be quoted.
+            //   * For comment bindings we insert just the marker sentinel so we don't
+            //     close the comment.
+            //
+            // The following code scans the template source, but is *not* an HTML
+            // parser. We don't need to track the tree structure of the HTML, only
+            // whether a binding is inside a comment, and if not, if it appears to be
+            // the first binding in an attribute.
+            const commentOpen = s.lastIndexOf('<!--');
+            // We're in comment position if we have a comment open with no following
+            // comment close. Because <-- can appear in an attribute value there can
+            // be false positives.
+            isCommentBinding = (commentOpen > -1 || isCommentBinding) &&
+                s.indexOf('-->', commentOpen + 1) === -1;
+            // Check to see if we have an attribute-like sequence preceding the
+            // expression. This can match "name=value" like structures in text,
+            // comments, and attribute values, so there can be false-positives.
+            const attributeMatch = lastAttributeNameRegex.exec(s);
+            if (attributeMatch === null) {
+                // We're only in this branch if we don't have a attribute-like
+                // preceding sequence. For comments, this guards against unusual
+                // attribute values like <div foo="<!--${'bar'}">. Cases like
+                // <!-- foo=${'bar'}--> are handled correctly in the attribute branch
+                // below.
+                html += s + (isCommentBinding ? commentMarker : nodeMarker);
+            }
+            else {
+                // For attributes we use just a marker sentinel, and also append a
+                // $lit$ suffix to the name to opt-out of attribute-specific parsing
+                // that IE and Edge do for style and certain SVG attributes.
+                html += s.substr(0, attributeMatch.index) + attributeMatch[1] +
+                    attributeMatch[2] + boundAttributeSuffix + attributeMatch[3] +
+                    marker;
+            }
+        }
+        html += this.strings[l];
+        return html;
+    }
+    getTemplateElement() {
+        const template = document.createElement('template');
+        let value = this.getHTML();
+        if (policy !== undefined) {
+            // this is secure because `this.strings` is a TemplateStringsArray.
+            // TODO: validate this when
+            // https://github.com/tc39/proposal-array-is-template-object is
+            // implemented.
+            value = policy.createHTML(value);
+        }
+        template.innerHTML = value;
+        return template;
+    }
+}
+
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+const isPrimitive = (value) => {
+    return (value === null ||
+        !(typeof value === 'object' || typeof value === 'function'));
+};
+const isIterable = (value) => {
+    return Array.isArray(value) ||
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        !!(value && value[Symbol.iterator]);
+};
+/**
+ * Writes attribute values to the DOM for a group of AttributeParts bound to a
+ * single attribute. The value is only set once even if there are multiple parts
+ * for an attribute.
+ */
+class AttributeCommitter {
+    constructor(element, name, strings) {
+        this.dirty = true;
+        this.element = element;
+        this.name = name;
+        this.strings = strings;
+        this.parts = [];
+        for (let i = 0; i < strings.length - 1; i++) {
+            this.parts[i] = this._createPart();
+        }
+    }
+    /**
+     * Creates a single part. Override this to create a differnt type of part.
+     */
+    _createPart() {
+        return new AttributePart(this);
+    }
+    _getValue() {
+        const strings = this.strings;
+        const l = strings.length - 1;
+        const parts = this.parts;
+        // If we're assigning an attribute via syntax like:
+        //    attr="${foo}"  or  attr=${foo}
+        // but not
+        //    attr="${foo} ${bar}" or attr="${foo} baz"
+        // then we don't want to coerce the attribute value into one long
+        // string. Instead we want to just return the value itself directly,
+        // so that sanitizeDOMValue can get the actual value rather than
+        // String(value)
+        // The exception is if v is an array, in which case we do want to smash
+        // it together into a string without calling String() on the array.
+        //
+        // This also allows trusted values (when using TrustedTypes) being
+        // assigned to DOM sinks without being stringified in the process.
+        if (l === 1 && strings[0] === '' && strings[1] === '') {
+            const v = parts[0].value;
+            if (typeof v === 'symbol') {
+                return String(v);
+            }
+            if (typeof v === 'string' || !isIterable(v)) {
+                return v;
+            }
+        }
+        let text = '';
+        for (let i = 0; i < l; i++) {
+            text += strings[i];
+            const part = parts[i];
+            if (part !== undefined) {
+                const v = part.value;
+                if (isPrimitive(v) || !isIterable(v)) {
+                    text += typeof v === 'string' ? v : String(v);
+                }
+                else {
+                    for (const t of v) {
+                        text += typeof t === 'string' ? t : String(t);
+                    }
+                }
+            }
+        }
+        text += strings[l];
+        return text;
+    }
+    commit() {
+        if (this.dirty) {
+            this.dirty = false;
+            this.element.setAttribute(this.name, this._getValue());
+        }
+    }
+}
+/**
+ * A Part that controls all or part of an attribute value.
+ */
+class AttributePart {
+    constructor(committer) {
+        this.value = undefined;
+        this.committer = committer;
+    }
+    setValue(value) {
+        if (value !== noChange && (!isPrimitive(value) || value !== this.value)) {
+            this.value = value;
+            // If the value is a not a directive, dirty the committer so that it'll
+            // call setAttribute. If the value is a directive, it'll dirty the
+            // committer if it calls setValue().
+            if (!isDirective(value)) {
+                this.committer.dirty = true;
+            }
+        }
+    }
+    commit() {
+        while (isDirective(this.value)) {
+            const directive = this.value;
+            this.value = noChange;
+            directive(this);
+        }
+        if (this.value === noChange) {
+            return;
+        }
+        this.committer.commit();
+    }
+}
+/**
+ * A Part that controls a location within a Node tree. Like a Range, NodePart
+ * has start and end locations and can set and update the Nodes between those
+ * locations.
+ *
+ * NodeParts support several value types: primitives, Nodes, TemplateResults,
+ * as well as arrays and iterables of those types.
+ */
+class NodePart {
+    constructor(options) {
+        this.value = undefined;
+        this.__pendingValue = undefined;
+        this.options = options;
+    }
+    /**
+     * Appends this part into a container.
+     *
+     * This part must be empty, as its contents are not automatically moved.
+     */
+    appendInto(container) {
+        this.startNode = container.appendChild(createMarker());
+        this.endNode = container.appendChild(createMarker());
+    }
+    /**
+     * Inserts this part after the `ref` node (between `ref` and `ref`'s next
+     * sibling). Both `ref` and its next sibling must be static, unchanging nodes
+     * such as those that appear in a literal section of a template.
+     *
+     * This part must be empty, as its contents are not automatically moved.
+     */
+    insertAfterNode(ref) {
+        this.startNode = ref;
+        this.endNode = ref.nextSibling;
+    }
+    /**
+     * Appends this part into a parent part.
+     *
+     * This part must be empty, as its contents are not automatically moved.
+     */
+    appendIntoPart(part) {
+        part.__insert(this.startNode = createMarker());
+        part.__insert(this.endNode = createMarker());
+    }
+    /**
+     * Inserts this part after the `ref` part.
+     *
+     * This part must be empty, as its contents are not automatically moved.
+     */
+    insertAfterPart(ref) {
+        ref.__insert(this.startNode = createMarker());
+        this.endNode = ref.endNode;
+        ref.endNode = this.startNode;
+    }
+    setValue(value) {
+        this.__pendingValue = value;
+    }
+    commit() {
+        if (this.startNode.parentNode === null) {
+            return;
+        }
+        while (isDirective(this.__pendingValue)) {
+            const directive = this.__pendingValue;
+            this.__pendingValue = noChange;
+            directive(this);
+        }
+        const value = this.__pendingValue;
+        if (value === noChange) {
+            return;
+        }
+        if (isPrimitive(value)) {
+            if (value !== this.value) {
+                this.__commitText(value);
+            }
+        }
+        else if (value instanceof TemplateResult) {
+            this.__commitTemplateResult(value);
+        }
+        else if (value instanceof Node) {
+            this.__commitNode(value);
+        }
+        else if (isIterable(value)) {
+            this.__commitIterable(value);
+        }
+        else if (value === nothing) {
+            this.value = nothing;
+            this.clear();
+        }
+        else {
+            // Fallback, will render the string representation
+            this.__commitText(value);
+        }
+    }
+    __insert(node) {
+        this.endNode.parentNode.insertBefore(node, this.endNode);
+    }
+    __commitNode(value) {
+        if (this.value === value) {
+            return;
+        }
+        this.clear();
+        this.__insert(value);
+        this.value = value;
+    }
+    __commitText(value) {
+        const node = this.startNode.nextSibling;
+        value = value == null ? '' : value;
+        // If `value` isn't already a string, we explicitly convert it here in case
+        // it can't be implicitly converted - i.e. it's a symbol.
+        const valueAsString = typeof value === 'string' ? value : String(value);
+        if (node === this.endNode.previousSibling &&
+            node.nodeType === 3 /* Node.TEXT_NODE */) {
+            // If we only have a single text node between the markers, we can just
+            // set its value, rather than replacing it.
+            // TODO(justinfagnani): Can we just check if this.value is primitive?
+            node.data = valueAsString;
+        }
+        else {
+            this.__commitNode(document.createTextNode(valueAsString));
+        }
+        this.value = value;
+    }
+    __commitTemplateResult(value) {
+        const template = this.options.templateFactory(value);
+        if (this.value instanceof TemplateInstance &&
+            this.value.template === template) {
+            this.value.update(value.values);
+        }
+        else {
+            // Make sure we propagate the template processor from the TemplateResult
+            // so that we use its syntax extension, etc. The template factory comes
+            // from the render function options so that it can control template
+            // caching and preprocessing.
+            const instance = new TemplateInstance(template, value.processor, this.options);
+            const fragment = instance._clone();
+            instance.update(value.values);
+            this.__commitNode(fragment);
+            this.value = instance;
+        }
+    }
+    __commitIterable(value) {
+        // For an Iterable, we create a new InstancePart per item, then set its
+        // value to the item. This is a little bit of overhead for every item in
+        // an Iterable, but it lets us recurse easily and efficiently update Arrays
+        // of TemplateResults that will be commonly returned from expressions like:
+        // array.map((i) => html`${i}`), by reusing existing TemplateInstances.
+        // If _value is an array, then the previous render was of an
+        // iterable and _value will contain the NodeParts from the previous
+        // render. If _value is not an array, clear this part and make a new
+        // array for NodeParts.
+        if (!Array.isArray(this.value)) {
+            this.value = [];
+            this.clear();
+        }
+        // Lets us keep track of how many items we stamped so we can clear leftover
+        // items from a previous render
+        const itemParts = this.value;
+        let partIndex = 0;
+        let itemPart;
+        for (const item of value) {
+            // Try to reuse an existing part
+            itemPart = itemParts[partIndex];
+            // If no existing part, create a new one
+            if (itemPart === undefined) {
+                itemPart = new NodePart(this.options);
+                itemParts.push(itemPart);
+                if (partIndex === 0) {
+                    itemPart.appendIntoPart(this);
+                }
+                else {
+                    itemPart.insertAfterPart(itemParts[partIndex - 1]);
+                }
+            }
+            itemPart.setValue(item);
+            itemPart.commit();
+            partIndex++;
+        }
+        if (partIndex < itemParts.length) {
+            // Truncate the parts array so _value reflects the current state
+            itemParts.length = partIndex;
+            this.clear(itemPart && itemPart.endNode);
+        }
+    }
+    clear(startNode = this.startNode) {
+        removeNodes(this.startNode.parentNode, startNode.nextSibling, this.endNode);
+    }
+}
+/**
+ * Implements a boolean attribute, roughly as defined in the HTML
+ * specification.
+ *
+ * If the value is truthy, then the attribute is present with a value of
+ * ''. If the value is falsey, the attribute is removed.
+ */
+class BooleanAttributePart {
+    constructor(element, name, strings) {
+        this.value = undefined;
+        this.__pendingValue = undefined;
+        if (strings.length !== 2 || strings[0] !== '' || strings[1] !== '') {
+            throw new Error('Boolean attributes can only contain a single expression');
+        }
+        this.element = element;
+        this.name = name;
+        this.strings = strings;
+    }
+    setValue(value) {
+        this.__pendingValue = value;
+    }
+    commit() {
+        while (isDirective(this.__pendingValue)) {
+            const directive = this.__pendingValue;
+            this.__pendingValue = noChange;
+            directive(this);
+        }
+        if (this.__pendingValue === noChange) {
+            return;
+        }
+        const value = !!this.__pendingValue;
+        if (this.value !== value) {
+            if (value) {
+                this.element.setAttribute(this.name, '');
+            }
+            else {
+                this.element.removeAttribute(this.name);
+            }
+            this.value = value;
+        }
+        this.__pendingValue = noChange;
+    }
+}
+/**
+ * Sets attribute values for PropertyParts, so that the value is only set once
+ * even if there are multiple parts for a property.
+ *
+ * If an expression controls the whole property value, then the value is simply
+ * assigned to the property under control. If there are string literals or
+ * multiple expressions, then the strings are expressions are interpolated into
+ * a string first.
+ */
+class PropertyCommitter extends AttributeCommitter {
+    constructor(element, name, strings) {
+        super(element, name, strings);
+        this.single =
+            (strings.length === 2 && strings[0] === '' && strings[1] === '');
+    }
+    _createPart() {
+        return new PropertyPart(this);
+    }
+    _getValue() {
+        if (this.single) {
+            return this.parts[0].value;
+        }
+        return super._getValue();
+    }
+    commit() {
+        if (this.dirty) {
+            this.dirty = false;
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            this.element[this.name] = this._getValue();
+        }
+    }
+}
+class PropertyPart extends AttributePart {
+}
+// Detect event listener options support. If the `capture` property is read
+// from the options object, then options are supported. If not, then the third
+// argument to add/removeEventListener is interpreted as the boolean capture
+// value so we should only pass the `capture` property.
+let eventOptionsSupported = false;
+// Wrap into an IIFE because MS Edge <= v41 does not support having try/catch
+// blocks right into the body of a module
+(() => {
+    try {
+        const options = {
+            get capture() {
+                eventOptionsSupported = true;
+                return false;
+            }
+        };
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        window.addEventListener('test', options, options);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        window.removeEventListener('test', options, options);
+    }
+    catch (_e) {
+        // event options not supported
+    }
+})();
+class EventPart {
+    constructor(element, eventName, eventContext) {
+        this.value = undefined;
+        this.__pendingValue = undefined;
+        this.element = element;
+        this.eventName = eventName;
+        this.eventContext = eventContext;
+        this.__boundHandleEvent = (e) => this.handleEvent(e);
+    }
+    setValue(value) {
+        this.__pendingValue = value;
+    }
+    commit() {
+        while (isDirective(this.__pendingValue)) {
+            const directive = this.__pendingValue;
+            this.__pendingValue = noChange;
+            directive(this);
+        }
+        if (this.__pendingValue === noChange) {
+            return;
+        }
+        const newListener = this.__pendingValue;
+        const oldListener = this.value;
+        const shouldRemoveListener = newListener == null ||
+            oldListener != null &&
+                (newListener.capture !== oldListener.capture ||
+                    newListener.once !== oldListener.once ||
+                    newListener.passive !== oldListener.passive);
+        const shouldAddListener = newListener != null && (oldListener == null || shouldRemoveListener);
+        if (shouldRemoveListener) {
+            this.element.removeEventListener(this.eventName, this.__boundHandleEvent, this.__options);
+        }
+        if (shouldAddListener) {
+            this.__options = getOptions(newListener);
+            this.element.addEventListener(this.eventName, this.__boundHandleEvent, this.__options);
+        }
+        this.value = newListener;
+        this.__pendingValue = noChange;
+    }
+    handleEvent(event) {
+        if (typeof this.value === 'function') {
+            this.value.call(this.eventContext || this.element, event);
+        }
+        else {
+            this.value.handleEvent(event);
+        }
+    }
+}
+// We copy options because of the inconsistent behavior of browsers when reading
+// the third argument of add/removeEventListener. IE11 doesn't support options
+// at all. Chrome 41 only reads `capture` if the argument is an object.
+const getOptions = (o) => o &&
+    (eventOptionsSupported ?
+        { capture: o.capture, passive: o.passive, once: o.once } :
+        o.capture);
+
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+/**
+ * The default TemplateFactory which caches Templates keyed on
+ * result.type and result.strings.
+ */
+function templateFactory(result) {
+    let templateCache = templateCaches.get(result.type);
+    if (templateCache === undefined) {
+        templateCache = {
+            stringsArray: new WeakMap(),
+            keyString: new Map()
+        };
+        templateCaches.set(result.type, templateCache);
+    }
+    let template = templateCache.stringsArray.get(result.strings);
+    if (template !== undefined) {
+        return template;
+    }
+    // If the TemplateStringsArray is new, generate a key from the strings
+    // This key is shared between all templates with identical content
+    const key = result.strings.join(marker);
+    // Check if we already have a Template for this key
+    template = templateCache.keyString.get(key);
+    if (template === undefined) {
+        // If we have not seen this key before, create a new Template
+        template = new Template(result, result.getTemplateElement());
+        // Cache the Template for this key
+        templateCache.keyString.set(key, template);
+    }
+    // Cache all future queries for this TemplateStringsArray
+    templateCache.stringsArray.set(result.strings, template);
+    return template;
+}
+const templateCaches = new Map();
+
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+const parts = new WeakMap();
+/**
+ * Renders a template result or other value to a container.
+ *
+ * To update a container with new values, reevaluate the template literal and
+ * call `render` with the new result.
+ *
+ * @param result Any value renderable by NodePart - typically a TemplateResult
+ *     created by evaluating a template tag like `html` or `svg`.
+ * @param container A DOM parent to render to. The entire contents are either
+ *     replaced, or efficiently updated if the same result type was previous
+ *     rendered there.
+ * @param options RenderOptions for the entire render tree rendered to this
+ *     container. Render options must *not* change between renders to the same
+ *     container, as those changes will not effect previously rendered DOM.
+ */
+const render = (result, container, options) => {
+    let part = parts.get(container);
+    if (part === undefined) {
+        removeNodes(container, container.firstChild);
+        parts.set(container, part = new NodePart(Object.assign({ templateFactory }, options)));
+        part.appendInto(container);
+    }
+    part.setValue(result);
+    part.commit();
+};
+
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+/**
+ * Creates Parts when a template is instantiated.
+ */
+class DefaultTemplateProcessor {
+    /**
+     * Create parts for an attribute-position binding, given the event, attribute
+     * name, and string literals.
+     *
+     * @param element The element containing the binding
+     * @param name  The attribute name
+     * @param strings The string literals. There are always at least two strings,
+     *   event for fully-controlled bindings with a single expression.
+     */
+    handleAttributeExpressions(element, name, strings, options) {
+        const prefix = name[0];
+        if (prefix === '.') {
+            const committer = new PropertyCommitter(element, name.slice(1), strings);
+            return committer.parts;
+        }
+        if (prefix === '@') {
+            return [new EventPart(element, name.slice(1), options.eventContext)];
+        }
+        if (prefix === '?') {
+            return [new BooleanAttributePart(element, name.slice(1), strings)];
+        }
+        const committer = new AttributeCommitter(element, name, strings);
+        return committer.parts;
+    }
+    /**
+     * Create parts for a text-position binding.
+     * @param templateFactory
+     */
+    handleTextExpression(options) {
+        return new NodePart(options);
+    }
+}
+const defaultTemplateProcessor = new DefaultTemplateProcessor();
+
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+// IMPORTANT: do not change the property name or the assignment expression.
+// This line will be used in regexes to search for lit-html usage.
+// TODO(justinfagnani): inject version number at build time
+if (typeof window !== 'undefined') {
+    (window['litHtmlVersions'] || (window['litHtmlVersions'] = [])).push('1.3.0');
+}
+/**
+ * Interprets a template literal as an HTML template that can efficiently
+ * render to and update a container.
+ */
+const html = (strings, ...values) => new TemplateResult(strings, values, 'html', defaultTemplateProcessor);
+
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+// Get a key to lookup in `templateCaches`.
+const getTemplateCacheKey = (type, scopeName) => `${type}--${scopeName}`;
+let compatibleShadyCSSVersion = true;
+if (typeof window.ShadyCSS === 'undefined') {
+    compatibleShadyCSSVersion = false;
+}
+else if (typeof window.ShadyCSS.prepareTemplateDom === 'undefined') {
+    console.warn(`Incompatible ShadyCSS version detected. ` +
+        `Please update to at least @webcomponents/webcomponentsjs@2.0.2 and ` +
+        `@webcomponents/shadycss@1.3.1.`);
+    compatibleShadyCSSVersion = false;
+}
+/**
+ * Template factory which scopes template DOM using ShadyCSS.
+ * @param scopeName {string}
+ */
+const shadyTemplateFactory = (scopeName) => (result) => {
+    const cacheKey = getTemplateCacheKey(result.type, scopeName);
+    let templateCache = templateCaches.get(cacheKey);
+    if (templateCache === undefined) {
+        templateCache = {
+            stringsArray: new WeakMap(),
+            keyString: new Map()
+        };
+        templateCaches.set(cacheKey, templateCache);
+    }
+    let template = templateCache.stringsArray.get(result.strings);
+    if (template !== undefined) {
+        return template;
+    }
+    const key = result.strings.join(marker);
+    template = templateCache.keyString.get(key);
+    if (template === undefined) {
+        const element = result.getTemplateElement();
+        if (compatibleShadyCSSVersion) {
+            window.ShadyCSS.prepareTemplateDom(element, scopeName);
+        }
+        template = new Template(result, element);
+        templateCache.keyString.set(key, template);
+    }
+    templateCache.stringsArray.set(result.strings, template);
+    return template;
+};
+const TEMPLATE_TYPES = ['html', 'svg'];
+/**
+ * Removes all style elements from Templates for the given scopeName.
+ */
+const removeStylesFromLitTemplates = (scopeName) => {
+    TEMPLATE_TYPES.forEach((type) => {
+        const templates = templateCaches.get(getTemplateCacheKey(type, scopeName));
+        if (templates !== undefined) {
+            templates.keyString.forEach((template) => {
+                const { element: { content } } = template;
+                // IE 11 doesn't support the iterable param Set constructor
+                const styles = new Set();
+                Array.from(content.querySelectorAll('style')).forEach((s) => {
+                    styles.add(s);
+                });
+                removeNodesFromTemplate(template, styles);
+            });
+        }
+    });
+};
+const shadyRenderSet = new Set();
+/**
+ * For the given scope name, ensures that ShadyCSS style scoping is performed.
+ * This is done just once per scope name so the fragment and template cannot
+ * be modified.
+ * (1) extracts styles from the rendered fragment and hands them to ShadyCSS
+ * to be scoped and appended to the document
+ * (2) removes style elements from all lit-html Templates for this scope name.
+ *
+ * Note, <style> elements can only be placed into templates for the
+ * initial rendering of the scope. If <style> elements are included in templates
+ * dynamically rendered to the scope (after the first scope render), they will
+ * not be scoped and the <style> will be left in the template and rendered
+ * output.
+ */
+const prepareTemplateStyles = (scopeName, renderedDOM, template) => {
+    shadyRenderSet.add(scopeName);
+    // If `renderedDOM` is stamped from a Template, then we need to edit that
+    // Template's underlying template element. Otherwise, we create one here
+    // to give to ShadyCSS, which still requires one while scoping.
+    const templateElement = !!template ? template.element : document.createElement('template');
+    // Move styles out of rendered DOM and store.
+    const styles = renderedDOM.querySelectorAll('style');
+    const { length } = styles;
+    // If there are no styles, skip unnecessary work
+    if (length === 0) {
+        // Ensure prepareTemplateStyles is called to support adding
+        // styles via `prepareAdoptedCssText` since that requires that
+        // `prepareTemplateStyles` is called.
+        //
+        // ShadyCSS will only update styles containing @apply in the template
+        // given to `prepareTemplateStyles`. If no lit Template was given,
+        // ShadyCSS will not be able to update uses of @apply in any relevant
+        // template. However, this is not a problem because we only create the
+        // template for the purpose of supporting `prepareAdoptedCssText`,
+        // which doesn't support @apply at all.
+        window.ShadyCSS.prepareTemplateStyles(templateElement, scopeName);
+        return;
+    }
+    const condensedStyle = document.createElement('style');
+    // Collect styles into a single style. This helps us make sure ShadyCSS
+    // manipulations will not prevent us from being able to fix up template
+    // part indices.
+    // NOTE: collecting styles is inefficient for browsers but ShadyCSS
+    // currently does this anyway. When it does not, this should be changed.
+    for (let i = 0; i < length; i++) {
+        const style = styles[i];
+        style.parentNode.removeChild(style);
+        condensedStyle.textContent += style.textContent;
+    }
+    // Remove styles from nested templates in this scope.
+    removeStylesFromLitTemplates(scopeName);
+    // And then put the condensed style into the "root" template passed in as
+    // `template`.
+    const content = templateElement.content;
+    if (!!template) {
+        insertNodeIntoTemplate(template, condensedStyle, content.firstChild);
+    }
+    else {
+        content.insertBefore(condensedStyle, content.firstChild);
+    }
+    // Note, it's important that ShadyCSS gets the template that `lit-html`
+    // will actually render so that it can update the style inside when
+    // needed (e.g. @apply native Shadow DOM case).
+    window.ShadyCSS.prepareTemplateStyles(templateElement, scopeName);
+    const style = content.querySelector('style');
+    if (window.ShadyCSS.nativeShadow && style !== null) {
+        // When in native Shadow DOM, ensure the style created by ShadyCSS is
+        // included in initially rendered output (`renderedDOM`).
+        renderedDOM.insertBefore(style.cloneNode(true), renderedDOM.firstChild);
+    }
+    else if (!!template) {
+        // When no style is left in the template, parts will be broken as a
+        // result. To fix this, we put back the style node ShadyCSS removed
+        // and then tell lit to remove that node from the template.
+        // There can be no style in the template in 2 cases (1) when Shady DOM
+        // is in use, ShadyCSS removes all styles, (2) when native Shadow DOM
+        // is in use ShadyCSS removes the style if it contains no content.
+        // NOTE, ShadyCSS creates its own style so we can safely add/remove
+        // `condensedStyle` here.
+        content.insertBefore(condensedStyle, content.firstChild);
+        const removes = new Set();
+        removes.add(condensedStyle);
+        removeNodesFromTemplate(template, removes);
+    }
+};
+/**
+ * Extension to the standard `render` method which supports rendering
+ * to ShadowRoots when the ShadyDOM (https://github.com/webcomponents/shadydom)
+ * and ShadyCSS (https://github.com/webcomponents/shadycss) polyfills are used
+ * or when the webcomponentsjs
+ * (https://github.com/webcomponents/webcomponentsjs) polyfill is used.
+ *
+ * Adds a `scopeName` option which is used to scope element DOM and stylesheets
+ * when native ShadowDOM is unavailable. The `scopeName` will be added to
+ * the class attribute of all rendered DOM. In addition, any style elements will
+ * be automatically re-written with this `scopeName` selector and moved out
+ * of the rendered DOM and into the document `<head>`.
+ *
+ * It is common to use this render method in conjunction with a custom element
+ * which renders a shadowRoot. When this is done, typically the element's
+ * `localName` should be used as the `scopeName`.
+ *
+ * In addition to DOM scoping, ShadyCSS also supports a basic shim for css
+ * custom properties (needed only on older browsers like IE11) and a shim for
+ * a deprecated feature called `@apply` that supports applying a set of css
+ * custom properties to a given location.
+ *
+ * Usage considerations:
+ *
+ * * Part values in `<style>` elements are only applied the first time a given
+ * `scopeName` renders. Subsequent changes to parts in style elements will have
+ * no effect. Because of this, parts in style elements should only be used for
+ * values that will never change, for example parts that set scope-wide theme
+ * values or parts which render shared style elements.
+ *
+ * * Note, due to a limitation of the ShadyDOM polyfill, rendering in a
+ * custom element's `constructor` is not supported. Instead rendering should
+ * either done asynchronously, for example at microtask timing (for example
+ * `Promise.resolve()`), or be deferred until the first time the element's
+ * `connectedCallback` runs.
+ *
+ * Usage considerations when using shimmed custom properties or `@apply`:
+ *
+ * * Whenever any dynamic changes are made which affect
+ * css custom properties, `ShadyCSS.styleElement(element)` must be called
+ * to update the element. There are two cases when this is needed:
+ * (1) the element is connected to a new parent, (2) a class is added to the
+ * element that causes it to match different custom properties.
+ * To address the first case when rendering a custom element, `styleElement`
+ * should be called in the element's `connectedCallback`.
+ *
+ * * Shimmed custom properties may only be defined either for an entire
+ * shadowRoot (for example, in a `:host` rule) or via a rule that directly
+ * matches an element with a shadowRoot. In other words, instead of flowing from
+ * parent to child as do native css custom properties, shimmed custom properties
+ * flow only from shadowRoots to nested shadowRoots.
+ *
+ * * When using `@apply` mixing css shorthand property names with
+ * non-shorthand names (for example `border` and `border-width`) is not
+ * supported.
+ */
+const render$1 = (result, container, options) => {
+    if (!options || typeof options !== 'object' || !options.scopeName) {
+        throw new Error('The `scopeName` option is required.');
+    }
+    const scopeName = options.scopeName;
+    const hasRendered = parts.has(container);
+    const needsScoping = compatibleShadyCSSVersion &&
+        container.nodeType === 11 /* Node.DOCUMENT_FRAGMENT_NODE */ &&
+        !!container.host;
+    // Handle first render to a scope specially...
+    const firstScopeRender = needsScoping && !shadyRenderSet.has(scopeName);
+    // On first scope render, render into a fragment; this cannot be a single
+    // fragment that is reused since nested renders can occur synchronously.
+    const renderContainer = firstScopeRender ? document.createDocumentFragment() : container;
+    render(result, renderContainer, Object.assign({ templateFactory: shadyTemplateFactory(scopeName) }, options));
+    // When performing first scope render,
+    // (1) We've rendered into a fragment so that there's a chance to
+    // `prepareTemplateStyles` before sub-elements hit the DOM
+    // (which might cause them to render based on a common pattern of
+    // rendering in a custom element's `connectedCallback`);
+    // (2) Scope the template with ShadyCSS one time only for this scope.
+    // (3) Render the fragment into the container and make sure the
+    // container knows its `part` is the one we just rendered. This ensures
+    // DOM will be re-used on subsequent renders.
+    if (firstScopeRender) {
+        const part = parts.get(renderContainer);
+        parts.delete(renderContainer);
+        // ShadyCSS might have style sheets (e.g. from `prepareAdoptedCssText`)
+        // that should apply to `renderContainer` even if the rendered value is
+        // not a TemplateInstance. However, it will only insert scoped styles
+        // into the document if `prepareTemplateStyles` has already been called
+        // for the given scope name.
+        const template = part.value instanceof TemplateInstance ?
+            part.value.template :
+            undefined;
+        prepareTemplateStyles(scopeName, renderContainer, template);
+        removeNodes(container, container.firstChild);
+        container.appendChild(renderContainer);
+        parts.set(container, part);
+    }
+    // After elements have hit the DOM, update styling if this is the
+    // initial render to this container.
+    // This is needed whenever dynamic changes are made so it would be
+    // safest to do every render; however, this would regress performance
+    // so we leave it up to the user to call `ShadyCSS.styleElement`
+    // for dynamic changes.
+    if (!hasRendered && needsScoping) {
+        window.ShadyCSS.styleElement(container.host);
+    }
+};
+
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+var _a;
+/**
+ * Use this module if you want to create your own base class extending
+ * [[UpdatingElement]].
+ * @packageDocumentation
+ */
+/*
+ * When using Closure Compiler, JSCompiler_renameProperty(property, object) is
+ * replaced at compile time by the munged name for object[property]. We cannot
+ * alias this function, so we have to use a small shim that has the same
+ * behavior when not compiling.
+ */
+window.JSCompiler_renameProperty =
+    (prop, _obj) => prop;
+const defaultConverter = {
+    toAttribute(value, type) {
+        switch (type) {
+            case Boolean:
+                return value ? '' : null;
+            case Object:
+            case Array:
+                // if the value is `null` or `undefined` pass this through
+                // to allow removing/no change behavior.
+                return value == null ? value : JSON.stringify(value);
+        }
+        return value;
+    },
+    fromAttribute(value, type) {
+        switch (type) {
+            case Boolean:
+                return value !== null;
+            case Number:
+                return value === null ? null : Number(value);
+            case Object:
+            case Array:
+                return JSON.parse(value);
+        }
+        return value;
+    }
+};
+/**
+ * Change function that returns true if `value` is different from `oldValue`.
+ * This method is used as the default for a property's `hasChanged` function.
+ */
+const notEqual = (value, old) => {
+    // This ensures (old==NaN, value==NaN) always returns false
+    return old !== value && (old === old || value === value);
+};
+const defaultPropertyDeclaration = {
+    attribute: true,
+    type: String,
+    converter: defaultConverter,
+    reflect: false,
+    hasChanged: notEqual
+};
+const STATE_HAS_UPDATED = 1;
+const STATE_UPDATE_REQUESTED = 1 << 2;
+const STATE_IS_REFLECTING_TO_ATTRIBUTE = 1 << 3;
+const STATE_IS_REFLECTING_TO_PROPERTY = 1 << 4;
+/**
+ * The Closure JS Compiler doesn't currently have good support for static
+ * property semantics where "this" is dynamic (e.g.
+ * https://github.com/google/closure-compiler/issues/3177 and others) so we use
+ * this hack to bypass any rewriting by the compiler.
+ */
+const finalized = 'finalized';
+/**
+ * Base element class which manages element properties and attributes. When
+ * properties change, the `update` method is asynchronously called. This method
+ * should be supplied by subclassers to render updates as desired.
+ * @noInheritDoc
+ */
+class UpdatingElement extends HTMLElement {
+    constructor() {
+        super();
+        this.initialize();
+    }
+    /**
+     * Returns a list of attributes corresponding to the registered properties.
+     * @nocollapse
+     */
+    static get observedAttributes() {
+        // note: piggy backing on this to ensure we're finalized.
+        this.finalize();
+        const attributes = [];
+        // Use forEach so this works even if for/of loops are compiled to for loops
+        // expecting arrays
+        this._classProperties.forEach((v, p) => {
+            const attr = this._attributeNameForProperty(p, v);
+            if (attr !== undefined) {
+                this._attributeToPropertyMap.set(attr, p);
+                attributes.push(attr);
+            }
+        });
+        return attributes;
+    }
+    /**
+     * Ensures the private `_classProperties` property metadata is created.
+     * In addition to `finalize` this is also called in `createProperty` to
+     * ensure the `@property` decorator can add property metadata.
+     */
+    /** @nocollapse */
+    static _ensureClassProperties() {
+        // ensure private storage for property declarations.
+        if (!this.hasOwnProperty(JSCompiler_renameProperty('_classProperties', this))) {
+            this._classProperties = new Map();
+            // NOTE: Workaround IE11 not supporting Map constructor argument.
+            const superProperties = Object.getPrototypeOf(this)._classProperties;
+            if (superProperties !== undefined) {
+                superProperties.forEach((v, k) => this._classProperties.set(k, v));
+            }
+        }
+    }
+    /**
+     * Creates a property accessor on the element prototype if one does not exist
+     * and stores a PropertyDeclaration for the property with the given options.
+     * The property setter calls the property's `hasChanged` property option
+     * or uses a strict identity check to determine whether or not to request
+     * an update.
+     *
+     * This method may be overridden to customize properties; however,
+     * when doing so, it's important to call `super.createProperty` to ensure
+     * the property is setup correctly. This method calls
+     * `getPropertyDescriptor` internally to get a descriptor to install.
+     * To customize what properties do when they are get or set, override
+     * `getPropertyDescriptor`. To customize the options for a property,
+     * implement `createProperty` like this:
+     *
+     * static createProperty(name, options) {
+     *   options = Object.assign(options, {myOption: true});
+     *   super.createProperty(name, options);
+     * }
+     *
+     * @nocollapse
+     */
+    static createProperty(name, options = defaultPropertyDeclaration) {
+        // Note, since this can be called by the `@property` decorator which
+        // is called before `finalize`, we ensure storage exists for property
+        // metadata.
+        this._ensureClassProperties();
+        this._classProperties.set(name, options);
+        // Do not generate an accessor if the prototype already has one, since
+        // it would be lost otherwise and that would never be the user's intention;
+        // Instead, we expect users to call `requestUpdate` themselves from
+        // user-defined accessors. Note that if the super has an accessor we will
+        // still overwrite it
+        if (options.noAccessor || this.prototype.hasOwnProperty(name)) {
+            return;
+        }
+        const key = typeof name === 'symbol' ? Symbol() : `__${name}`;
+        const descriptor = this.getPropertyDescriptor(name, key, options);
+        if (descriptor !== undefined) {
+            Object.defineProperty(this.prototype, name, descriptor);
+        }
+    }
+    /**
+     * Returns a property descriptor to be defined on the given named property.
+     * If no descriptor is returned, the property will not become an accessor.
+     * For example,
+     *
+     *   class MyElement extends LitElement {
+     *     static getPropertyDescriptor(name, key, options) {
+     *       const defaultDescriptor =
+     *           super.getPropertyDescriptor(name, key, options);
+     *       const setter = defaultDescriptor.set;
+     *       return {
+     *         get: defaultDescriptor.get,
+     *         set(value) {
+     *           setter.call(this, value);
+     *           // custom action.
+     *         },
+     *         configurable: true,
+     *         enumerable: true
+     *       }
+     *     }
+     *   }
+     *
+     * @nocollapse
+     */
+    static getPropertyDescriptor(name, key, options) {
+        return {
+            // tslint:disable-next-line:no-any no symbol in index
+            get() {
+                return this[key];
+            },
+            set(value) {
+                const oldValue = this[name];
+                this[key] = value;
+                this
+                    .requestUpdateInternal(name, oldValue, options);
+            },
+            configurable: true,
+            enumerable: true
+        };
+    }
+    /**
+     * Returns the property options associated with the given property.
+     * These options are defined with a PropertyDeclaration via the `properties`
+     * object or the `@property` decorator and are registered in
+     * `createProperty(...)`.
+     *
+     * Note, this method should be considered "final" and not overridden. To
+     * customize the options for a given property, override `createProperty`.
+     *
+     * @nocollapse
+     * @final
+     */
+    static getPropertyOptions(name) {
+        return this._classProperties && this._classProperties.get(name) ||
+            defaultPropertyDeclaration;
+    }
+    /**
+     * Creates property accessors for registered properties and ensures
+     * any superclasses are also finalized.
+     * @nocollapse
+     */
+    static finalize() {
+        // finalize any superclasses
+        const superCtor = Object.getPrototypeOf(this);
+        if (!superCtor.hasOwnProperty(finalized)) {
+            superCtor.finalize();
+        }
+        this[finalized] = true;
+        this._ensureClassProperties();
+        // initialize Map populated in observedAttributes
+        this._attributeToPropertyMap = new Map();
+        // make any properties
+        // Note, only process "own" properties since this element will inherit
+        // any properties defined on the superClass, and finalization ensures
+        // the entire prototype chain is finalized.
+        if (this.hasOwnProperty(JSCompiler_renameProperty('properties', this))) {
+            const props = this.properties;
+            // support symbols in properties (IE11 does not support this)
+            const propKeys = [
+                ...Object.getOwnPropertyNames(props),
+                ...(typeof Object.getOwnPropertySymbols === 'function') ?
+                    Object.getOwnPropertySymbols(props) :
+                    []
+            ];
+            // This for/of is ok because propKeys is an array
+            for (const p of propKeys) {
+                // note, use of `any` is due to TypeSript lack of support for symbol in
+                // index types
+                // tslint:disable-next-line:no-any no symbol in index
+                this.createProperty(p, props[p]);
+            }
+        }
+    }
+    /**
+     * Returns the property name for the given attribute `name`.
+     * @nocollapse
+     */
+    static _attributeNameForProperty(name, options) {
+        const attribute = options.attribute;
+        return attribute === false ?
+            undefined :
+            (typeof attribute === 'string' ?
+                attribute :
+                (typeof name === 'string' ? name.toLowerCase() : undefined));
+    }
+    /**
+     * Returns true if a property should request an update.
+     * Called when a property value is set and uses the `hasChanged`
+     * option for the property if present or a strict identity check.
+     * @nocollapse
+     */
+    static _valueHasChanged(value, old, hasChanged = notEqual) {
+        return hasChanged(value, old);
+    }
+    /**
+     * Returns the property value for the given attribute value.
+     * Called via the `attributeChangedCallback` and uses the property's
+     * `converter` or `converter.fromAttribute` property option.
+     * @nocollapse
+     */
+    static _propertyValueFromAttribute(value, options) {
+        const type = options.type;
+        const converter = options.converter || defaultConverter;
+        const fromAttribute = (typeof converter === 'function' ? converter : converter.fromAttribute);
+        return fromAttribute ? fromAttribute(value, type) : value;
+    }
+    /**
+     * Returns the attribute value for the given property value. If this
+     * returns undefined, the property will *not* be reflected to an attribute.
+     * If this returns null, the attribute will be removed, otherwise the
+     * attribute will be set to the value.
+     * This uses the property's `reflect` and `type.toAttribute` property options.
+     * @nocollapse
+     */
+    static _propertyValueToAttribute(value, options) {
+        if (options.reflect === undefined) {
+            return;
+        }
+        const type = options.type;
+        const converter = options.converter;
+        const toAttribute = converter && converter.toAttribute ||
+            defaultConverter.toAttribute;
+        return toAttribute(value, type);
+    }
+    /**
+     * Performs element initialization. By default captures any pre-set values for
+     * registered properties.
+     */
+    initialize() {
+        this._updateState = 0;
+        this._updatePromise =
+            new Promise((res) => this._enableUpdatingResolver = res);
+        this._changedProperties = new Map();
+        this._saveInstanceProperties();
+        // ensures first update will be caught by an early access of
+        // `updateComplete`
+        this.requestUpdateInternal();
+    }
+    /**
+     * Fixes any properties set on the instance before upgrade time.
+     * Otherwise these would shadow the accessor and break these properties.
+     * The properties are stored in a Map which is played back after the
+     * constructor runs. Note, on very old versions of Safari (<=9) or Chrome
+     * (<=41), properties created for native platform properties like (`id` or
+     * `name`) may not have default values set in the element constructor. On
+     * these browsers native properties appear on instances and therefore their
+     * default value will overwrite any element default (e.g. if the element sets
+     * this.id = 'id' in the constructor, the 'id' will become '' since this is
+     * the native platform default).
+     */
+    _saveInstanceProperties() {
+        // Use forEach so this works even if for/of loops are compiled to for loops
+        // expecting arrays
+        this.constructor
+            ._classProperties.forEach((_v, p) => {
+            if (this.hasOwnProperty(p)) {
+                const value = this[p];
+                delete this[p];
+                if (!this._instanceProperties) {
+                    this._instanceProperties = new Map();
+                }
+                this._instanceProperties.set(p, value);
+            }
+        });
+    }
+    /**
+     * Applies previously saved instance properties.
+     */
+    _applyInstanceProperties() {
+        // Use forEach so this works even if for/of loops are compiled to for loops
+        // expecting arrays
+        // tslint:disable-next-line:no-any
+        this._instanceProperties.forEach((v, p) => this[p] = v);
+        this._instanceProperties = undefined;
+    }
+    connectedCallback() {
+        // Ensure first connection completes an update. Updates cannot complete
+        // before connection.
+        this.enableUpdating();
+    }
+    enableUpdating() {
+        if (this._enableUpdatingResolver !== undefined) {
+            this._enableUpdatingResolver();
+            this._enableUpdatingResolver = undefined;
+        }
+    }
+    /**
+     * Allows for `super.disconnectedCallback()` in extensions while
+     * reserving the possibility of making non-breaking feature additions
+     * when disconnecting at some point in the future.
+     */
+    disconnectedCallback() {
+    }
+    /**
+     * Synchronizes property values when attributes change.
+     */
+    attributeChangedCallback(name, old, value) {
+        if (old !== value) {
+            this._attributeToProperty(name, value);
+        }
+    }
+    _propertyToAttribute(name, value, options = defaultPropertyDeclaration) {
+        const ctor = this.constructor;
+        const attr = ctor._attributeNameForProperty(name, options);
+        if (attr !== undefined) {
+            const attrValue = ctor._propertyValueToAttribute(value, options);
+            // an undefined value does not change the attribute.
+            if (attrValue === undefined) {
+                return;
+            }
+            // Track if the property is being reflected to avoid
+            // setting the property again via `attributeChangedCallback`. Note:
+            // 1. this takes advantage of the fact that the callback is synchronous.
+            // 2. will behave incorrectly if multiple attributes are in the reaction
+            // stack at time of calling. However, since we process attributes
+            // in `update` this should not be possible (or an extreme corner case
+            // that we'd like to discover).
+            // mark state reflecting
+            this._updateState = this._updateState | STATE_IS_REFLECTING_TO_ATTRIBUTE;
+            if (attrValue == null) {
+                this.removeAttribute(attr);
+            }
+            else {
+                this.setAttribute(attr, attrValue);
+            }
+            // mark state not reflecting
+            this._updateState = this._updateState & ~STATE_IS_REFLECTING_TO_ATTRIBUTE;
+        }
+    }
+    _attributeToProperty(name, value) {
+        // Use tracking info to avoid deserializing attribute value if it was
+        // just set from a property setter.
+        if (this._updateState & STATE_IS_REFLECTING_TO_ATTRIBUTE) {
+            return;
+        }
+        const ctor = this.constructor;
+        // Note, hint this as an `AttributeMap` so closure clearly understands
+        // the type; it has issues with tracking types through statics
+        // tslint:disable-next-line:no-unnecessary-type-assertion
+        const propName = ctor._attributeToPropertyMap.get(name);
+        if (propName !== undefined) {
+            const options = ctor.getPropertyOptions(propName);
+            // mark state reflecting
+            this._updateState = this._updateState | STATE_IS_REFLECTING_TO_PROPERTY;
+            this[propName] =
+                // tslint:disable-next-line:no-any
+                ctor._propertyValueFromAttribute(value, options);
+            // mark state not reflecting
+            this._updateState = this._updateState & ~STATE_IS_REFLECTING_TO_PROPERTY;
+        }
+    }
+    /**
+     * This protected version of `requestUpdate` does not access or return the
+     * `updateComplete` promise. This promise can be overridden and is therefore
+     * not free to access.
+     */
+    requestUpdateInternal(name, oldValue, options) {
+        let shouldRequestUpdate = true;
+        // If we have a property key, perform property update steps.
+        if (name !== undefined) {
+            const ctor = this.constructor;
+            options = options || ctor.getPropertyOptions(name);
+            if (ctor._valueHasChanged(this[name], oldValue, options.hasChanged)) {
+                if (!this._changedProperties.has(name)) {
+                    this._changedProperties.set(name, oldValue);
+                }
+                // Add to reflecting properties set.
+                // Note, it's important that every change has a chance to add the
+                // property to `_reflectingProperties`. This ensures setting
+                // attribute + property reflects correctly.
+                if (options.reflect === true &&
+                    !(this._updateState & STATE_IS_REFLECTING_TO_PROPERTY)) {
+                    if (this._reflectingProperties === undefined) {
+                        this._reflectingProperties = new Map();
+                    }
+                    this._reflectingProperties.set(name, options);
+                }
+            }
+            else {
+                // Abort the request if the property should not be considered changed.
+                shouldRequestUpdate = false;
+            }
+        }
+        if (!this._hasRequestedUpdate && shouldRequestUpdate) {
+            this._updatePromise = this._enqueueUpdate();
+        }
+    }
+    /**
+     * Requests an update which is processed asynchronously. This should
+     * be called when an element should update based on some state not triggered
+     * by setting a property. In this case, pass no arguments. It should also be
+     * called when manually implementing a property setter. In this case, pass the
+     * property `name` and `oldValue` to ensure that any configured property
+     * options are honored. Returns the `updateComplete` Promise which is resolved
+     * when the update completes.
+     *
+     * @param name {PropertyKey} (optional) name of requesting property
+     * @param oldValue {any} (optional) old value of requesting property
+     * @returns {Promise} A Promise that is resolved when the update completes.
+     */
+    requestUpdate(name, oldValue) {
+        this.requestUpdateInternal(name, oldValue);
+        return this.updateComplete;
+    }
+    /**
+     * Sets up the element to asynchronously update.
+     */
+    async _enqueueUpdate() {
+        this._updateState = this._updateState | STATE_UPDATE_REQUESTED;
+        try {
+            // Ensure any previous update has resolved before updating.
+            // This `await` also ensures that property changes are batched.
+            await this._updatePromise;
+        }
+        catch (e) {
+            // Ignore any previous errors. We only care that the previous cycle is
+            // done. Any error should have been handled in the previous update.
+        }
+        const result = this.performUpdate();
+        // If `performUpdate` returns a Promise, we await it. This is done to
+        // enable coordinating updates with a scheduler. Note, the result is
+        // checked to avoid delaying an additional microtask unless we need to.
+        if (result != null) {
+            await result;
+        }
+        return !this._hasRequestedUpdate;
+    }
+    get _hasRequestedUpdate() {
+        return (this._updateState & STATE_UPDATE_REQUESTED);
+    }
+    get hasUpdated() {
+        return (this._updateState & STATE_HAS_UPDATED);
+    }
+    /**
+     * Performs an element update. Note, if an exception is thrown during the
+     * update, `firstUpdated` and `updated` will not be called.
+     *
+     * You can override this method to change the timing of updates. If this
+     * method is overridden, `super.performUpdate()` must be called.
+     *
+     * For instance, to schedule updates to occur just before the next frame:
+     *
+     * ```
+     * protected async performUpdate(): Promise<unknown> {
+     *   await new Promise((resolve) => requestAnimationFrame(() => resolve()));
+     *   super.performUpdate();
+     * }
+     * ```
+     */
+    performUpdate() {
+        // Abort any update if one is not pending when this is called.
+        // This can happen if `performUpdate` is called early to "flush"
+        // the update.
+        if (!this._hasRequestedUpdate) {
+            return;
+        }
+        // Mixin instance properties once, if they exist.
+        if (this._instanceProperties) {
+            this._applyInstanceProperties();
+        }
+        let shouldUpdate = false;
+        const changedProperties = this._changedProperties;
+        try {
+            shouldUpdate = this.shouldUpdate(changedProperties);
+            if (shouldUpdate) {
+                this.update(changedProperties);
+            }
+            else {
+                this._markUpdated();
+            }
+        }
+        catch (e) {
+            // Prevent `firstUpdated` and `updated` from running when there's an
+            // update exception.
+            shouldUpdate = false;
+            // Ensure element can accept additional updates after an exception.
+            this._markUpdated();
+            throw e;
+        }
+        if (shouldUpdate) {
+            if (!(this._updateState & STATE_HAS_UPDATED)) {
+                this._updateState = this._updateState | STATE_HAS_UPDATED;
+                this.firstUpdated(changedProperties);
+            }
+            this.updated(changedProperties);
+        }
+    }
+    _markUpdated() {
+        this._changedProperties = new Map();
+        this._updateState = this._updateState & ~STATE_UPDATE_REQUESTED;
+    }
+    /**
+     * Returns a Promise that resolves when the element has completed updating.
+     * The Promise value is a boolean that is `true` if the element completed the
+     * update without triggering another update. The Promise result is `false` if
+     * a property was set inside `updated()`. If the Promise is rejected, an
+     * exception was thrown during the update.
+     *
+     * To await additional asynchronous work, override the `_getUpdateComplete`
+     * method. For example, it is sometimes useful to await a rendered element
+     * before fulfilling this Promise. To do this, first await
+     * `super._getUpdateComplete()`, then any subsequent state.
+     *
+     * @returns {Promise} The Promise returns a boolean that indicates if the
+     * update resolved without triggering another update.
+     */
+    get updateComplete() {
+        return this._getUpdateComplete();
+    }
+    /**
+     * Override point for the `updateComplete` promise.
+     *
+     * It is not safe to override the `updateComplete` getter directly due to a
+     * limitation in TypeScript which means it is not possible to call a
+     * superclass getter (e.g. `super.updateComplete.then(...)`) when the target
+     * language is ES5 (https://github.com/microsoft/TypeScript/issues/338).
+     * This method should be overridden instead. For example:
+     *
+     *   class MyElement extends LitElement {
+     *     async _getUpdateComplete() {
+     *       await super._getUpdateComplete();
+     *       await this._myChild.updateComplete;
+     *     }
+     *   }
+     */
+    _getUpdateComplete() {
+        return this._updatePromise;
+    }
+    /**
+     * Controls whether or not `update` should be called when the element requests
+     * an update. By default, this method always returns `true`, but this can be
+     * customized to control when to update.
+     *
+     * @param _changedProperties Map of changed properties with old values
+     */
+    shouldUpdate(_changedProperties) {
+        return true;
+    }
+    /**
+     * Updates the element. This method reflects property values to attributes.
+     * It can be overridden to render and keep updated element DOM.
+     * Setting properties inside this method will *not* trigger
+     * another update.
+     *
+     * @param _changedProperties Map of changed properties with old values
+     */
+    update(_changedProperties) {
+        if (this._reflectingProperties !== undefined &&
+            this._reflectingProperties.size > 0) {
+            // Use forEach so this works even if for/of loops are compiled to for
+            // loops expecting arrays
+            this._reflectingProperties.forEach((v, k) => this._propertyToAttribute(k, this[k], v));
+            this._reflectingProperties = undefined;
+        }
+        this._markUpdated();
+    }
+    /**
+     * Invoked whenever the element is updated. Implement to perform
+     * post-updating tasks via DOM APIs, for example, focusing an element.
+     *
+     * Setting properties inside this method will trigger the element to update
+     * again after this update cycle completes.
+     *
+     * @param _changedProperties Map of changed properties with old values
+     */
+    updated(_changedProperties) {
+    }
+    /**
+     * Invoked when the element is first updated. Implement to perform one time
+     * work on the element after update.
+     *
+     * Setting properties inside this method will trigger the element to update
+     * again after this update cycle completes.
+     *
+     * @param _changedProperties Map of changed properties with old values
+     */
+    firstUpdated(_changedProperties) {
+    }
+}
+_a = finalized;
+/**
+ * Marks class as having finished creating properties.
+ */
+UpdatingElement[_a] = true;
+
+/**
+@license
+Copyright (c) 2019 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
+*/
+/**
+ * Whether the current browser supports `adoptedStyleSheets`.
+ */
+const supportsAdoptingStyleSheets = (window.ShadowRoot) &&
+    (window.ShadyCSS === undefined || window.ShadyCSS.nativeShadow) &&
+    ('adoptedStyleSheets' in Document.prototype) &&
+    ('replace' in CSSStyleSheet.prototype);
+const constructionToken = Symbol();
+class CSSResult {
+    constructor(cssText, safeToken) {
+        if (safeToken !== constructionToken) {
+            throw new Error('CSSResult is not constructable. Use `unsafeCSS` or `css` instead.');
+        }
+        this.cssText = cssText;
+    }
+    // Note, this is a getter so that it's lazy. In practice, this means
+    // stylesheets are not created until the first element instance is made.
+    get styleSheet() {
+        if (this._styleSheet === undefined) {
+            // Note, if `supportsAdoptingStyleSheets` is true then we assume
+            // CSSStyleSheet is constructable.
+            if (supportsAdoptingStyleSheets) {
+                this._styleSheet = new CSSStyleSheet();
+                this._styleSheet.replaceSync(this.cssText);
+            }
+            else {
+                this._styleSheet = null;
+            }
+        }
+        return this._styleSheet;
+    }
+    toString() {
+        return this.cssText;
+    }
+}
+/**
+ * Wrap a value for interpolation in a [[`css`]] tagged template literal.
+ *
+ * This is unsafe because untrusted CSS text can be used to phone home
+ * or exfiltrate data to an attacker controlled site. Take care to only use
+ * this with trusted input.
+ */
+const unsafeCSS = (value) => {
+    return new CSSResult(String(value), constructionToken);
+};
+const textFromCSSResult = (value) => {
+    if (value instanceof CSSResult) {
+        return value.cssText;
+    }
+    else if (typeof value === 'number') {
+        return value;
+    }
+    else {
+        throw new Error(`Value passed to 'css' function must be a 'css' function result: ${value}. Use 'unsafeCSS' to pass non-literal values, but
+            take care to ensure page security.`);
+    }
+};
+/**
+ * Template tag which which can be used with LitElement's [[LitElement.styles |
+ * `styles`]] property to set element styles. For security reasons, only literal
+ * string values may be used. To incorporate non-literal values [[`unsafeCSS`]]
+ * may be used inside a template string part.
+ */
+const css = (strings, ...values) => {
+    const cssText = values.reduce((acc, v, idx) => acc + textFromCSSResult(v) + strings[idx + 1], strings[0]);
+    return new CSSResult(cssText, constructionToken);
+};
+
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+// IMPORTANT: do not change the property name or the assignment expression.
+// This line will be used in regexes to search for LitElement usage.
+// TODO(justinfagnani): inject version number at build time
+(window['litElementVersions'] || (window['litElementVersions'] = []))
+    .push('2.4.0');
+/**
+ * Sentinal value used to avoid calling lit-html's render function when
+ * subclasses do not implement `render`
+ */
+const renderNotImplemented = {};
+/**
+ * Base element class that manages element properties and attributes, and
+ * renders a lit-html template.
+ *
+ * To define a component, subclass `LitElement` and implement a
+ * `render` method to provide the component's template. Define properties
+ * using the [[`properties`]] property or the [[`property`]] decorator.
+ */
+class LitElement extends UpdatingElement {
+    /**
+     * Return the array of styles to apply to the element.
+     * Override this method to integrate into a style management system.
+     *
+     * @nocollapse
+     */
+    static getStyles() {
+        return this.styles;
+    }
+    /** @nocollapse */
+    static _getUniqueStyles() {
+        // Only gather styles once per class
+        if (this.hasOwnProperty(JSCompiler_renameProperty('_styles', this))) {
+            return;
+        }
+        // Take care not to call `this.getStyles()` multiple times since this
+        // generates new CSSResults each time.
+        // TODO(sorvell): Since we do not cache CSSResults by input, any
+        // shared styles will generate new stylesheet objects, which is wasteful.
+        // This should be addressed when a browser ships constructable
+        // stylesheets.
+        const userStyles = this.getStyles();
+        if (Array.isArray(userStyles)) {
+            // De-duplicate styles preserving the _last_ instance in the set.
+            // This is a performance optimization to avoid duplicated styles that can
+            // occur especially when composing via subclassing.
+            // The last item is kept to try to preserve the cascade order with the
+            // assumption that it's most important that last added styles override
+            // previous styles.
+            const addStyles = (styles, set) => styles.reduceRight((set, s) => 
+            // Note: On IE set.add() does not return the set
+            Array.isArray(s) ? addStyles(s, set) : (set.add(s), set), set);
+            // Array.from does not work on Set in IE, otherwise return
+            // Array.from(addStyles(userStyles, new Set<CSSResult>())).reverse()
+            const set = addStyles(userStyles, new Set());
+            const styles = [];
+            set.forEach((v) => styles.unshift(v));
+            this._styles = styles;
+        }
+        else {
+            this._styles = userStyles === undefined ? [] : [userStyles];
+        }
+        // Ensure that there are no invalid CSSStyleSheet instances here. They are
+        // invalid in two conditions.
+        // (1) the sheet is non-constructible (`sheet` of a HTMLStyleElement), but
+        //     this is impossible to check except via .replaceSync or use
+        // (2) the ShadyCSS polyfill is enabled (:. supportsAdoptingStyleSheets is
+        //     false)
+        this._styles = this._styles.map((s) => {
+            if (s instanceof CSSStyleSheet && !supportsAdoptingStyleSheets) {
+                // Flatten the cssText from the passed constructible stylesheet (or
+                // undetectable non-constructible stylesheet). The user might have
+                // expected to update their stylesheets over time, but the alternative
+                // is a crash.
+                const cssText = Array.prototype.slice.call(s.cssRules)
+                    .reduce((css, rule) => css + rule.cssText, '');
+                return unsafeCSS(cssText);
+            }
+            return s;
+        });
+    }
+    /**
+     * Performs element initialization. By default this calls
+     * [[`createRenderRoot`]] to create the element [[`renderRoot`]] node and
+     * captures any pre-set values for registered properties.
+     */
+    initialize() {
+        super.initialize();
+        this.constructor._getUniqueStyles();
+        this.renderRoot = this.createRenderRoot();
+        // Note, if renderRoot is not a shadowRoot, styles would/could apply to the
+        // element's getRootNode(). While this could be done, we're choosing not to
+        // support this now since it would require different logic around de-duping.
+        if (window.ShadowRoot && this.renderRoot instanceof window.ShadowRoot) {
+            this.adoptStyles();
+        }
+    }
+    /**
+     * Returns the node into which the element should render and by default
+     * creates and returns an open shadowRoot. Implement to customize where the
+     * element's DOM is rendered. For example, to render into the element's
+     * childNodes, return `this`.
+     * @returns {Element|DocumentFragment} Returns a node into which to render.
+     */
+    createRenderRoot() {
+        return this.attachShadow({ mode: 'open' });
+    }
+    /**
+     * Applies styling to the element shadowRoot using the [[`styles`]]
+     * property. Styling will apply using `shadowRoot.adoptedStyleSheets` where
+     * available and will fallback otherwise. When Shadow DOM is polyfilled,
+     * ShadyCSS scopes styles and adds them to the document. When Shadow DOM
+     * is available but `adoptedStyleSheets` is not, styles are appended to the
+     * end of the `shadowRoot` to [mimic spec
+     * behavior](https://wicg.github.io/construct-stylesheets/#using-constructed-stylesheets).
+     */
+    adoptStyles() {
+        const styles = this.constructor._styles;
+        if (styles.length === 0) {
+            return;
+        }
+        // There are three separate cases here based on Shadow DOM support.
+        // (1) shadowRoot polyfilled: use ShadyCSS
+        // (2) shadowRoot.adoptedStyleSheets available: use it
+        // (3) shadowRoot.adoptedStyleSheets polyfilled: append styles after
+        // rendering
+        if (window.ShadyCSS !== undefined && !window.ShadyCSS.nativeShadow) {
+            window.ShadyCSS.ScopingShim.prepareAdoptedCssText(styles.map((s) => s.cssText), this.localName);
+        }
+        else if (supportsAdoptingStyleSheets) {
+            this.renderRoot.adoptedStyleSheets =
+                styles.map((s) => s instanceof CSSStyleSheet ? s : s.styleSheet);
+        }
+        else {
+            // This must be done after rendering so the actual style insertion is done
+            // in `update`.
+            this._needsShimAdoptedStyleSheets = true;
+        }
+    }
+    connectedCallback() {
+        super.connectedCallback();
+        // Note, first update/render handles styleElement so we only call this if
+        // connected after first update.
+        if (this.hasUpdated && window.ShadyCSS !== undefined) {
+            window.ShadyCSS.styleElement(this);
+        }
+    }
+    /**
+     * Updates the element. This method reflects property values to attributes
+     * and calls `render` to render DOM via lit-html. Setting properties inside
+     * this method will *not* trigger another update.
+     * @param _changedProperties Map of changed properties with old values
+     */
+    update(changedProperties) {
+        // Setting properties in `render` should not trigger an update. Since
+        // updates are allowed after super.update, it's important to call `render`
+        // before that.
+        const templateResult = this.render();
+        super.update(changedProperties);
+        // If render is not implemented by the component, don't call lit-html render
+        if (templateResult !== renderNotImplemented) {
+            this.constructor
+                .render(templateResult, this.renderRoot, { scopeName: this.localName, eventContext: this });
+        }
+        // When native Shadow DOM is used but adoptedStyles are not supported,
+        // insert styling after rendering to ensure adoptedStyles have highest
+        // priority.
+        if (this._needsShimAdoptedStyleSheets) {
+            this._needsShimAdoptedStyleSheets = false;
+            this.constructor._styles.forEach((s) => {
+                const style = document.createElement('style');
+                style.textContent = s.cssText;
+                this.renderRoot.appendChild(style);
+            });
+        }
+    }
+    /**
+     * Invoked on each update to perform rendering tasks. This method may return
+     * any value renderable by lit-html's `NodePart` - typically a
+     * `TemplateResult`. Setting properties inside this method will *not* trigger
+     * the element to update.
+     */
+    render() {
+        return renderNotImplemented;
+    }
+}
+/**
+ * Ensure this class is marked as `finalized` as an optimization ensuring
+ * it will not needlessly try to `finalize`.
+ *
+ * Note this property name is a string to prevent breaking Closure JS Compiler
+ * optimizations. See updating-element.ts for more information.
+ */
+LitElement['finalized'] = true;
+/**
+ * Reference to the underlying library method used to render the element's
+ * DOM. By default, points to the `render` method from lit-html's shady-render
+ * module.
+ *
+ * **Most users will never need to touch this property.**
+ *
+ * This  property should not be confused with the `render` instance method,
+ * which should be overridden to define a template for the element.
+ *
+ * Advanced users creating a new base class based on LitElement can override
+ * this property to point to a custom render method with a signature that
+ * matches [shady-render's `render`
+ * method](https://lit-html.polymer-project.org/api/modules/shady_render.html#render).
+ *
+ * @nocollapse
+ */
+LitElement.render = render$1;
+
+export { AttributePart as A, LitElement as L, NodePart as N, PropertyPart as P, noChange as a, css as c, directive as d, html as h, nothing as n, templateFactory as t };

--- a/build/web_modules/common/ripple-handlers-866d8381.js
+++ b/build/web_modules/common/ripple-handlers-866d8381.js
@@ -1,0 +1,316 @@
+import { _ as __decorate } from './tslib.es6-d0741f12.js';
+import { h as html, c as css } from './lit-element-58192bd6.js';
+import { q as query, p as property, i as internalProperty, b as classMap, c as customElement } from './class-map-b1acbdf1.js';
+import { B as BaseElement } from './base-element-787f0cf8.js';
+import { M as MDCRippleFoundation } from './foundation-d04c4372.js';
+import { s as styleMap } from './style-map-e65726ec.js';
+
+/** @soyCompatible */
+class RippleBase extends BaseElement {
+    constructor() {
+        super(...arguments);
+        this.primary = false;
+        this.accent = false;
+        this.unbounded = false;
+        this.disabled = false;
+        this.activated = false;
+        this.selected = false;
+        this.hovering = false;
+        this.bgFocused = false;
+        this.fgActivation = false;
+        this.fgDeactivation = false;
+        this.fgScale = '';
+        this.fgSize = '';
+        this.translateStart = '';
+        this.translateEnd = '';
+        this.leftPos = '';
+        this.topPos = '';
+        this.mdcFoundationClass = MDCRippleFoundation;
+    }
+    get isActive() {
+        return (this.parentElement || this).matches(':active');
+    }
+    createAdapter() {
+        return {
+            browserSupportsCssVars: () => true,
+            isUnbounded: () => this.unbounded,
+            isSurfaceActive: () => this.isActive,
+            isSurfaceDisabled: () => this.disabled,
+            addClass: (className) => {
+                switch (className) {
+                    case 'mdc-ripple-upgraded--background-focused':
+                        this.bgFocused = true;
+                        break;
+                    case 'mdc-ripple-upgraded--foreground-activation':
+                        this.fgActivation = true;
+                        break;
+                    case 'mdc-ripple-upgraded--foreground-deactivation':
+                        this.fgDeactivation = true;
+                        break;
+                }
+            },
+            removeClass: (className) => {
+                switch (className) {
+                    case 'mdc-ripple-upgraded--background-focused':
+                        this.bgFocused = false;
+                        break;
+                    case 'mdc-ripple-upgraded--foreground-activation':
+                        this.fgActivation = false;
+                        break;
+                    case 'mdc-ripple-upgraded--foreground-deactivation':
+                        this.fgDeactivation = false;
+                        break;
+                }
+            },
+            containsEventTarget: () => true,
+            registerInteractionHandler: () => undefined,
+            deregisterInteractionHandler: () => undefined,
+            registerDocumentInteractionHandler: () => undefined,
+            deregisterDocumentInteractionHandler: () => undefined,
+            registerResizeHandler: () => undefined,
+            deregisterResizeHandler: () => undefined,
+            updateCssVariable: (varName, value) => {
+                switch (varName) {
+                    case '--mdc-ripple-fg-scale':
+                        this.fgScale = value;
+                        break;
+                    case '--mdc-ripple-fg-size':
+                        this.fgSize = value;
+                        break;
+                    case '--mdc-ripple-fg-translate-end':
+                        this.translateEnd = value;
+                        break;
+                    case '--mdc-ripple-fg-translate-start':
+                        this.translateStart = value;
+                        break;
+                    case '--mdc-ripple-left':
+                        this.leftPos = value;
+                        break;
+                    case '--mdc-ripple-top':
+                        this.topPos = value;
+                        break;
+                }
+            },
+            computeBoundingRect: () => (this.parentElement || this).getBoundingClientRect(),
+            getWindowPageOffset: () => ({ x: window.pageXOffset, y: window.pageYOffset }),
+        };
+    }
+    startPress(ev) {
+        this.waitForFoundation(() => {
+            this.mdcFoundation.activate(ev);
+        });
+    }
+    endPress() {
+        this.waitForFoundation(() => {
+            this.mdcFoundation.deactivate();
+        });
+    }
+    startFocus() {
+        this.waitForFoundation(() => {
+            this.mdcFoundation.handleFocus();
+        });
+    }
+    endFocus() {
+        this.waitForFoundation(() => {
+            this.mdcFoundation.handleBlur();
+        });
+    }
+    startHover() {
+        this.hovering = true;
+    }
+    endHover() {
+        this.hovering = false;
+    }
+    /**
+     * Wait for the MDCFoundation to be created by `firstUpdated`
+     */
+    waitForFoundation(fn) {
+        if (this.mdcFoundation) {
+            fn();
+        }
+        else {
+            this.updateComplete.then(fn);
+        }
+    }
+    /** @soyTemplate */
+    render() {
+        /** @classMap */
+        const classes = {
+            'mdc-ripple-upgraded--unbounded': this.unbounded,
+            'mdc-ripple-upgraded--background-focused': this.bgFocused,
+            'mdc-ripple-upgraded--foreground-activation': this.fgActivation,
+            'mdc-ripple-upgraded--foreground-deactivation': this.fgDeactivation,
+            'hover': this.hovering,
+            'primary': this.primary,
+            'accent': this.accent,
+            'disabled': this.disabled,
+            'activated': this.activated,
+            'selected': this.selected,
+        };
+        return html `
+        <div class="mdc-ripple-surface mdc-ripple-upgraded ${classMap(classes)}"
+          style="${styleMap({
+            '--mdc-ripple-fg-scale': this.fgScale,
+            '--mdc-ripple-fg-size': this.fgSize,
+            '--mdc-ripple-fg-translate-end': this.translateEnd,
+            '--mdc-ripple-fg-translate-start': this.translateStart,
+            '--mdc-ripple-left': this.leftPos,
+            '--mdc-ripple-top': this.topPos,
+        })}"></div>`;
+    }
+}
+__decorate([
+    query('.mdc-ripple-surface')
+], RippleBase.prototype, "mdcRoot", void 0);
+__decorate([
+    property({ type: Boolean })
+], RippleBase.prototype, "primary", void 0);
+__decorate([
+    property({ type: Boolean })
+], RippleBase.prototype, "accent", void 0);
+__decorate([
+    property({ type: Boolean })
+], RippleBase.prototype, "unbounded", void 0);
+__decorate([
+    property({ type: Boolean })
+], RippleBase.prototype, "disabled", void 0);
+__decorate([
+    property({ type: Boolean })
+], RippleBase.prototype, "activated", void 0);
+__decorate([
+    property({ type: Boolean })
+], RippleBase.prototype, "selected", void 0);
+__decorate([
+    internalProperty()
+], RippleBase.prototype, "hovering", void 0);
+__decorate([
+    internalProperty()
+], RippleBase.prototype, "bgFocused", void 0);
+__decorate([
+    internalProperty()
+], RippleBase.prototype, "fgActivation", void 0);
+__decorate([
+    internalProperty()
+], RippleBase.prototype, "fgDeactivation", void 0);
+__decorate([
+    internalProperty()
+], RippleBase.prototype, "fgScale", void 0);
+__decorate([
+    internalProperty()
+], RippleBase.prototype, "fgSize", void 0);
+__decorate([
+    internalProperty()
+], RippleBase.prototype, "translateStart", void 0);
+__decorate([
+    internalProperty()
+], RippleBase.prototype, "translateEnd", void 0);
+__decorate([
+    internalProperty()
+], RippleBase.prototype, "leftPos", void 0);
+__decorate([
+    internalProperty()
+], RippleBase.prototype, "topPos", void 0);
+
+/**
+@license
+Copyright 2018 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+const style = css `:host{display:block;position:absolute;top:0;bottom:0;left:0;right:0;width:100%;height:100%;pointer-events:none}@keyframes mdc-ripple-fg-radius-in{from{animation-timing-function:cubic-bezier(0.4, 0, 0.2, 1);transform:translate(var(--mdc-ripple-fg-translate-start, 0)) scale(1)}to{transform:translate(var(--mdc-ripple-fg-translate-end, 0)) scale(var(--mdc-ripple-fg-scale, 1))}}@keyframes mdc-ripple-fg-opacity-in{from{animation-timing-function:linear;opacity:0}to{opacity:var(--mdc-ripple-fg-opacity, 0)}}@keyframes mdc-ripple-fg-opacity-out{from{animation-timing-function:linear;opacity:var(--mdc-ripple-fg-opacity, 0)}to{opacity:0}}:host .primary{--mdc-ripple-color: var(--mdc-theme-primary, #6200ee)}:host .accent{--mdc-ripple-color: var( --mdc-theme-secondary, #018786 )}:host .mdc-ripple-surface{top:0;bottom:0;left:0;right:0;width:100%;height:100%;pointer-events:none;--mdc-ripple-fg-size: 0;--mdc-ripple-left: 0;--mdc-ripple-top: 0;--mdc-ripple-fg-scale: 1;--mdc-ripple-fg-translate-end: 0;--mdc-ripple-fg-translate-start: 0;-webkit-tap-highlight-color:rgba(0,0,0,0);will-change:transform,opacity;position:relative;outline:none;overflow:hidden;--mdc-ripple-fg-opacity: var( --mdc-ripple-press-opacity, 0.12 )}:host .mdc-ripple-surface::before,:host .mdc-ripple-surface::after{position:absolute;border-radius:50%;opacity:0;pointer-events:none;content:""}:host .mdc-ripple-surface::before{transition:opacity 15ms linear,background-color 15ms linear;z-index:1}:host .mdc-ripple-surface.mdc-ripple-upgraded::before{transform:scale(var(--mdc-ripple-fg-scale, 1))}:host .mdc-ripple-surface.mdc-ripple-upgraded::after{top:0;left:0;transform:scale(0);transform-origin:center center}:host .mdc-ripple-surface.mdc-ripple-upgraded--unbounded::after{top:var(--mdc-ripple-top, 0);left:var(--mdc-ripple-left, 0)}:host .mdc-ripple-surface.mdc-ripple-upgraded--foreground-activation::after{animation:mdc-ripple-fg-radius-in 225ms forwards,mdc-ripple-fg-opacity-in 75ms forwards}:host .mdc-ripple-surface.mdc-ripple-upgraded--foreground-deactivation::after{animation:mdc-ripple-fg-opacity-out 150ms;transform:translate(var(--mdc-ripple-fg-translate-end, 0)) scale(var(--mdc-ripple-fg-scale, 1))}:host .mdc-ripple-surface::before,:host .mdc-ripple-surface::after{top:calc(50% - 100%);left:calc(50% - 100%);width:200%;height:200%}:host .mdc-ripple-surface.mdc-ripple-upgraded::after{width:var(--mdc-ripple-fg-size, 100%);height:var(--mdc-ripple-fg-size, 100%)}:host .mdc-ripple-surface.mdc-ripple-upgraded--unbounded{overflow:visible}:host .mdc-ripple-surface.mdc-ripple-upgraded--unbounded::before,:host .mdc-ripple-surface.mdc-ripple-upgraded--unbounded::after{top:calc(50% - 50%);left:calc(50% - 50%);width:100%;height:100%}:host .mdc-ripple-surface.mdc-ripple-upgraded--unbounded.mdc-ripple-upgraded::before,:host .mdc-ripple-surface.mdc-ripple-upgraded--unbounded.mdc-ripple-upgraded::after{top:var(--mdc-ripple-top, calc(50% - 50%));left:var(--mdc-ripple-left, calc(50% - 50%));width:var(--mdc-ripple-fg-size, 100%);height:var(--mdc-ripple-fg-size, 100%)}:host .mdc-ripple-surface.mdc-ripple-upgraded--unbounded.mdc-ripple-upgraded::after{width:var(--mdc-ripple-fg-size, 100%);height:var(--mdc-ripple-fg-size, 100%)}:host .mdc-ripple-surface.hover::before{opacity:0.04;opacity:var(--mdc-ripple-hover-opacity, 0.04)}:host .mdc-ripple-surface.mdc-ripple-upgraded--background-focused::before{opacity:0.12;opacity:var(--mdc-ripple-focus-opacity, 0.12)}:host .mdc-ripple-surface::before,:host .mdc-ripple-surface::after{background-color:#000;background-color:var(--mdc-ripple-color, #000)}:host .mdc-ripple-surface.activated{--mdc-ripple-press-opacity: calc( var(--mdc-ripple-press-opacity, 0.12) + 0.12 )}:host .mdc-ripple-surface.activated::before{opacity:0.12;opacity:var(--mdc-ripple-activated-opacity, 0.12)}:host .mdc-ripple-surface.activated.hover::before{opacity:.16;opacity:calc( var(--mdc-ripple-hover-opacity, 0.04) + var(--mdc-ripple-activated-opacity, 0.12) )}:host .mdc-ripple-surface.activated.mdc-ripple-upgraded--background-focused::before{opacity:.24;opacity:calc( var(--mdc-ripple-focus-opacity, 0.12) + var(--mdc-ripple-activated-opacity, 0.12) )}:host .mdc-ripple-surface.selected{--mdc-ripple-press-opacity: calc( var(--mdc-ripple-press-opacity, 0.12) + 0.08 )}:host .mdc-ripple-surface.selected::before{opacity:0.08;opacity:var(--mdc-ripple-selected-opacity, 0.08)}:host .mdc-ripple-surface.selected.hover::before{opacity:.12;opacity:calc( var(--mdc-ripple-hover-opacity, 0.04) + var(--mdc-ripple-selected-opacity, 0.08) )}:host .mdc-ripple-surface.selected.mdc-ripple-upgraded--background-focused::before{opacity:.2;opacity:calc( var(--mdc-ripple-focus-opacity, 0.12) + var(--mdc-ripple-selected-opacity, 0.08) )}:host .mdc-ripple-surface.disabled{--mdc-ripple-color: transparent}:host .mdc-ripple-surface::before{z-index:1;z-index:var(--m-ripple-z-index, 1)}:host .mdc-ripple-surface::after{z-index:0;z-index:var(--m-ripple-z-index, 0)}`;
+
+/** @soyCompatible */
+let Ripple = class Ripple extends RippleBase {
+};
+Ripple.styles = style;
+Ripple = __decorate([
+    customElement('mwc-ripple')
+], Ripple);
+
+/**
+@license
+Copyright 2020 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/**
+ * Class that encapsulates the events handlers for `mwc-ripple`
+ *
+ *
+ * Example:
+ * ```
+ * class XFoo extends LitElement {
+ *   async getRipple() {
+ *     this.renderRipple = true;
+ *     await this.updateComplete;
+ *     return this.renderRoot.querySelector('mwc-ripple');
+ *   }
+ *   rippleHandlers = new RippleHandlers(() => this.getRipple());
+ *
+ *   render() {
+ *     return html`
+ *       <div @mousedown=${this.rippleHandlers.startPress}></div>
+ *       ${this.renderRipple ? html`<mwc-ripple></mwc-ripple>` : ''}
+ *     `;
+ *   }
+ * }
+ * ```
+ */
+class RippleHandlers {
+    constructor(
+    /** Function that returns a `mwc-ripple` */
+    rippleFn) {
+        this.startPress = (ev) => {
+            rippleFn().then((r) => {
+                r && r.startPress(ev);
+            });
+        };
+        this.endPress = () => {
+            rippleFn().then((r) => {
+                r && r.endPress();
+            });
+        };
+        this.startFocus = () => {
+            rippleFn().then((r) => {
+                r && r.startFocus();
+            });
+        };
+        this.endFocus = () => {
+            rippleFn().then((r) => {
+                r && r.endFocus();
+            });
+        };
+        this.startHover = () => {
+            rippleFn().then((r) => {
+                r && r.startHover();
+            });
+        };
+        this.endHover = () => {
+            rippleFn().then((r) => {
+                r && r.endHover();
+            });
+        };
+    }
+}
+
+export { RippleHandlers as R };

--- a/build/web_modules/common/style-map-e65726ec.js
+++ b/build/web_modules/common/style-map-e65726ec.js
@@ -1,0 +1,80 @@
+import { d as directive, A as AttributePart, P as PropertyPart } from './lit-element-58192bd6.js';
+
+/**
+ * @license
+ * Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+/**
+ * Stores the StyleInfo object applied to a given AttributePart.
+ * Used to unset existing values when a new StyleInfo object is applied.
+ */
+const previousStylePropertyCache = new WeakMap();
+/**
+ * A directive that applies CSS properties to an element.
+ *
+ * `styleMap` can only be used in the `style` attribute and must be the only
+ * expression in the attribute. It takes the property names in the `styleInfo`
+ * object and adds the property values as CSS properties. Property names with
+ * dashes (`-`) are assumed to be valid CSS property names and set on the
+ * element's style object using `setProperty()`. Names without dashes are
+ * assumed to be camelCased JavaScript property names and set on the element's
+ * style object using property assignment, allowing the style object to
+ * translate JavaScript-style names to CSS property names.
+ *
+ * For example `styleMap({backgroundColor: 'red', 'border-top': '5px', '--size':
+ * '0'})` sets the `background-color`, `border-top` and `--size` properties.
+ *
+ * @param styleInfo {StyleInfo}
+ */
+const styleMap = directive((styleInfo) => (part) => {
+    if (!(part instanceof AttributePart) || (part instanceof PropertyPart) ||
+        part.committer.name !== 'style' || part.committer.parts.length > 1) {
+        throw new Error('The `styleMap` directive must be used in the style attribute ' +
+            'and must be the only part in the attribute.');
+    }
+    const { committer } = part;
+    const { style } = committer.element;
+    let previousStyleProperties = previousStylePropertyCache.get(part);
+    if (previousStyleProperties === undefined) {
+        // Write static styles once
+        style.cssText = committer.strings.join(' ');
+        previousStylePropertyCache.set(part, previousStyleProperties = new Set());
+    }
+    // Remove old properties that no longer exist in styleInfo
+    // We use forEach() instead of for-of so that re don't require down-level
+    // iteration.
+    previousStyleProperties.forEach((name) => {
+        if (!(name in styleInfo)) {
+            previousStyleProperties.delete(name);
+            if (name.indexOf('-') === -1) {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                style[name] = null;
+            }
+            else {
+                style.removeProperty(name);
+            }
+        }
+    });
+    // Add or update properties
+    for (const name in styleInfo) {
+        previousStyleProperties.add(name);
+        if (name.indexOf('-') === -1) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            style[name] = styleInfo[name];
+        }
+        else {
+            style.setProperty(name, styleInfo[name]);
+        }
+    }
+});
+
+export { styleMap as s };

--- a/build/web_modules/kalman-filter/lib/kalman-filter.js
+++ b/build/web_modules/kalman-filter/lib/kalman-filter.js
@@ -1,0 +1,5158 @@
+/**
+*Returns the corresponding matrix in dim*1, given an dim matrix, and checks
+* if corresponding with the observation dimension
+*@param {Array.<Number> | Array.<Array.<Number>>} observation
+*@param {Number} dimension
+*@returns {Array.<Array.<Number>>}
+*/
+
+var arrayToMatrix = function ({observation, dimension}) {
+	if (!Array.isArray(observation)) {
+		if (dimension === 1 && typeof (observation) === 'number') {
+			return [[observation]];
+		}
+
+		throw (new TypeError(`The observation (${observation}) should be an array (dimension: ${dimension})`));
+	}
+
+	if (observation.length !== dimension) {
+		throw (new TypeError(`Observation (${observation.length}) and dimension (${dimension}) not matching`));
+	}
+
+	if (typeof (observation[0]) === 'number' || observation[0] === null) {
+		return observation.map(element => [element]);
+	}
+
+	return observation;
+};
+
+/**
+*Verifies that dimensions are matching and set dynamic.dimension and observation.dimension
+* with respect of stateProjection and transition dimensions
+*@param {ObservationConfig} observation
+*@param {DynamicConfig} dynamic
+*@returns {ObservationConfig, DynamicConfig}
+*/
+
+var setDimensions = function ({observation, dynamic}) {
+	const {stateProjection} = observation;
+	const {transition} = dynamic;
+	const dynamicDimension = dynamic.dimension;
+	const observationDimension = observation.dimension;
+
+	if (dynamicDimension && observationDimension && Array.isArray(stateProjection) && (dynamicDimension !== stateProjection[0].length || observationDimension !== stateProjection.length)) {
+		throw (new TypeError('stateProjection dimensions not matching with observation and dynamic dimensions'));
+	}
+
+	if (dynamicDimension && Array.isArray(transition) && dynamicDimension !== transition.length) {
+		throw (new TypeError('transition dimension not matching with dynamic dimension'));
+	}
+
+	if (Array.isArray(stateProjection)) {
+		return {
+			observation: Object.assign({}, observation, {
+				dimension: stateProjection.length
+			}),
+			dynamic: Object.assign({}, dynamic, {
+				dimension: stateProjection[0].length
+			})
+		};
+	}
+
+	if (Array.isArray(transition)) {
+		return {
+			observation,
+			dynamic: Object.assign({}, dynamic, {
+				dimension: transition.length
+			})
+		};
+	}
+
+	return {observation, dynamic};
+};
+
+/**
+*Verifies that dynamic.dimension and observation.dimension are set
+*@param {ObservationConfig} observation
+*@param {DynamicConfig} dynamic
+*/
+
+var checkDimensions = function ({observation, dynamic}) {
+	const dynamicDimension = dynamic.dimension;
+	const observationDimension = observation.dimension;
+	if (!dynamicDimension || !observationDimension) {
+		throw (new TypeError('Dimension is not set'));
+	}
+
+	return {observation, dynamic};
+};
+
+/**
+*This function returns the stateProjection paded with zeros with respect to a given
+*observedProjection
+*@param {Array.<Number> | Array.<Array.<Number>>} array the array we need to pad
+*@param {Number} dimension in our case, the dynamic dimension
+*@returns {Array.<Number> | Array.<Array.<Number>>} paded array
+*/
+var padWithZeros = function (array, {dimension}) {
+	const l1 = array.length;
+	const l = array[0].length;
+	const result = array.map(a => a.concat());
+
+	if (dimension < l) {
+		throw (new TypeError(`Dynamic dimension ${dimension} does not match with observedProjection ${l}`));
+	}
+
+	for (let i = 0; i < l1; i++) {
+		for (let j = 0; j < dimension - l; j++) {
+			result[i].push(0);
+		}
+	}
+
+	return result;
+};
+
+var identity = function (stateSize) {
+	const identityArray = [];
+	for (let i = 0; i < stateSize; i++) {
+		const rowIdentity = [];
+		for (let j = 0; j < stateSize; j++) {
+			if (i === j) {
+				rowIdentity.push(1);
+			} else {
+				rowIdentity.push(0);
+			}
+		}
+
+		identityArray.push(rowIdentity);
+	}
+
+	return identityArray;
+};
+
+/**
+*Builds the stateProjection given an observedProjection
+*@param {ObservationConfig} observation
+*@param {DynamicConfig} dynamic
+*@returns {ObservationConfig, DynamicConfig} the model containing the created stateProjection
+*/
+
+var buildStateProjection = function ({observation, dynamic}) {
+	const {observedProjection, stateProjection} = observation;
+	const observationDimension = observation.dimension;
+	const dynamicDimension = dynamic.dimension;
+	if (observedProjection && stateProjection) {
+		throw (new TypeError('You cannot use both observedProjection and stateProjection'));
+	}
+
+	if (observedProjection) {
+		const stateProjection = padWithZeros(observedProjection, {dimension: dynamicDimension});
+		return {
+			observation: Object.assign({}, observation, {
+				stateProjection
+			}),
+			dynamic
+		};
+	}
+
+	if (observationDimension && dynamicDimension) {
+		const observationMatrix = identity(observationDimension);
+		return {
+			observation: Object.assign({}, observation, {
+				stateProjection: padWithZeros(observationMatrix, {dimension: dynamicDimension})
+			}),
+			dynamic
+		};
+	}
+
+	return {observation, dynamic};
+};
+
+var zeros = function (rows, cols) {
+	return new Array(rows).fill(1).map(() => new Array(cols).fill(0));
+};
+
+var diag = function (mat) {
+	const result = zeros(mat.length, mat.length);
+
+	for (const [i, element] of mat.entries()) {
+		result[i][i] = element;
+	}
+
+	return result;
+};
+
+/**
+*Initializes the dynamic.init when not given
+*@param {ObservationConfig} observation
+*@param {DynamicConfig} dynamic
+*@returns {ObservationConfig, DynamicConfig}
+*/
+
+var extendDynamicInit = function ({observation, dynamic}) {
+	if (!dynamic.init) {
+		const huge = 1e6;
+		const dynamicDimension = dynamic.dimension;
+		const meanArray = new Array(dynamicDimension).fill(0);
+		const covarianceArray = new Array(dynamicDimension).fill(huge);
+		const withInitOptions = {
+			observation,
+			dynamic: Object.assign({}, dynamic, {
+				init: {
+					mean: meanArray.map(element => [element]),
+					covariance: diag(covarianceArray),
+					index: -1
+				}
+			})
+		};
+		return withInitOptions;
+	}
+
+	return {observation, dynamic};
+};
+
+// Const diag = require('../linalgebra/diag.js');
+
+/**
+* @callback MatrixCallback
+* @returns <Array.<Array.<Number>>
+*/
+
+/**
+* Tranforms:
+** a 2d array into a function (() => array)
+** a 1d array into a function (() => diag(array))
+*@param {Array.<Number> | Array.<Array.<Number>>} array
+*@returns {MatrixCallback}
+*/
+
+var toFunction = function (array) {
+	if (typeof (array) === 'function') {
+		return array;
+	}
+
+	if (Array.isArray(array)) {
+		return array;
+	}
+
+	throw (new Error('Only arrays and functions are authorized'));
+};
+
+var uniq = function (array) {
+	return array.filter((value, index) =>
+		array.indexOf(value) === index
+	);
+};
+
+const limit = 100;
+
+/**
+*Equivalent to the Object.assign methode, takes several arguments and creates a new object corresponding to the assignment of the arguments
+* @param {Object} args
+* @param {Number} step
+*/
+const deepAssign = function (args, step) {
+	if (step > limit) {
+		throw (new Error(`In deepAssign, number of recursive call (${step}) reached limit (${limit}), deepAssign is not working on  self-referencing objects`));
+	}
+
+	const filterArguments = args.filter(arg => typeof (arg) !== 'undefined' && arg !== null);
+	const lastArgument = filterArguments[filterArguments.length - 1];
+	if (filterArguments.length === 1) {
+		return filterArguments[0];
+	}
+
+	if (typeof (lastArgument) !== 'object' || Array.isArray(lastArgument)) {
+		return lastArgument;
+	}
+
+	if (filterArguments.length === 0) {
+		return null;
+	}
+
+	const objectsArguments = filterArguments.filter(arg => typeof (arg) === 'object');
+	let keys = [];
+	objectsArguments.forEach(arg => {
+		keys = keys.concat(Object.keys(arg));
+	});
+	const uniqKeys = uniq(keys);
+	const result = {};
+	uniqKeys.forEach(key => {
+		const values = objectsArguments.map(arg => arg[key]);
+		result[key] = deepAssign(values, step + 1);
+	});
+	return result;
+};
+
+var deepAssign_1 = ((...args) => deepAssign(args, 0));
+
+const checkShape = function (matrix, shape, title = 'checkShape') {
+	if (matrix.length !== shape[0]) {
+		throw (new Error(`[${title}] expected size (${shape[0]}) and length (${matrix.length}) does not match`));
+	}
+
+	if (shape.length > 1) {
+		return matrix.forEach(m => checkShape(m, shape.slice(1), title));
+	}
+};
+
+var checkShape_1 = checkShape;
+
+var checkMatrix = function (matrix, shape, title = 'checkMatrix') {
+	if (matrix.reduce((a, b) => a.concat(b)).filter(a => Number.isNaN(a)).length > 0) {
+		throw (new Error(
+			`[${title}] Matrix should not have a NaN\nIn : \n` +
+			matrix.join('\n')
+		));
+	}
+
+	if (shape) {
+		checkShape_1(matrix, shape, title);
+	}
+};
+
+/**
+* @typedef {Number | Array.<Number> | Array.<Array.<Number>>} CovarianceParam
+*/
+
+
+/**
+* If cov is a number, result will be Identity*cov
+* If cov is an Array.<Number>, result will be diag(cov)
+* If cov is an Array.<Array.<Number>>, result will be cov
+* @param {CovarianceParam} cov
+* @param {Number} dimension
+* @returns {Array.<Array.<Number>>}
+*/
+var polymorphMatrix = function (array, {dimension, title = 'polymorph'} = {}) {
+	if (typeof (array) === 'number' || Array.isArray(array)) {
+		if (typeof (array) === 'number' && typeof (dimension) === 'number') {
+			return diag(new Array(dimension).fill(array));
+		}
+
+		if ((Array.isArray(array)) && (Array.isArray(array[0]))) {
+			let shape;
+			if (typeof (dimension) === 'number') {
+				shape = [dimension, dimension];
+			}
+
+			checkMatrix(array, shape, title);
+			return array;
+		}
+
+		if ((Array.isArray(array)) && (typeof (array[0]) === 'number')) {
+			return diag(array);
+		}
+	}
+
+	return array;
+};
+
+var trace = function (array) {
+	let diag = 0;
+	for (const [row, element] of array.entries()) {
+		diag += element[row];
+	}
+
+	return diag;
+};
+
+var transpose = function (array) {
+	return array[0].map((col, i) => array.map(row => row[i]));
+};
+
+/**
+* @callback elemWiseCb
+* @param {Array.<Number>} arr
+* @param {Number} rowId
+* @param {Number} colId
+*/
+/**
+* run a function on cell per cell for each Matrixes
+* @param {<Array.<Array.<Array.<Number>>>} arrMatrixes list of matrixes
+* @param {elemWiseCb} fn
+* @returns {Array.<Array.<Number>>} resulting matrix
+* @example
+// this will do m1 + m2 + m3 + m4 on matrixes
+elemWise([m1, m2, m3, m4], args2 => {
+	return args2.reduce((a, b) => a + b, 0);
+});
+*/
+
+var elemWise = function (arrayMatrixes, fn) {
+	return arrayMatrixes[0].map((row, rowId) => {
+		return row.map((cell, colId) => {
+			const array = arrayMatrixes.map(m => m[rowId][colId]);
+			return fn(array, rowId, colId);
+		});
+	});
+};
+
+var sub = function (...args) {
+	return elemWise(args, ([a, b]) => a - b);
+};
+
+/**
+* Multiply 2 matrixes together
+* @param {<Array.<Array.<Number>>} m1
+* @param {<Array.<Array.<Number>>} m2
+* @returns {Array.<Array.<Number>>}
+*/
+var matMul = function (m1, m2) {
+	// Console.log({m1, m2});
+	const result = [];
+	for (let i = 0; i < m1.length; i++) {
+		result[i] = [];
+		for (let j = 0; j < m2[0].length; j++) {
+			let sum = 0;
+			let isNull = false;
+			for (let k = 0; k < m1[0].length; k++) {
+				if ((m1[i][k] === null && m2[k][j] !== 0) || (m2[k][j] === null && m1[i][k] !== 0)) {
+					isNull = true;
+				}
+
+				sum += m1[i][k] * m2[k][j];
+			}
+
+			result[i][j] = isNull ? null : sum;
+		}
+	}
+
+	return result;
+};
+
+// Sum all the terms of a given matrix
+var sum = function (array) {
+	let s = 0;
+	for (let i = 0; i < array.length; i++) {
+		for (let j = 0; j < array.length; j++) {
+			s += array[i][j];
+		}
+	}
+
+	return s;
+};
+
+// [Frobenius norm](https://en.wikipedia.org/wiki/Matrix_norm#Frobenius_norm )
+var distanceMat = function (array1, array2) {
+	if (typeof (array1) === 'undefined') {
+		return sum(array2);
+	}
+
+	if (typeof (array2) === 'undefined') {
+		return sum(array1);
+	}
+
+	const m = sub(array1, array2);
+	const p = matMul(transpose(m), m);
+	return Math.sqrt(trace(p));
+};
+
+var Sylvester = {};
+
+Sylvester.Matrix = function () {};
+
+Sylvester.Matrix.create = function (elements) {
+  var M = new Sylvester.Matrix();
+  return M.setElements(elements)
+};
+
+Sylvester.Matrix.I = function (n) {
+  var els = [],
+    i = n,
+    j;
+  while (i--) {
+    j = n;
+    els[i] = [];
+    while (j--) {
+      els[i][j] = i === j ? 1 : 0;
+    }
+  }
+  return Sylvester.Matrix.create(els)
+};
+
+Sylvester.Matrix.prototype = {
+  dup: function () {
+    return Sylvester.Matrix.create(this.elements)
+  },
+
+  isSquare: function () {
+    var cols = this.elements.length === 0 ? 0 : this.elements[0].length;
+    return this.elements.length === cols
+  },
+
+  toRightTriangular: function () {
+    if (this.elements.length === 0) return Sylvester.Matrix.create([])
+    var M = this.dup(),
+      els;
+    var n = this.elements.length,
+      i,
+      j,
+      np = this.elements[0].length,
+      p;
+    for (i = 0; i < n; i++) {
+      if (M.elements[i][i] === 0) {
+        for (j = i + 1; j < n; j++) {
+          if (M.elements[j][i] !== 0) {
+            els = [];
+            for (p = 0; p < np; p++) {
+              els.push(M.elements[i][p] + M.elements[j][p]);
+            }
+            M.elements[i] = els;
+            break
+          }
+        }
+      }
+      if (M.elements[i][i] !== 0) {
+        for (j = i + 1; j < n; j++) {
+          var multiplier = M.elements[j][i] / M.elements[i][i];
+          els = [];
+          for (p = 0; p < np; p++) {
+            // Elements with column numbers up to an including the number of the
+            // row that we're subtracting can safely be set straight to zero,
+            // since that's the point of this routine and it avoids having to
+            // loop over and correct rounding errors later
+            els.push(
+              p <= i ? 0 : M.elements[j][p] - M.elements[i][p] * multiplier
+            );
+          }
+          M.elements[j] = els;
+        }
+      }
+    }
+    return M
+  },
+
+  determinant: function () {
+    if (this.elements.length === 0) {
+      return 1
+    }
+    if (!this.isSquare()) {
+      return null
+    }
+    var M = this.toRightTriangular();
+    var det = M.elements[0][0],
+      n = M.elements.length;
+    for (var i = 1; i < n; i++) {
+      det = det * M.elements[i][i];
+    }
+    return det
+  },
+
+  isSingular: function () {
+    return this.isSquare() && this.determinant() === 0
+  },
+
+  augment: function (matrix) {
+    if (this.elements.length === 0) {
+      return this.dup()
+    }
+    var M = matrix.elements || matrix;
+    if (typeof M[0][0] === 'undefined') {
+      M = Sylvester.Matrix.create(M).elements;
+    }
+    var T = this.dup(),
+      cols = T.elements[0].length;
+    var i = T.elements.length,
+      nj = M[0].length,
+      j;
+    if (i !== M.length) {
+      return null
+    }
+    while (i--) {
+      j = nj;
+      while (j--) {
+        T.elements[i][cols + j] = M[i][j];
+      }
+    }
+    return T
+  },
+
+  inverse: function () {
+    if (this.elements.length === 0) {
+      return null
+    }
+    if (!this.isSquare() || this.isSingular()) {
+      return null
+    }
+    var n = this.elements.length,
+      i = n,
+      j;
+    var M = this.augment(Sylvester.Matrix.I(n)).toRightTriangular();
+    var np = M.elements[0].length,
+      p,
+      els,
+      divisor;
+    var inverse_elements = [],
+      new_element;
+    // Sylvester.Matrix is non-singular so there will be no zeros on the
+    // diagonal. Cycle through rows from last to first.
+    while (i--) {
+      // First, normalise diagonal elements to 1
+      els = [];
+      inverse_elements[i] = [];
+      divisor = M.elements[i][i];
+      for (p = 0; p < np; p++) {
+        new_element = M.elements[i][p] / divisor;
+        els.push(new_element);
+        // Shuffle off the current row of the right hand side into the results
+        // array as it will not be modified by later runs through this loop
+        if (p >= n) {
+          inverse_elements[i].push(new_element);
+        }
+      }
+      M.elements[i] = els;
+      // Then, subtract this row from those above it to give the identity matrix
+      // on the left hand side
+      j = i;
+      while (j--) {
+        els = [];
+        for (p = 0; p < np; p++) {
+          els.push(M.elements[j][p] - M.elements[i][p] * M.elements[j][i]);
+        }
+        M.elements[j] = els;
+      }
+    }
+    return Sylvester.Matrix.create(inverse_elements)
+  },
+
+  setElements: function (els) {
+    var i,
+      j,
+      elements = els.elements || els;
+    if (elements[0] && typeof elements[0][0] !== 'undefined') {
+      i = elements.length;
+      this.elements = [];
+      while (i--) {
+        j = elements[i].length;
+        this.elements[i] = [];
+        while (j--) {
+          this.elements[i][j] = elements[i][j];
+        }
+      }
+      return this
+    }
+    var n = elements.length;
+    this.elements = [];
+    for (i = 0; i < n; i++) {
+      this.elements.push([elements[i]]);
+    }
+    return this
+  },
+};
+
+var matrixInverse = function (elements) {
+  const mat = Sylvester.Matrix.create(elements).inverse();
+  if (mat !== null) {
+    return mat.elements
+  } else {
+    return null
+  }
+};
+
+var invert = function (m) {
+	return matrixInverse(m);
+};
+
+var subSquareMatrix = (mat, obsIndexes) => {
+	return obsIndexes.map(s1 => obsIndexes.map(s2 => mat[s1][s2]));
+};
+
+var isNumber = function isNumber(_int) {
+  return Number.isFinite(_int);
+};
+
+var isMatrix = function isMatrix(matrix) {
+  if (!Array.isArray(matrix)) {
+    return false;
+  }
+
+  var height = matrix.length;
+
+  if (height === 0) {
+    return true; // [] represents empty matrix (0 x 0 matrix)
+  }
+
+  var firstRow = matrix[0];
+
+  if (!Array.isArray(firstRow)) {
+    return false;
+  }
+
+  var width = firstRow.length;
+
+  if (width === 0) {
+    return false; // [ [] ] is not allowed
+  }
+
+  for (var i = 0; i < height; i++) {
+    var row = matrix[i];
+
+    if (!Array.isArray(row) || row.length !== width) {
+      return false;
+    }
+
+    for (var j = 0; j < width; j++) {
+      if (!isNumber(row[j])) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+};
+
+var _Error = {
+  INVALID_ARRAY: 'Invalid argument: Received a non-array argument',
+  INVALID_MATRIX: 'Invalid argument: Received an invalid matrix',
+  INVALID_SQUARE_MATRIX: 'Invalid argument: Received a non-square matrix',
+  INVALID_UPPER_TRIANGULAR_MATRIX: 'Invalid argument: Received a non upper-triangular matrix',
+  INVALID_LOWER_TRIANGULAR_MATRIX: 'Invalid argument: Received a non lower-triangular matrix',
+  INVALID_EXPONENT: 'Invalid argument: Expected a non-negative integer exponent',
+  INVALID_ROW_COL: 'Invalid argument: Expected non-negative integer row and column',
+  INVALID_ROW: 'Invalid argument: Expected non-negative integer row',
+  INVALID_COLUMN: 'Invalid argument: Expected non-negative integer column',
+  INVALID_ROWS_EXPRESSION: 'Invalid argument: Received invalid rows expression',
+  INVALID_COLUMNS_EXPRESSION: 'Invalid argument: Received invalid columns expression',
+  INVALID_P_NORM: 'Invalid argument: Received invalid p-norm',
+  OVERFLOW_INDEX: 'Invalid argument: Matrix index overflow',
+  OVERFLOW_COLUMN: 'Invalid argument: Column index overflow',
+  OVERFLOW_ROW: 'Invalid argument: Row index overflow',
+  NO_UNIQUE_SOLUTION: 'Arithmetic Exception: The system has no unique solution',
+  SIZE_INCOMPATIBLE: 'Invalid argument: Matrix size-incompatible',
+  SINGULAR_MATRIX: 'Arithmetic Exception: The matrix is not invertible',
+  EXPECTED_STRING_NUMBER_AT_POS_1_2: 'Invalid argument: Expected a string or a number at arguments[1] and arguments[2]',
+  EXPECTED_ARRAY_OF_NUMBERS_OR_MATRICES: 'Invalid argument: Expected either an array of numbers or an array of square matrices'
+};
+
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
+
+function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
+
+/**
+ * Determines whether a Matrix is diagonal or not.<br><br>
+ * 
+ * Diagonal Matrix is a Matrix in which the entries outside the main diagonal
+ * are all zero. Note that the term diagonal refers to rectangular diagonal.<br><br>
+ * 
+ * The result is cached.
+ * @memberof Matrix
+ * @instance
+ * @param {number} [digit=8] - Number of significant digits
+ * @returns {boolean} Returns rue if the Matrix is diagonal Matrix
+ */
+function isDiagonal() {
+  var digit = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : this._digit;
+
+  if (this._isDiagonal !== undefined) {
+    return this._isDiagonal;
+  }
+
+  var EPSILON = 1 / (Math.pow(10, digit) * 2);
+  var A = this._matrix;
+
+  var _this$size = this.size(),
+      _this$size2 = _slicedToArray(_this$size, 2),
+      row = _this$size2[0],
+      col = _this$size2[1];
+
+  if (row === 0) {
+    this._isDiagonal = true;
+    return true;
+  }
+
+  for (var i = 0; i < row; i++) {
+    for (var j = 0; j < col; j++) {
+      if (i !== j && Math.abs(A[i][j]) >= EPSILON) {
+        this.isDiagonal = false;
+        return false;
+      }
+    }
+  }
+
+  this._isDiagonal = true;
+  return true;
+}
+var isDiagonal_1 = isDiagonal;
+
+/**
+ * Determines whether a square Matrix is skew symmetric or not.<br><br>
+ * 
+ * Skew symmetric Matrix is a square Matrix whose transpose equals its negative.<br><br>
+ * 
+ * The result is cached.
+ * @memberof Matrix
+ * @instance
+ * @param {number} [digit=8] - Number of significant digits
+ * @returns {boolean} Returns true if the square Matrix is skew symmetric
+ */
+function isSkewSymmetric() {
+  var digit = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : this._digit;
+
+  if (this._isSkewSymmetric !== undefined) {
+    return this._isSkewSymmetric;
+  }
+
+  if (!this.isSquare()) {
+    this._isSkewSymmetric = false;
+    return false;
+  }
+
+  var A = this._matrix;
+  var EPSILON = 1 / (Math.pow(10, digit) * 2);
+  var size = A.length;
+
+  if (size === 0) {
+    this._isSkewSymmetric = true;
+    return true; // []
+  }
+
+  for (var i = 0; i < size; i++) {
+    for (var j = 0; j < i; j++) {
+      if (Math.abs(A[i][j] + A[j][i]) >= EPSILON) {
+        this._isSkewSymmetric = false;
+        return false;
+      }
+    }
+  }
+
+  this._isSkewSymmetric = true;
+  return true;
+}
+var isSkewSymmetric_1 = isSkewSymmetric;
+
+/**
+ * Determines whether a Matrix is square or not.<br><br>
+ * 
+ * Square Matrix is a Matrix with same number of rows and columns.<br><br>
+ * 
+ * The result is cached.
+ * @memberof Matrix
+ * @instance
+ * @returns {boolean} Returns true if the Matrix is square
+ */
+function isSquare() {
+  if (this._isSquare !== undefined) {
+    return this._isSquare;
+  }
+
+  var A = this._matrix;
+
+  if (A.length === 0) {
+    // 0x0 matrix
+    this._isSquare = true;
+    return true;
+  }
+
+  this._isSquare = A.length === A[0].length;
+  return this._isSquare;
+}
+var isSquare_1 = isSquare;
+
+/**
+ * Determines whether a square Matrix is symmetric or not.<br><br>
+ * 
+ * Symmetric Matrix is a square Matrix that is equal to its transpose.<br><br>
+ * 
+ * The result is cached.
+ * @memberof Matrix
+ * @instance
+ * @param {number} [digit=8] - Number of significant digits
+ * @returns {boolean} Returns true if the square Matrix is symmetric
+ */
+function isSymmetric() {
+  var digit = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : this._digit;
+
+  if (this._isSymmetric !== undefined) {
+    return this._isSymmetric;
+  }
+
+  if (!this.isSquare()) {
+    return false;
+  }
+
+  var A = this._matrix;
+  var EPSILON = 1 / (Math.pow(10, digit) * 2);
+  var size = A.length;
+
+  for (var i = 0; i < size; i++) {
+    for (var j = 0; j <= i; j++) {
+      if (Math.abs(A[i][j] - A[j][i]) >= EPSILON) {
+        this._isSymmetric = false;
+        return false;
+      }
+    }
+  }
+
+  this._isSymmetric = true;
+  return true;
+}
+var isSymmetric_1 = isSymmetric;
+
+function _slicedToArray$1(arr, i) { return _arrayWithHoles$1(arr) || _iterableToArrayLimit$1(arr, i) || _unsupportedIterableToArray$1(arr, i) || _nonIterableRest$1(); }
+
+function _nonIterableRest$1() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray$1(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray$1(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray$1(o, minLen); }
+
+function _arrayLikeToArray$1(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit$1(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles$1(arr) { if (Array.isArray(arr)) return arr; }
+
+/**
+ * Determines whether a Matrix is lower triangular Matrix or not.<br><br>
+ * 
+ * Lower triangular Matrix is a Matrix in which all the entries
+ * above the main diagonal are zero. Note that it can be applied
+ * to any non-square Matrix.<br><br>
+ * 
+ * The result is cached.
+ * @memberof Matrix
+ * @instance
+ * @param {number} [digit=8] - Number of significant digits
+ * @returns {boolean} Returns true if the Matrix is lower triangular
+ */
+function isLowerTriangular() {
+  var digit = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : this._digit;
+
+  if (this._isLowerTriangular !== undefined) {
+    return this._isLowerTriangular;
+  }
+
+  var EPSILON = 1 / (Math.pow(10, digit) * 2);
+  var A = this._matrix;
+
+  var _this$size = this.size(),
+      _this$size2 = _slicedToArray$1(_this$size, 2),
+      row = _this$size2[0],
+      col = _this$size2[1];
+
+  if (row === 0) {
+    // []
+    this._isLowerTriangular = true;
+    return true;
+  }
+
+  for (var i = 0; i < row; i++) {
+    for (var j = i + 1; j < col; j++) {
+      if (Math.abs(A[i][j]) >= EPSILON) {
+        this._isLowerTriangular = false;
+        return false;
+      }
+    }
+  }
+
+  this._isLowerTriangular = true;
+  return true;
+}
+var isLowerTriangular_1 = isLowerTriangular;
+
+function _slicedToArray$2(arr, i) { return _arrayWithHoles$2(arr) || _iterableToArrayLimit$2(arr, i) || _unsupportedIterableToArray$2(arr, i) || _nonIterableRest$2(); }
+
+function _nonIterableRest$2() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray$2(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray$2(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray$2(o, minLen); }
+
+function _arrayLikeToArray$2(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit$2(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles$2(arr) { if (Array.isArray(arr)) return arr; }
+
+/**
+ * Determines whether a Matrix is upper triangular Matrix or not.<br><br>
+ * 
+ * Upper triangular Matrix is a Matrix in which all the entries below the
+ * main diagonal are zero. Note that it can be applied to any non-square Matrix.<br><br>
+ *  
+ * The result is cached.
+ * @memberof Matrix
+ * @instance
+ * @param {number} [digit=8] - Number of significant digits
+ * @returns {boolean} Returns true if the Matrix is upper triangular
+ */
+function isUpperTriangular() {
+  var digit = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : this._digit;
+
+  if (this._isUpperTriangular !== undefined) {
+    return this._isUpperTriangular;
+  }
+
+  var EPSILON = 1 / (Math.pow(10, digit) * 2);
+  var A = this._matrix;
+
+  var _this$size = this.size(),
+      _this$size2 = _slicedToArray$2(_this$size, 2),
+      row = _this$size2[0],
+      col = _this$size2[1];
+
+  if (row === 0) {
+    // []
+    this._isUpperTriangular = true;
+    return true;
+  }
+
+  for (var i = 0; i < row; i++) {
+    for (var j = 0; j < col; j++) {
+      if (i <= j) {
+        continue;
+      }
+
+      if (Math.abs(A[i][j]) >= EPSILON) {
+        this._isUpperTriangular = false;
+        return false;
+      }
+    }
+  }
+
+  this._isUpperTriangular = true;
+  return true;
+}
+var isUpperTriangular_1 = isUpperTriangular;
+
+/**
+ * Determines whether a square Matrix is orthogonal or not.<br><br>
+ * 
+ * Orthogonal Matrix is a Matrix in which all rows and columns are
+ * orthonormal vectors.<br><br>
+ * 
+ * The result is cached.
+ * @memberof Matrix
+ * @instance
+ * @param {number} [digit=8] - Number of significant digits
+ * @returns {boolean} Returns true if the square Matrix is orthogonal
+ */
+function isOrthogonal() {
+  var digit = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : this._digit;
+
+  if (this._isOrthogonal !== undefined) {
+    return this._isOrthogonal;
+  }
+
+  if (!this.isSquare()) {
+    this._isOrthogonal = false;
+    return false;
+  }
+
+  var A = this._matrix;
+  var EPSILON = 1 / (Math.pow(10, digit) * 2);
+  var size = A.length;
+
+  for (var i = 0; i < size; i++) {
+    for (var j = i; j < size; j++) {
+      var entry = 0;
+
+      for (var k = 0; k < size; k++) {
+        entry += A[i][k] * A[j][k];
+      }
+
+      if (i === j && Math.abs(entry - 1) >= EPSILON) {
+        this._isOrthogonal = false;
+        return false;
+      }
+
+      if (i !== j && Math.abs(entry) >= EPSILON) {
+        this._isOrthogonal = false;
+        return false;
+      }
+    }
+  }
+
+  this._isOrthogonal = true;
+  return true;
+}
+var isOrthogonal_1 = isOrthogonal;
+
+var INVALID_P_NORM = _Error.INVALID_P_NORM,
+    SINGULAR_MATRIX = _Error.SINGULAR_MATRIX,
+    INVALID_SQUARE_MATRIX = _Error.INVALID_SQUARE_MATRIX;
+/**
+ * Calculations the condition number of square Matrix
+ * with respect to the choice of Matrix norm. 
+ * If the Matrix is singular, returns Infinity.<br><br>
+ * The condition number is not cached.
+ * @memberof Matrix
+ * @instance
+ * @param {(1|2|Infinity|'F')} p - Type of Matrix norm
+ * @returns {number} The condition number of Matrix
+ */
+
+
+function cond() {
+  var p = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 2;
+
+  if (p !== 1 && p !== 2 && p !== Infinity && p !== 'F') {
+    throw new Error(INVALID_P_NORM);
+  }
+
+  if (!this.isSquare()) {
+    throw new Error(INVALID_SQUARE_MATRIX);
+  }
+
+  try {
+    var inverse = lib$1.inverse(this);
+    return inverse.norm(p) * this.norm(p);
+  } catch (error) {
+    if (error.message === SINGULAR_MATRIX) {
+      return Infinity;
+    }
+
+    throw error;
+  }
+}
+var cond_1 = cond;
+
+function _slicedToArray$3(arr, i) { return _arrayWithHoles$3(arr) || _iterableToArrayLimit$3(arr, i) || _unsupportedIterableToArray$3(arr, i) || _nonIterableRest$3(); }
+
+function _nonIterableRest$3() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray$3(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray$3(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray$3(o, minLen); }
+
+function _arrayLikeToArray$3(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit$3(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles$3(arr) { if (Array.isArray(arr)) return arr; }
+
+/* eslint-disable prefer-destructuring */
+
+
+var INVALID_SQUARE_MATRIX$1 = _Error.INVALID_SQUARE_MATRIX;
+/**
+ * Calculates the determinant of square Matrix.
+ * If the Matrix size is larger than 3, it calculates the determinant using
+ * LU decomposition, otherwise, using Leibniz Formula.<br><br>
+ * The determinant is cached.
+ * @memberof Matrix
+ * @instance
+ * @returns {number} Returns the determinant of square matrirx
+ */
+
+
+function det() {
+  if (!this.isSquare()) {
+    throw new Error(INVALID_SQUARE_MATRIX$1);
+  }
+
+  if (this._det !== undefined) {
+    return this._det;
+  }
+
+  var matrix = this._matrix;
+  var size = matrix.length;
+
+  if (size === 0) {
+    this._det = 1;
+    return 1; // the determinant of 0x0 matrix must be 1
+  }
+
+  if (size === 1) {
+    this._det = matrix[0][0];
+    return this._det;
+  }
+
+  if (size === 2) {
+    this._det = matrix[0][0] * matrix[1][1] - matrix[0][1] * matrix[1][0];
+    return this._det;
+  }
+
+  if (size === 3) {
+    this._det = matrix[0][0] * matrix[1][1] * matrix[2][2] + matrix[0][1] * matrix[1][2] * matrix[2][0] + matrix[0][2] * matrix[1][0] * matrix[2][1] - matrix[0][2] * matrix[1][1] * matrix[2][0] - matrix[0][1] * matrix[1][0] * matrix[2][2] - matrix[0][0] * matrix[1][2] * matrix[2][1];
+    return this._det;
+  }
+
+  var _Matrix$LU = lib$1.LU(this, true),
+      _Matrix$LU2 = _slicedToArray$3(_Matrix$LU, 2),
+      P = _Matrix$LU2[0],
+      LU = _Matrix$LU2[1];
+
+  var matrixLU = LU._matrix; // count whether the number of permutations <swap> is odd or even
+  // O(n^2)
+
+  var swap = 0;
+
+  for (var i = 0; i < size; i++) {
+    if (P[i] === i) {
+      continue;
+    }
+
+    while (P[i] !== i) {
+      var target = P[i];
+      P[i] = P[target];
+      P[target] = target;
+      swap++;
+    }
+  }
+
+  var result = 1;
+
+  for (var _i2 = 0; _i2 < size; _i2++) {
+    result *= matrixLU[_i2][_i2];
+  }
+
+  if (swap % 2 === 1) {
+    this._det = result * -1;
+    return this._det;
+  }
+
+  this._det = result;
+  return result;
+}
+var det_1 = det;
+
+/**
+ * Gets the real part of a Complex Number.
+ * @memberof Complex
+ * @instance
+ * @returns {number} The real part of the Complex Number
+ */
+function getReal() {
+  return this.re;
+}
+
+var getReal_1 = getReal;
+
+/**
+ * Gets the imaginary part of a Complex Number.
+ * @memberof Complex
+ * @instance
+ * @returns {number} The imaginary part of the Complex Number
+ */
+function getImaginary() {
+  return this.im;
+}
+
+var getImaginary_1 = getImaginary;
+
+/**
+ * Calculates the modulus of a Complex Number.<br><br>
+ * 
+ * The modulus of the complex number is the length of the vector
+ * representing the complex number on complex plane.
+ * @memberof Complex
+ * @instance
+ * @returns {number} The modulus of the Complex Number
+ */
+function getModulus() {
+  return Math.sqrt(Math.pow(this.re, 2) + Math.pow(this.im, 2));
+}
+
+var getModulus_1 = getModulus;
+
+/**
+ * Calculates the argument of a Complex Number which is restricted to the interval [ 0, 2π ).<br><br>
+ * 
+ * The argument of the Complex Number is the angle between positive real-axis
+ * and the vector representing the Complex Number on Complex plane.<br><br>
+ * 
+ * If the given Complex Number is considered as 0, returns undefined.
+ * @memberof Complex
+ * @instance
+ * @returns {number} The argument of the Complex Number
+ */
+function getArgument() {
+  var x = this.re;
+  var y = this.im;
+  var epsilon = 1 / (Math.pow(10, 15) * 2);
+
+  if (Math.abs(x) < epsilon && Math.abs(y) < epsilon) {
+    return undefined;
+  }
+
+  if (x === 0) {
+    if (y > 0) {
+      return Math.PI * 0.5;
+    }
+
+    return Math.PI * 1.5;
+  }
+
+  if (y === 0) {
+    if (x > 0) {
+      return 0;
+    }
+
+    return Math.PI;
+  }
+
+  if (x > 0 && y > 0) {
+    return Math.atan(y / x);
+  }
+
+  if (x < 0 && y > 0) {
+    return Math.PI - Math.atan(y / (x * -1));
+  }
+
+  if (x < 0 && y < 0) {
+    return Math.PI + Math.atan(y * -1 / (x * -1));
+  }
+
+  return Math.PI * 2 - Math.atan(y * -1 / x);
+}
+
+var getArgument_1 = getArgument;
+
+/**
+ * Gets the stringified and formatted Complex Number.
+ * @memberof Complex
+ * @instance
+ * @returns {string} The stringified and formatted Complex Number
+ */
+function toString() {
+  var re = this.re,
+      im = this.im;
+
+  if (Number.isNaN(re) || Number.isNaN(im)) {
+    return 'NaN';
+  }
+
+  if (re === 0 && im === 0) {
+    return '0';
+  }
+
+  if (re === 0) {
+    if (im === 1) {
+      return 'i';
+    }
+
+    if (im === -1) {
+      return '-i';
+    }
+
+    return "".concat(im, "i");
+  }
+
+  if (im === 0) {
+    return "".concat(re);
+  }
+
+  if (im > 0) {
+    if (im === 1) {
+      return "".concat(re, " + i");
+    }
+
+    return "".concat(re, " + ").concat(im, "i");
+  }
+
+  if (im === -1) {
+    return "".concat(re, " - i");
+  }
+
+  return "".concat(re, " - ").concat(Math.abs(im), "i");
+}
+
+var toString_1 = toString;
+
+/**
+ * Determines whether the Complex Number is NaN or not.
+ * @memberof Complex
+ * @static
+ * @param {Complex} num - Any Complex number
+ * @returns {boolean} Returns true if one of real and imaginary part are NaN
+ */
+function isNaN(num) {
+  if (!(num instanceof this)) {
+    return false;
+  }
+
+  var re = num.getReal();
+  var im = num.getImaginary();
+
+  if (Number.isNaN(re) || Number.isNaN(im)) {
+    return true;
+  }
+
+  return false;
+}
+
+var _isNaN = isNaN;
+
+/**
+ * Determines whether two Complex Numbers are considered as identical.<br><br>
+ * 
+ * Two Complex Numbers are considered as identical if either
+ * both are NaN or both real and imaginary parts are extremely closed.<br><br>
+ * 
+ * The test criterion is Math.abs(x - y) < 1 / (10 ** digit * 2).
+ * For default value 15, it should be 5e-16.
+ * That means if the difference of two numbers is less than 5e-16,
+ * they are considered as same value.
+ * @memberof Complex
+ * @static
+ * @param {Complex} num1 - Complex Number
+ * @param {Complex} num2 - Complex Number
+ * @param {number} [digit=15] - Number of significant digits
+ * @returns {boolean} Returns true if two Complex Numbers are considered as identical
+ */
+function isEqual(num1, num2) {
+  var digit = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 15;
+
+  if (!(num1 instanceof this) || !(num2 instanceof this)) {
+    return false;
+  }
+
+  if (!Number.isInteger(digit) || digit < 0) {
+    throw new Error('Invalid argument: Expected a non-negative integer digit');
+  }
+
+  var EPSILON = 1 / (Math.pow(10, digit) * 2);
+  var a = num1.getReal();
+  var b = num1.getImaginary();
+  var c = num2.getReal();
+  var d = num2.getImaginary();
+
+  if (Number.isNaN(a) && Number.isNaN(b) && Number.isNaN(c) && Number.isNaN(d)) {
+    return true;
+  }
+
+  return Math.abs(a - c) < EPSILON && Math.abs(b - d) < EPSILON;
+}
+
+var isEqual_1 = isEqual;
+
+/**
+ * Calculates the complex conjugate of the Complex Number.
+ * @memberof Complex
+ * @static
+ * @param {Complex} num - Complex number
+ * @returns {Complex} The complex conjugate of the Complex Number
+ */
+function conjugate(num) {
+  if (!(num instanceof this)) {
+    return this.NaN;
+  }
+
+  return new this(num.getReal(), num.getImaginary() * -1);
+}
+
+var conjugate_1 = conjugate;
+
+/**
+ * Calculates the inverse of the Complex Number.
+ * @memberof Complex
+ * @static
+ * @param {Complex} num - Complex Number
+ * @returns {number} Inverse of the Complex Number
+ */
+function inverse(num) {
+  if (!(num instanceof this)) {
+    return this.NaN;
+  }
+
+  return this.divide(this.ONE, num);
+}
+
+var inverse_1 = inverse;
+
+/**
+ * Calculates the sum of two Complex Number.
+ * @memberof Complex
+ * @static
+ * @param {Complex} num1 - The Complex Number on the left of '+' operator.
+ * @param {Complex} num2 - The Complex Number on the right of '+' operator.
+ * @returns {Complex} The sum of two Complex Numbers
+ */
+function add(num1, num2) {
+  if (!(num1 instanceof this) || !(num2 instanceof this)) {
+    return this.NaN;
+  }
+
+  return new this(num1.re + num2.re, num1.im + num2.im);
+}
+
+var add_1 = add;
+
+/**
+ * Calculates the difference of two Complex Number.
+ * @memberof Complex
+ * @static
+ * @param {Complex} num1 - The Complex Number on the left of '-' operator.
+ * @param {Complex} num2 - The Complex Number on the right of '-' operator.
+ * @returns {Complex} The difference of two Complex Numbers
+ */
+function subtract(num1, num2) {
+  if (!(num1 instanceof this) || !(num2 instanceof this)) {
+    return this.NaN;
+  }
+
+  return new this(num1.re - num2.re, num1.im - num2.im);
+}
+
+var subtract_1 = subtract;
+
+/**
+ * Calculates the product of two Complex Number.
+ * @memberof Complex
+ * @static
+ * @param {Complex} num1 - The Complex Number on the left of '*' operator.
+ * @param {Complex} num2 - The Complex Number on the right of '*' operator.
+ * @returns {Complex} The product of two Complex Numbers
+ */
+function multiply(num1, num2) {
+  if (!(num1 instanceof this) || !(num2 instanceof this)) {
+    return this.NaN;
+  }
+
+  var a = num1.re;
+  var b = num1.im;
+  var c = num2.re;
+  var d = num2.im;
+  return new this(a * c - b * d, a * d + b * c);
+}
+
+var multiply_1 = multiply;
+
+/**
+ * Calculates the quotient of two Complex Number.<br><br>
+ * 
+ * Note that if the denominator is considered as 0,
+ * returns Complex.NaN instead of Infinity.
+ * @memberof Complex
+ * @static
+ * @param {Complex} num1 - The Complex Number on the left of '/' operator.
+ * @param {Complex} num2 - The Complex Number on the right of '/' operator.
+ * @returns {Complex} The quotient of two Complex Numbers
+ */
+function divide(num1, num2) {
+  if (!(num1 instanceof this) || !(num2 instanceof this)) {
+    return this.NaN;
+  }
+
+  var a = num1.re;
+  var b = num1.im;
+  var c = num2.re;
+  var d = num2.im;
+
+  if (Math.abs(c) < this.EPSILON && Math.abs(d) < this.EPSILON) {
+    return this.NaN;
+  }
+
+  var denominator = Math.pow(c, 2) + Math.pow(d, 2);
+  return new this((a * c + b * d) / denominator, (b * c - a * d) / denominator);
+}
+
+var divide_1 = divide;
+
+/**
+ * Calculates the exponential function with base E.
+ * @memberof Complex
+ * @static
+ * @param {Complex} num - Exponent
+ * @returns {Complex} The value of E to the power of num
+ */
+function exp(num) {
+  if (!(num instanceof this)) {
+    return this.NaN;
+  }
+
+  var re = num.getReal();
+  var theta = num.getImaginary();
+  var r = Math.exp(re);
+  return new this(r * Math.cos(theta), r * Math.sin(theta));
+}
+
+var exp_1 = exp;
+
+/**
+ * Calculates the natural log of the Complex Number.<br><br>
+ * 
+ * Note that complex log is a multivalued function,
+ * and this function only provides the principal value by
+ * restricting the imaginary part to the interval [0, 2π).
+ * @memberof Complex
+ * @static
+ * @param {Complex} num - Complex Number
+ * @returns {number} Natural log of the Complex Number
+ */
+function log(num) {
+  if (!(num instanceof this)) {
+    return this.NaN;
+  }
+
+  var r = num.getModulus();
+  var theta = num.getArgument();
+
+  if (r < this.EPSILON || theta === undefined) {
+    return this.NaN;
+  }
+
+  return new this(Math.log(r), theta);
+}
+
+var log_1 = log;
+
+/**
+ * Calculates the power of the Complex Number.
+ * The exponent can be any real number or Complex Number<br><br>
+ * 
+ * You can find the k-th root of complex number by setting the exponent to 1 / k.
+ * But you should know that it only returns one out of k possible solutions.
+ * @memberof Complex
+ * @static
+ * @param {Complex} num - Base
+ * @param {Complex|number} n - Exponent
+ * @returns {Complex} The result of the exponentiation
+ */
+function pow(num, n) {
+  if (!(num instanceof this) || typeof n !== 'number' && !(n instanceof this)) {
+    return this.NaN;
+  }
+
+  if (typeof n === 'number') {
+    if (!Number.isFinite(n) || Number.isNaN(n)) {
+      return this.NaN;
+    }
+
+    if (n === 0) {
+      return this.ONE;
+    }
+
+    if (this.isEqual(num, this.ZERO)) {
+      return this.ZERO;
+    }
+
+    return this.exp(this.multiply(new this(n, 0), this.log(num)));
+  }
+
+  if (n instanceof this) {
+    return this.exp(this.multiply(n, this.log(num)));
+  }
+
+  return this.NaN;
+}
+
+var pow_1 = pow;
+
+/**
+ * Calculates the sine of a Complex Number.
+ * @memberof Complex
+ * @static
+ * @param {Complex} num - Any Complex Number
+ * @returns {Complex} The result of sine function
+ */
+function sin(num) {
+  if (!(num instanceof this)) {
+    return this.NaN;
+  }
+
+  var a = num.getReal();
+  var b = num.getImaginary();
+  return new this(Math.sin(a) * Math.cosh(b), Math.cos(a) * Math.sinh(b));
+}
+
+var sin_1 = sin;
+
+/**
+ * Calculates the cosine of a Complex Number.
+ * @memberof Complex
+ * @static
+ * @param {Complex} num - Any Complex Number
+ * @returns {Complex} The result of cosine function
+ */
+function cos(num) {
+  if (!(num instanceof this)) {
+    return this.NaN;
+  }
+
+  var a = num.getReal();
+  var b = num.getImaginary();
+  return new this(Math.cos(a) * Math.cosh(b), Math.sin(a) * Math.sinh(b) * -1);
+}
+
+var cos_1 = cos;
+
+/**
+ * Calculates the tangent of a Complex Number.
+ * The domain of this function is C / { (k + 0.5)π : k is any integer }.<br><br>
+ * 
+ * If the argument is out of its domain, it returns Complex.NaN.
+ * @memberof Complex
+ * @static
+ * @param {Complex} num - Any Complex Number which is not in the form of (k + 0.5)π
+ * @returns {Complex} The result of tangent function
+ */
+function tan(num) {
+  return this.divide(this.sin(num), this.cos(num));
+}
+
+var tan_1 = tan;
+
+/**
+ * Calculates the cosecant of a Complex Number.
+ * The domain of this function is C / { kπ : k is any integer }.<br><br>
+ * 
+ * If the argument is out of its domain, it returns Complex.NaN.
+ * @memberof Complex
+ * @static
+ * @param {Complex} num - Any Complex Number which is not the multiple of π
+ * @returns {Complex} The result of cosecant function
+ */
+function csc(num) {
+  return this.divide(this.ONE, this.sin(num));
+}
+
+var csc_1 = csc;
+
+/**
+ * Calculates the secant of a Complex Number.
+ * The domain of this function is C / { (k + 0.5)π : k is any integer }.<br><br>
+ * 
+ * If the argument is out of its domain, it returns Complex.NaN.
+ * @memberof Complex
+ * @static
+ * @param {Complex} num - Any Complex Number which is not in the form of (k + 0.5)π
+ * @returns {Complex} The result of secant function
+ */
+function sec(num) {
+  return this.divide(this.ONE, this.cos(num));
+}
+
+var sec_1 = sec;
+
+/**
+ * Calculates the cotangent of a Complex Number.
+ * The domain of this function is C / { kπ/2 : k is any integer }.<br><br>
+ * 
+ * If the argument is out of its domain, it returns Complex.NaN.
+ * @memberof Complex
+ * @static
+ * @param {Complex} num - Any Complex Number which is not the multiple of π/2
+ * @returns {Complex} The result of cotangent function
+ */
+function cot(num) {
+  return this.divide(this.ONE, this.tan(num));
+}
+
+var cot_1 = cot;
+
+/**
+ * Calculates the inverse sine of a Complex Number.
+ * @memberof Complex
+ * @static
+ * @param {Complex} num - Any Complex Number
+ * @returns {Complex} The result of inverse sine function
+ */
+function asin(num) {
+  return this.multiply(new this(0, -1), this.log(this.add(this.multiply(new this(0, 1), num), this.pow(this.subtract(this.ONE, this.pow(num, 2)), 0.5))));
+}
+
+var asin_1 = asin;
+
+/**
+ * Calculates the inverse cosine of a Complex Number.
+ * @memberof Complex
+ * @static
+ * @param {Complex} num - Any Complex Number
+ * @returns {Complex} The result of inverse cosine function
+ */
+function acos(num) {
+  return this.subtract(new this(Math.PI / 2), this.asin(num));
+}
+
+var acos_1 = acos;
+
+/**
+ * Calculates the inverse tangent of a Complex Number.
+ * The domain of this function is C / { i , -i }.<br><br>
+ * 
+ * If the argument is out of its domain, it returns Complex.NaN.
+ * @memberof Complex
+ * @static
+ * @param {Complex} num - Any Complex Number except i and -i
+ * @returns {Complex} The result of inverse tangent function
+ */
+function atan(num) {
+  return this.multiply(new this(0, 1 / 2), this.subtract(this.log(this.subtract(this.ONE, this.multiply(new this(0, 1), num))), this.log(this.add(this.ONE, this.multiply(new this(0, 1), num)))));
+}
+
+var atan_1 = atan;
+
+/**
+ * Calculates the inverse cosecant of a Complex Number.
+ * The domain of this function is C / { 0 }.<br><br>
+ * 
+ * If the argument is out of its domain, it returns Complex.NaN.
+ * @memberof Complex
+ * @static
+ * @param {Complex} num - Any Complex Number except 0
+ * @returns {Complex} The result of inverse cosecant function
+ */
+function acsc(num) {
+  return this.asin(this.inverse(num));
+}
+
+var acsc_1 = acsc;
+
+/**
+ * Calculates the inverse secant of a Complex Number.
+ * The domain of this function is C / { 0 }.<br><br>
+ * 
+ * If the argument is out of its domain, it returns Complex.NaN.
+ * @memberof Complex
+ * @static
+ * @param {Complex} num - Any Complex Number except 0
+ * @returns {Complex} The result of inverse secant function
+ */
+function asec(num) {
+  return this.acos(this.inverse(num));
+}
+
+var asec_1 = asec;
+
+/**
+ * Calculates the inverse cotangent of a Complex Number.
+ * The domain of this function is C / { i , -i , 0 }.<br><br>
+ * 
+ * If the argument is out of its domain, it returns Complex.NaN.
+ * @memberof Complex
+ * @static
+ * @param {Complex} num - Any Complex Number except i, -i and 0
+ * @returns {Complex} The result of inverse cotangent function
+ */
+function acot(num) {
+  return this.atan(this.inverse(num));
+}
+
+var acot_1 = acot;
+
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+/**
+ * Creates a new Complex Number.
+ * @namespace Complex
+ * @class
+ * @param {number} arg1 - The real part of the Complex Number
+ * @param {number} arg2 - The imaginary part of the Complex Number
+ */
+function Complex(arg1, arg2) {
+  var type1 = _typeof(arg1);
+
+  var type2 = _typeof(arg2);
+
+  if (type1 === 'number' && type2 === 'undefined') {
+    if (Number.isNaN(arg1) || !Number.isFinite(arg1)) {
+      this.re = NaN;
+      this.im = NaN;
+      return this;
+    }
+
+    this.re = arg1;
+    this.im = 0;
+    return this;
+  }
+
+  if (type1 === 'number' && type2 === 'number') {
+    if (Number.isNaN(arg1) || Number.isNaN(arg2) || !Number.isFinite(arg1) || !Number.isFinite(arg2)) {
+      this.re = NaN;
+      this.im = NaN;
+      return this;
+    }
+
+    this.re = arg1;
+    this.im = arg2;
+    return this;
+  }
+
+  this.re = NaN;
+  this.im = NaN;
+  return this;
+}
+
+var lib = Complex;
+Complex.prototype.getReal = getReal_1;
+Complex.prototype.getImaginary = getImaginary_1;
+Complex.prototype.getModulus = getModulus_1;
+Complex.prototype.getArgument = getArgument_1;
+Complex.prototype.toString = toString_1;
+Complex.isNaN = _isNaN;
+Complex.isEqual = isEqual_1;
+Complex.conjugate = conjugate_1;
+Complex.inverse = inverse_1;
+Complex.add = add_1;
+Complex.subtract = subtract_1;
+Complex.multiply = multiply_1;
+Complex.divide = divide_1;
+Complex.exp = exp_1;
+Complex.log = log_1;
+Complex.pow = pow_1;
+Complex.sin = sin_1;
+Complex.cos = cos_1;
+Complex.tan = tan_1;
+Complex.csc = csc_1;
+Complex.sec = sec_1;
+Complex.cot = cot_1;
+Complex.asin = asin_1;
+Complex.acos = acos_1;
+Complex.atan = atan_1;
+Complex.acsc = acsc_1;
+Complex.asec = asec_1;
+Complex.acot = acot_1;
+/**
+ * It represents NaN in this library. It is equivalent to new Complex(NaN).<br><br>
+ * 
+ * It is important to know that this library does not introduce the concept of Complex Infinity,
+ * all Infinity in this library are represented by Complex.NaN.
+ * @static
+ */
+
+Complex.NaN = new Complex(NaN);
+/** @static */
+
+Complex.ONE = new Complex(1);
+/** @static */
+
+Complex.ZERO = new Complex(0);
+/** @static */
+
+Complex.PI = new Complex(Math.PI);
+/** @static */
+
+Complex.E = new Complex(Math.E);
+/**
+ * It represents the value of 5e-16, which is the smallest number considered as non-zero in this library.
+ * In the other words, any number less than Complex.EPSILON is considered as 0.<br><br>
+ * 
+ * Note that Complex.EPSILON is number instead of instance of Complex.
+ * @static
+ */
+
+Complex.EPSILON = 1 / (Math.pow(10, 15) * 2);
+
+function _slicedToArray$4(arr, i) { return _arrayWithHoles$4(arr) || _iterableToArrayLimit$4(arr, i) || _unsupportedIterableToArray$4(arr, i) || _nonIterableRest$4(); }
+
+function _nonIterableRest$4() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray$4(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray$4(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray$4(o, minLen); }
+
+function _arrayLikeToArray$4(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit$4(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles$4(arr) { if (Array.isArray(arr)) return arr; }
+
+/* eslint-disable no-param-reassign */
+// reference: https://people.inf.ethz.ch/arbenz/ewp/Lnotes/chapter4.pdf
+
+
+
+
+var INVALID_SQUARE_MATRIX$2 = _Error.INVALID_SQUARE_MATRIX;
+/**
+ * Calculates the eigenvalues of any square Matrix using QR Algorithm.<br><br>
+ * 
+ * The eigenvalues can be either real number or complex number.
+ * Note that all eigenvalues are instance of Complex,
+ * for more details please visit [Complex.js]{@link https://rayyamhk.github.io/Complex.js}.<br><br>
+ * 
+ * The eigenvalues are cached.
+ * @memberof Matrix
+ * @instance
+ * @returns {Complex[]} Array of eigenvalues
+ */
+
+
+function eigenvalues() {
+  if (!this.isSquare()) {
+    throw new Error(INVALID_SQUARE_MATRIX$2);
+  }
+
+  if (this._eigenvalues !== undefined) {
+    return this._eigenvalues;
+  }
+
+  var size = this.size()[0];
+  var values = [];
+  var digit = this._digit;
+  var EPSILON = 1 / (Math.pow(10, digit) * 2);
+
+  var clone = lib$1.clone(this)._matrix;
+
+  var isConvergent = true; // flag
+
+  var skip = false; // Transform matrix to Hessenberg matrix
+
+  HouseholderTransform(clone, digit);
+
+  for (var i = size - 1; i > 0; i--) {
+    var divergenceCount = 0;
+    var prev = void 0; // used to determine convergence
+    // if obtains complex eigenvalues pair in previous iteration, skip current round
+
+    if (skip) {
+      skip = false;
+      continue;
+    }
+
+    var shift = clone[size - 1][size - 1]; // eslint-disable-next-line no-constant-condition
+
+    while (true) {
+      if (!isConvergent) {
+        // if the current eigenvalue is not real
+        prev = size2Eigenvalues(clone[i - 1][i - 1], clone[i - 1][i], clone[i][i - 1], clone[i][i]).metric;
+      } else {
+        // if the current eigenvalue is real
+        prev = Math.abs(clone[i][i - 1]);
+      } // apply single shift
+
+
+      for (var j = 0; j < size; j++) {
+        clone[j][j] -= shift;
+      } // Apply QR Algorithm
+
+
+      HessenbergQR(clone, digit);
+
+      for (var _j = 0; _j < size; _j++) {
+        clone[_j][_j] += shift;
+      }
+
+      if (isConvergent && prev < Math.abs(clone[i][i - 1])) {
+        divergenceCount++;
+      } // if the current eigenvalue is real and the entry is almost ZERO => break;
+
+
+      if (isConvergent && Math.abs(clone[i][i - 1]) < EPSILON) {
+        values[i] = new lib(clone[i][i]);
+        break;
+      } // if the current eigenvalues pair is complex, if the difference of the previous eiganvalues and the
+      // eigenvalues of submatrix is almost ZERO => break
+
+
+      var _size2Eigenvalues = size2Eigenvalues(clone[i - 1][i - 1], clone[i - 1][i], clone[i][i - 1], clone[i][i]),
+          metric = _size2Eigenvalues.metric,
+          eigen1 = _size2Eigenvalues.eigen1,
+          eigen2 = _size2Eigenvalues.eigen2;
+
+      if (!isConvergent && Math.abs(prev - metric) < EPSILON) {
+        isConvergent = true; // re-initialize
+
+        skip = true;
+        var re1 = eigen1.re,
+            im1 = eigen1.im;
+        var re2 = eigen2.re,
+            im2 = eigen2.im;
+        values[i] = new lib(re1, im1);
+        values[i - 1] = new lib(re2, im2);
+        break;
+      } // if the entry doesn't converge => complex eigenvalues pair
+
+
+      if (divergenceCount > 3) {
+        isConvergent = false;
+      }
+    }
+  }
+
+  if (!skip) {
+    values[0] = new lib(clone[0][0]);
+  }
+
+  this._eigenvalues = values;
+  return values;
+}
+
+function HouseholderTransform(A, digit) {
+  var size = A.length;
+  var EPSILON = 1 / (Math.pow(10, digit) * 2);
+
+  for (var j = 0; j < size - 2; j++) {
+    var xNorm = 0;
+    var u = new Array(size - j - 1);
+
+    for (var i = j + 1; i < size; i++) {
+      var entry = A[i][j];
+      xNorm += Math.pow(entry, 2);
+      u[i - j - 1] = entry;
+    }
+
+    xNorm = Math.sqrt(xNorm);
+
+    if (Math.abs(xNorm) < EPSILON) {
+      continue;
+    }
+
+    if (u[0] >= 0) {
+      u[0] += xNorm;
+    } else {
+      u[0] -= xNorm;
+    } // Make 'u' unit vector
+
+
+    var uNorm = 0;
+
+    for (var _i = 0; _i < u.length; _i++) {
+      uNorm += Math.pow(u[_i], 2);
+    }
+
+    uNorm = Math.sqrt(uNorm);
+
+    for (var _i2 = 0; _i2 < u.length; _i2++) {
+      u[_i2] /= uNorm;
+    } // update the matrix, multiply P from left
+
+
+    for (var n = j; n < size; n++) {
+      // column
+      var v = new Array(size - j - 1);
+
+      for (var m = j + 1; m < size; m++) {
+        v[m - j - 1] = A[m][n];
+      }
+
+      var scaler = 0;
+
+      for (var _m = 0; _m < v.length; _m++) {
+        scaler += v[_m] * u[_m];
+      }
+
+      scaler *= 2;
+
+      for (var _m2 = j + 1; _m2 < size; _m2++) {
+        // row
+        if (n === j && _m2 !== j + 1) {
+          A[_m2][n] = 0;
+        } else {
+          A[_m2][n] = v[_m2 - j - 1] - scaler * u[_m2 - j - 1];
+        }
+      }
+    } // update the matrix, multiply P from right
+
+
+    for (var _m3 = 0; _m3 < size; _m3++) {
+      // row
+      var _v = new Array(size - j - 1);
+
+      for (var _n = j + 1; _n < size; _n++) {
+        _v[_n - j - 1] = A[_m3][_n];
+      }
+
+      var _scaler = 0;
+
+      for (var _n2 = 0; _n2 < _v.length; _n2++) {
+        _scaler += _v[_n2] * u[_n2];
+      }
+
+      _scaler *= 2;
+
+      for (var _n3 = j + 1; _n3 < size; _n3++) {
+        // column
+        A[_m3][_n3] = _v[_n3 - j - 1] - _scaler * u[_n3 - j - 1];
+      }
+    }
+  }
+}
+
+function HessenbergQR(H, digit) {
+  var size = H.length;
+  var EPSILON = 1 / (Math.pow(10, digit) * 2);
+  var sincos = new Array(size - 1);
+
+  for (var i = 0; i < size - 1; i++) {
+    var a = H[i][i];
+    var c = H[i + 1][i];
+    var norm = Math.sqrt(Math.pow(a, 2) + Math.pow(c, 2));
+
+    if (norm < EPSILON) {
+      continue;
+    }
+
+    var cos = a / norm;
+    var sin = c * -1 / norm;
+    sincos[i] = [sin, cos];
+    var row1 = new Array(size - i);
+    var row2 = new Array(size - i);
+
+    for (var j = i; j < size; j++) {
+      row1[j - i] = H[i][j];
+      row2[j - i] = H[i + 1][j];
+    }
+
+    for (var _j2 = i; _j2 < size; _j2++) {
+      H[i][_j2] = cos * row1[_j2 - i] + sin * -1 * row2[_j2 - i];
+
+      if (i === _j2) {
+        H[i + 1][_j2] = 0;
+      } else {
+        H[i + 1][_j2] = sin * row1[_j2 - i] + cos * row2[_j2 - i];
+      }
+    }
+  }
+
+  for (var _j3 = 0; _j3 < size - 1; _j3++) {
+    if (!sincos[_j3]) {
+      continue;
+    }
+
+    var _sincos$_j = _slicedToArray$4(sincos[_j3], 2),
+        _sin = _sincos$_j[0],
+        _cos = _sincos$_j[1];
+
+    var col1 = new Array(_j3 + 2);
+    var col2 = new Array(_j3 + 2);
+
+    for (var _i3 = 0; _i3 <= _j3 + 1; _i3++) {
+      col1[_i3] = H[_i3][_j3];
+      col2[_i3] = H[_i3][_j3 + 1];
+    }
+
+    for (var _i4 = 0; _i4 <= _j3 + 1; _i4++) {
+      H[_i4][_j3] = col1[_i4] * _cos - col2[_i4] * _sin;
+      H[_i4][_j3 + 1] = col1[_i4] * _sin + col2[_i4] * _cos;
+    }
+  }
+} // find the eigenvalues of 2x2 matrix
+
+
+function size2Eigenvalues(e11, e12, e21, e22) {
+  var b = (e11 + e22) * -1;
+  var c = e11 * e22 - e21 * e12;
+  var delta = Math.pow(b, 2) - 4 * c;
+  var re1;
+  var im1;
+  var re2;
+  var im2;
+
+  if (delta >= 0) {
+    im1 = 0;
+    im2 = 0;
+
+    if (b >= 0) {
+      re1 = (b * -1 - Math.sqrt(delta)) / 2;
+    } else {
+      re1 = (b * -1 + Math.sqrt(delta)) / 2;
+    }
+
+    re2 = c / re1;
+  } else {
+    re1 = -b / 2;
+    re2 = re1;
+    im1 = Math.sqrt(delta * -1) / 2;
+    im2 = im1 * -1;
+  }
+
+  return {
+    metric: Math.sqrt(Math.pow(re1, 2) + Math.pow(im1, 2)),
+    eigen1: {
+      re: re1,
+      im: im1
+    },
+    eigen2: {
+      re: re2,
+      im: im2
+    }
+  };
+}
+
+var eigenvalues_1 = eigenvalues;
+
+/**
+ * Calculates the nullity of any Matrix, which is the dimension
+ * of the nullspace.<br><br>
+ * 
+ * The nullity is cached.
+ * @memberof Matrix
+ * @instance
+ * @returns {number} The nullity of the matrix
+ */
+function nullity() {
+  if (this._nullity !== undefined) {
+    return this._nullity;
+  }
+
+  var col = this.size()[1];
+  var rank = this.rank();
+  this._nullity = col - rank;
+  return this._nullity;
+}
+var nullity_1 = nullity;
+
+function _slicedToArray$5(arr, i) { return _arrayWithHoles$5(arr) || _iterableToArrayLimit$5(arr, i) || _unsupportedIterableToArray$5(arr, i) || _nonIterableRest$5(); }
+
+function _nonIterableRest$5() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray$5(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray$5(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray$5(o, minLen); }
+
+function _arrayLikeToArray$5(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit$5(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles$5(arr) { if (Array.isArray(arr)) return arr; }
+
+
+
+var INVALID_P_NORM$1 = _Error.INVALID_P_NORM;
+/**
+ * Calculates the Matrix norm of any Matrix with respect to the choice of norm.<br><br>
+ * 
+ * 1-norm: Maximum absolute column sum of the Matrix.<br>
+ * 2-norm: The largest singular value of Matrix.<br>
+ * Infinity-norm: Maximum absolute row sum of the Matrix.<br>
+ * Frobenius-norm: Euclidean norm invloving all entries.<br><br>
+ * 
+ * The norms are not cached.
+ * @memberof Matrix
+ * @instance
+ * @param {(1|2|Infinity|'F')} p - The choice of Matrix norm
+ * @returns {number} The norm of the Matrix.
+ */
+
+
+function norm() {
+  var p = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 2;
+
+  var _this$size = this.size(),
+      _this$size2 = _slicedToArray$5(_this$size, 2),
+      row = _this$size2[0],
+      col = _this$size2[1];
+
+  if (p !== 1 && p !== 2 && p !== Infinity && p !== 'F') {
+    throw new Error(INVALID_P_NORM$1);
+  }
+
+  var matrix = this._matrix;
+  var result = 0;
+
+  if (p === 1) {
+    // max of column sum
+    for (var j = 0; j < col; j++) {
+      var columnSum = 0;
+
+      for (var i = 0; i < row; i++) {
+        columnSum += Math.abs(matrix[i][j]);
+      }
+
+      if (columnSum > result) {
+        result = columnSum;
+      }
+    }
+
+    return result;
+  } // largest singular value
+
+
+  if (p === 2) {
+    var transpose = lib$1.transpose(this);
+    var M = lib$1.multiply(transpose, this);
+    var eigenvalues = M.eigenvalues();
+
+    for (var _i2 = 0; _i2 < eigenvalues.length; _i2++) {
+      var value = eigenvalues[_i2].getModulus();
+
+      if (value > result) {
+        result = value;
+      }
+    }
+
+    return Math.sqrt(result);
+  }
+
+  if (p === Infinity) {
+    // max of row sum
+    for (var _i3 = 0; _i3 < row; _i3++) {
+      var rowSum = 0;
+
+      for (var _j = 0; _j < col; _j++) {
+        rowSum += Math.abs(matrix[_i3][_j]);
+      }
+
+      if (rowSum > result) {
+        result = rowSum;
+      }
+    }
+
+    return result;
+  } // F
+
+
+  for (var _i4 = 0; _i4 < row; _i4++) {
+    for (var _j2 = 0; _j2 < col; _j2++) {
+      result += Math.pow(matrix[_i4][_j2], 2);
+    }
+  }
+
+  return Math.sqrt(result);
+}
+var norm_1 = norm;
+
+function _slicedToArray$6(arr, i) { return _arrayWithHoles$6(arr) || _iterableToArrayLimit$6(arr, i) || _unsupportedIterableToArray$6(arr, i) || _nonIterableRest$6(); }
+
+function _nonIterableRest$6() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray$6(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray$6(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray$6(o, minLen); }
+
+function _arrayLikeToArray$6(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit$6(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles$6(arr) { if (Array.isArray(arr)) return arr; }
+
+
+/**
+ * Calculates the rank of any Matrix,
+ * which is the dimension of the row space.<br><br>
+ * 
+ * The rank is cached.
+ * @memberof Matrix
+ * @instance
+ * @returns {number} The rank of the Matrix
+ */
+
+
+function rank() {
+  if (this._rank !== undefined) {
+    return this._rank;
+  }
+
+  var EPSILON = 1 / (Math.pow(10, this._digit) * 2);
+  var R = lib$1.QR(this)[1];
+  var matrixR = R._matrix;
+
+  var _R$size = R.size(),
+      _R$size2 = _slicedToArray$6(_R$size, 2),
+      row = _R$size2[0],
+      col = _R$size2[1];
+
+  if (row === 0) {
+    this._rank = 1;
+    return 1;
+  }
+
+  var rk = 0;
+
+  for (var i = 0; i < row; i++) {
+    for (var j = i; j < col; j++) {
+      if (Math.abs(matrixR[i][j]) >= EPSILON) {
+        rk++;
+        break;
+      }
+    }
+  }
+
+  this._rank = rk;
+  return rk;
+}
+var rank_1 = rank;
+
+/**
+ * Calculates the size of any Matrix,
+ * which is in the form of [row, column].<br><br>
+ * 
+ * The size of Matrix is cached.
+ * @memberof Matrix
+ * @instance
+ * @returns {number[]} The number of rows and columns of a Matrix
+ */
+function size() {
+  if (this._size !== undefined) {
+    return this._size;
+  }
+
+  var A = this._matrix;
+
+  if (A.length === 0) {
+    this._size = [0, 0];
+    return this._size;
+  }
+
+  this._size = [A.length, A[0].length];
+  return this._size;
+}
+var size_1 = size;
+
+var INVALID_SQUARE_MATRIX$3 = _Error.INVALID_SQUARE_MATRIX;
+/**
+ * Calculates the trace of any square Matrix,
+ * which is the sum of all entries on the main diagonal.<br><br>
+ * 
+ * The trace is cached.
+ * @memberof Matrix
+ * @instance
+ * @returns {number} The trace of the square Matrix.
+ */
+
+
+function trace$1() {
+  var isSquare = this._isSquare !== undefined ? this._isSquare : this.isSquare();
+
+  if (!isSquare) {
+    throw new Error(INVALID_SQUARE_MATRIX$3);
+  }
+
+  if (this._trace !== undefined) {
+    return this._trace;
+  }
+
+  var A = this._matrix;
+  var size = A.length;
+  var tr = 0;
+
+  for (var i = 0; i < size; i++) {
+    tr += A[i][i];
+  }
+
+  this._trace = tr;
+  return tr;
+}
+var trace_1 = trace$1;
+
+function _slicedToArray$7(arr, i) { return _arrayWithHoles$7(arr) || _iterableToArrayLimit$7(arr, i) || _unsupportedIterableToArray$7(arr, i) || _nonIterableRest$7(); }
+
+function _nonIterableRest$7() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray$7(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray$7(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray$7(o, minLen); }
+
+function _arrayLikeToArray$7(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit$7(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles$7(arr) { if (Array.isArray(arr)) return arr; }
+
+var INVALID_MATRIX = _Error.INVALID_MATRIX,
+    SIZE_INCOMPATIBLE = _Error.SIZE_INCOMPATIBLE;
+/**
+ * Calculates the sum of two Matrices.
+ * @memberof Matrix
+ * @static
+ * @param {Matrix} A - Any Matrix
+ * @param {Matrix} B - Any Matrix that has same size with A
+ * @returns {Matrix} The sum of two Matrices
+ */
+
+
+function add$1(A, B) {
+  if (!(A instanceof this) || !(B instanceof this)) {
+    throw new Error(INVALID_MATRIX);
+  }
+
+  var _A$size = A.size(),
+      _A$size2 = _slicedToArray$7(_A$size, 2),
+      row = _A$size2[0],
+      col = _A$size2[1];
+
+  var _B$size = B.size(),
+      _B$size2 = _slicedToArray$7(_B$size, 2),
+      row2 = _B$size2[0],
+      col2 = _B$size2[1];
+
+  if (row !== row2 || col !== col2) {
+    throw new Error(SIZE_INCOMPATIBLE);
+  }
+
+  var matrix1 = A._matrix;
+  var matrix2 = B._matrix;
+  return this.generate(row, col, function (i, j) {
+    return matrix1[i][j] + matrix2[i][j];
+  });
+}
+var add_1$1 = add$1;
+
+var INVALID_MATRIX$1 = _Error.INVALID_MATRIX,
+    INVALID_SQUARE_MATRIX$4 = _Error.INVALID_SQUARE_MATRIX,
+    SINGULAR_MATRIX$1 = _Error.SINGULAR_MATRIX;
+
+
+/**
+ * Find the inverse of non-singular matrix using Elementary Row Operations.
+ * If the matrix is singular, an error is thrown.
+ * @memberof Matrix
+ * @static
+ * @param {Matrix} A - Any square Matrix
+ * @returns {Matrix} The inverse of A
+ */
+
+
+function inverse$1(A) {
+  if (!(A instanceof this)) {
+    throw new Error(INVALID_MATRIX$1);
+  }
+
+  if (!A.isSquare()) {
+    throw new Error(INVALID_SQUARE_MATRIX$4);
+  }
+
+  var size = A.size()[0];
+
+  if (size === 0) {
+    // inverse of 0x0 matrix is itself
+    return new lib$1([]);
+  }
+
+  var EPSILON = 1 / (Math.pow(10, A._digit) * 2);
+
+  var inv = this.identity(size)._matrix;
+
+  var clone = this.clone(A)._matrix;
+
+  var permutation = initPermutation(size); // iterate each column
+
+  for (var j = 0; j < size; j++) {
+    var pivotIdx = j;
+    var pivot = clone[permutation[j]][j];
+
+    while (Math.abs(pivot) < EPSILON && pivotIdx < size - 1) {
+      pivotIdx++;
+      pivot = clone[permutation[pivotIdx]][j];
+    }
+
+    if (Math.abs(pivot) < EPSILON) {
+      throw new Error(SINGULAR_MATRIX$1);
+    }
+
+    if (j !== pivotIdx) {
+      var temp = permutation[j];
+      permutation[j] = permutation[pivotIdx];
+      permutation[pivotIdx] = temp;
+    }
+
+    var pivotRow = permutation[j]; // the pivot is guaranteed to be non-zero
+
+    for (var i = 0; i < size; i++) {
+      var ith = permutation[i];
+
+      if (i === j) {
+        for (var k = 0; k < size; k++) {
+          if (k === j) {
+            clone[ith][k] = 1;
+          }
+
+          if (k > j) {
+            clone[ith][k] /= pivot;
+          }
+
+          inv[ith][k] /= pivot;
+        }
+
+        pivot = 1;
+      }
+
+      if (i !== j && Math.abs(clone[ith][j]) >= EPSILON) {
+        var factor = clone[ith][j] / pivot;
+
+        for (var _k = 0; _k < size; _k++) {
+          if (_k === j) {
+            clone[ith][_k] = 0;
+          }
+
+          if (_k > j) {
+            clone[ith][_k] -= factor * clone[pivotRow][_k];
+          }
+
+          inv[ith][_k] -= factor * inv[pivotRow][_k];
+        }
+      }
+    }
+  }
+
+  for (var _i = 0; _i < size; _i++) {
+    clone[_i] = inv[permutation[_i]];
+  }
+
+  return new this(clone);
+}
+
+function initPermutation(size) {
+  var permutation = new Array(size);
+
+  for (var i = 0; i < size; i++) {
+    permutation[i] = i;
+  }
+
+  return permutation;
+}
+
+var inverse_1$1 = inverse$1;
+
+var INVALID_ROW_COL = _Error.INVALID_ROW_COL;
+
+var empty = function empty(row, col) {
+  if (!Number.isInteger(row) || row < 0 || !Number.isInteger(col) || col < 0) {
+    throw new Error(INVALID_ROW_COL);
+  }
+
+  if (row === 0 || col === 0) {
+    return [];
+  }
+
+  var matrix = new Array(row);
+
+  for (var i = 0; i < row; i++) {
+    matrix[i] = new Array(col);
+  }
+
+  return matrix;
+};
+
+function _slicedToArray$8(arr, i) { return _arrayWithHoles$8(arr) || _iterableToArrayLimit$8(arr, i) || _unsupportedIterableToArray$8(arr, i) || _nonIterableRest$8(); }
+
+function _nonIterableRest$8() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray$8(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray$8(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray$8(o, minLen); }
+
+function _arrayLikeToArray$8(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit$8(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles$8(arr) { if (Array.isArray(arr)) return arr; }
+
+
+
+var INVALID_MATRIX$2 = _Error.INVALID_MATRIX,
+    SIZE_INCOMPATIBLE$1 = _Error.SIZE_INCOMPATIBLE;
+/**
+ * Calculates the product of two Matrices.
+ * @memberof Matrix
+ * @static
+ * @param {Matrix} A - Any Matrix
+ * @param {Matrix} B - Any Matrix that is size-compatible with A
+ * @returns {Matrix} The product of two Matrices
+ */
+
+
+function multiply$1(A, B) {
+  if (!(A instanceof this) || !(B instanceof this)) {
+    throw new Error(INVALID_MATRIX$2);
+  }
+
+  var _A$size = A.size(),
+      _A$size2 = _slicedToArray$8(_A$size, 2),
+      Arow = _A$size2[0],
+      Acol = _A$size2[1];
+
+  var _B$size = B.size(),
+      _B$size2 = _slicedToArray$8(_B$size, 2),
+      Brow = _B$size2[0],
+      Bcol = _B$size2[1];
+
+  if (Acol !== Brow) {
+    throw new Error(SIZE_INCOMPATIBLE$1);
+  }
+
+  var matrixA = A._matrix;
+  var matrixB = B._matrix;
+  var result = empty(Arow, Bcol);
+
+  for (var i = 0; i < Arow; i++) {
+    for (var j = 0; j < Bcol; j++) {
+      result[i][j] = 0;
+
+      for (var k = 0; k < Brow; k++) {
+        result[i][j] += matrixA[i][k] * matrixB[k][j];
+      }
+    }
+  }
+
+  return new this(result);
+}
+var multiply_1$1 = multiply$1;
+
+var INVALID_MATRIX$3 = _Error.INVALID_MATRIX,
+    INVALID_SQUARE_MATRIX$5 = _Error.INVALID_SQUARE_MATRIX,
+    INVALID_EXPONENT = _Error.INVALID_EXPONENT;
+/**
+ * Calculates the power of any square matrix.
+ * The algorithm is implemented recursively.
+ * @memberof Matrix
+ * @static
+ * @param {Matrix} A - Any square Matrix
+ * @param {number} exponent - Any Non-negative integer
+ * @returns {Matrix} The power of A
+ */
+
+
+function pow$1(A, exponent) {
+  if (!(A instanceof this)) {
+    throw new Error(INVALID_MATRIX$3);
+  }
+
+  if (!A.isSquare()) {
+    throw new Error(INVALID_SQUARE_MATRIX$5);
+  }
+
+  if (!Number.isInteger(exponent) || exponent < 0) {
+    throw new Error(INVALID_EXPONENT);
+  }
+
+  var size = A.size()[0];
+
+  if (exponent === 0) {
+    return this.identity(size);
+  }
+
+  if (exponent === 1) {
+    return this.clone(A);
+  }
+
+  if (exponent % 2 === 0) {
+    var _temp = this.pow(A, exponent / 2);
+
+    return this.multiply(_temp, _temp);
+  }
+
+  var temp = this.pow(A, (exponent - 1) / 2);
+  return this.multiply(this.multiply(temp, temp), A);
+}
+var pow_1$1 = pow$1;
+
+function _slicedToArray$9(arr, i) { return _arrayWithHoles$9(arr) || _iterableToArrayLimit$9(arr, i) || _unsupportedIterableToArray$9(arr, i) || _nonIterableRest$9(); }
+
+function _nonIterableRest$9() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray$9(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray$9(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray$9(o, minLen); }
+
+function _arrayLikeToArray$9(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit$9(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles$9(arr) { if (Array.isArray(arr)) return arr; }
+
+var SIZE_INCOMPATIBLE$2 = _Error.SIZE_INCOMPATIBLE,
+    INVALID_MATRIX$4 = _Error.INVALID_MATRIX;
+/**
+ * Calculates the difference of two Matrices.
+ * @memberof Matrix
+ * @static
+ * @param {Matrix} A - Any Matrix
+ * @param {Matrix} B - Any Matrix that has same size with A
+ * @returns {Matrix} The difference of two Matrices
+ */
+
+
+var subtract$1 = function subtract(A, B) {
+  if (!(A instanceof this) || !(B instanceof this)) {
+    throw new Error(INVALID_MATRIX$4);
+  }
+
+  var _A$size = A.size(),
+      _A$size2 = _slicedToArray$9(_A$size, 2),
+      row = _A$size2[0],
+      col = _A$size2[1];
+
+  var _B$size = B.size(),
+      _B$size2 = _slicedToArray$9(_B$size, 2),
+      row2 = _B$size2[0],
+      col2 = _B$size2[1];
+
+  if (row !== row2 || col !== col2) {
+    throw new Error(SIZE_INCOMPATIBLE$2);
+  }
+
+  var matrix1 = A._matrix;
+  var matrix2 = B._matrix;
+  return this.generate(row, col, function (i, j) {
+    return matrix1[i][j] - matrix2[i][j];
+  });
+};
+
+function _slicedToArray$a(arr, i) { return _arrayWithHoles$a(arr) || _iterableToArrayLimit$a(arr, i) || _unsupportedIterableToArray$a(arr, i) || _nonIterableRest$a(); }
+
+function _nonIterableRest$a() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray$a(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray$a(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray$a(o, minLen); }
+
+function _arrayLikeToArray$a(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit$a(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles$a(arr) { if (Array.isArray(arr)) return arr; }
+
+var INVALID_MATRIX$5 = _Error.INVALID_MATRIX;
+/**
+ * Find the transpose of a matrix.
+ * @memberof Matrix
+ * @static
+ * @param { Matrix } A - Any Matrix
+ * @returns { Matrix } Returns transpose of A
+ */
+
+
+function transpose$1(A) {
+  if (!(A instanceof this)) {
+    throw new Error(INVALID_MATRIX$5);
+  }
+
+  var _A$size = A.size(),
+      _A$size2 = _slicedToArray$a(_A$size, 2),
+      row = _A$size2[0],
+      col = _A$size2[1];
+
+  var matrix = A._matrix;
+  return this.generate(col, row, function (i, j) {
+    return matrix[j][i];
+  });
+}
+var transpose_1 = transpose$1;
+
+function _slicedToArray$b(arr, i) { return _arrayWithHoles$b(arr) || _iterableToArrayLimit$b(arr, i) || _unsupportedIterableToArray$b(arr, i) || _nonIterableRest$b(); }
+
+function _nonIterableRest$b() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray$b(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray$b(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray$b(o, minLen); }
+
+function _arrayLikeToArray$b(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit$b(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles$b(arr) { if (Array.isArray(arr)) return arr; }
+
+
+
+var INVALID_MATRIX$6 = _Error.INVALID_MATRIX,
+    INVALID_UPPER_TRIANGULAR_MATRIX = _Error.INVALID_UPPER_TRIANGULAR_MATRIX,
+    INVALID_SQUARE_MATRIX$6 = _Error.INVALID_SQUARE_MATRIX,
+    SIZE_INCOMPATIBLE$3 = _Error.SIZE_INCOMPATIBLE,
+    NO_UNIQUE_SOLUTION = _Error.NO_UNIQUE_SOLUTION;
+/**
+* Solve system of linear equations Ux = y using backward substitution,
+* where U is an upper triangular matrix.
+* If there is no unique solutions, an error is thrown.
+* @memberof Matrix
+* @static
+* @param {Matrix} U - Any n x n upper triangular Matrix
+* @param {Matrix} y - Any n x 1 Matrix
+* @returns {Matrix} n x 1 Matrix which is the solution of Ux = y
+*/
+
+
+function backward(U, y) {
+  if (!(U instanceof this) || !(y instanceof this)) {
+    throw new Error(INVALID_MATRIX$6);
+  }
+
+  if (!U.isUpperTriangular()) {
+    throw new Error(INVALID_UPPER_TRIANGULAR_MATRIX);
+  }
+
+  if (!U.isSquare()) {
+    throw new Error(INVALID_SQUARE_MATRIX$6);
+  }
+
+  var size = U.size()[0];
+
+  var _y$size = y.size(),
+      _y$size2 = _slicedToArray$b(_y$size, 2),
+      yrow = _y$size2[0],
+      ycol = _y$size2[1];
+
+  var matrixU = U._matrix;
+  var matrixY = y._matrix;
+
+  if (yrow !== size || ycol !== 1) {
+    throw new Error(SIZE_INCOMPATIBLE$3);
+  }
+
+  var EPSILON = 1 / (Math.pow(10, U._digit) * 2);
+
+  for (var i = 0; i < size; i++) {
+    if (Math.abs(matrixU[i][i]) < EPSILON) {
+      throw new Error(NO_UNIQUE_SOLUTION);
+    }
+  }
+
+  var coefficients = empty(size, 1);
+
+  for (var _i2 = size - 1; _i2 >= 0; _i2--) {
+    var summation = 0;
+
+    for (var j = _i2 + 1; j < size; j++) {
+      summation += coefficients[j][0] * matrixU[_i2][j];
+    }
+
+    coefficients[_i2][0] = (matrixY[_i2][0] - summation) / matrixU[_i2][_i2];
+  }
+
+  return new this(coefficients);
+}
+var backward_1 = backward;
+
+function _slicedToArray$c(arr, i) { return _arrayWithHoles$c(arr) || _iterableToArrayLimit$c(arr, i) || _unsupportedIterableToArray$c(arr, i) || _nonIterableRest$c(); }
+
+function _nonIterableRest$c() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray$c(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray$c(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray$c(o, minLen); }
+
+function _arrayLikeToArray$c(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit$c(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles$c(arr) { if (Array.isArray(arr)) return arr; }
+
+
+
+var INVALID_MATRIX$7 = _Error.INVALID_MATRIX,
+    INVALID_LOWER_TRIANGULAR_MATRIX = _Error.INVALID_LOWER_TRIANGULAR_MATRIX,
+    INVALID_SQUARE_MATRIX$7 = _Error.INVALID_SQUARE_MATRIX,
+    SIZE_INCOMPATIBLE$4 = _Error.SIZE_INCOMPATIBLE,
+    NO_UNIQUE_SOLUTION$1 = _Error.NO_UNIQUE_SOLUTION;
+/**
+ * Solve system of linear equations Lx = y using forward substitution,
+ * where L is a lower triangular matrix.
+ * If there is no unique solutions, an error is thrown.
+ * @memberof Matrix
+ * @static
+ * @param {Matrix} L - Any n x n lower triangular Matrix
+ * @param {Matrix} y - Any n x 1 Matrix
+ * @returns {Matrix} n x 1 Matrix which is the solution of Lx = y
+ */
+
+
+function forward(L, y) {
+  if (!(L instanceof this) || !(y instanceof this)) {
+    throw new Error(INVALID_MATRIX$7);
+  }
+
+  if (!L.isLowerTriangular()) {
+    throw new Error(INVALID_LOWER_TRIANGULAR_MATRIX);
+  }
+
+  if (!L.isSquare()) {
+    throw new Error(INVALID_SQUARE_MATRIX$7);
+  }
+
+  var size = L.size()[0];
+
+  var _y$size = y.size(),
+      _y$size2 = _slicedToArray$c(_y$size, 2),
+      yrow = _y$size2[0],
+      ycol = _y$size2[1];
+
+  var matrixL = L._matrix;
+  var matrixY = y._matrix;
+
+  if (size !== yrow || ycol !== 1) {
+    throw new Error(SIZE_INCOMPATIBLE$4);
+  }
+
+  var EPSILON = 1 / (Math.pow(10, L._digit) * 2);
+
+  for (var i = 0; i < size; i++) {
+    if (Math.abs(matrixL[i][i]) < EPSILON) {
+      throw new Error(NO_UNIQUE_SOLUTION$1);
+    }
+  }
+
+  var coefficients = empty(size, 1);
+
+  for (var _i2 = 0; _i2 < size; _i2++) {
+    var summation = 0;
+
+    for (var j = 0; j < _i2; j++) {
+      summation += coefficients[j][0] * matrixL[_i2][j];
+    }
+
+    coefficients[_i2][0] = (matrixY[_i2][0] - summation) / matrixL[_i2][_i2];
+  }
+
+  return new this(coefficients);
+}
+var forward_1 = forward;
+
+function _slicedToArray$d(arr, i) { return _arrayWithHoles$d(arr) || _iterableToArrayLimit$d(arr, i) || _unsupportedIterableToArray$d(arr, i) || _nonIterableRest$d(); }
+
+function _nonIterableRest$d() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray$d(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray$d(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray$d(o, minLen); }
+
+function _arrayLikeToArray$d(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit$d(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles$d(arr) { if (Array.isArray(arr)) return arr; }
+
+var INVALID_MATRIX$8 = _Error.INVALID_MATRIX,
+    NO_UNIQUE_SOLUTION$2 = _Error.NO_UNIQUE_SOLUTION,
+    INVALID_SQUARE_MATRIX$8 = _Error.INVALID_SQUARE_MATRIX,
+    SIZE_INCOMPATIBLE$5 = _Error.SIZE_INCOMPATIBLE;
+/**
+ * Solve system of linear equations Ax = y using LU decomposition.
+ * If there is no unique solutions, an error is thrown.
+ * @memberof Matrix
+ * @static
+ * @param {Matrix} L - Any n x n square Matrix
+ * @param {Matrix} y - Any n x 1 Matrix
+ * @returns {Matrix} n x 1 Matrix which is the solution of Ax = y
+ */
+
+
+function solve(A, b) {
+  if (!(A instanceof this) || !(b instanceof this)) {
+    throw new Error(INVALID_MATRIX$8);
+  }
+
+  if (!A.isSquare()) {
+    throw new Error(INVALID_SQUARE_MATRIX$8);
+  }
+
+  var _A$size = A.size(),
+      _A$size2 = _slicedToArray$d(_A$size, 2),
+      aRow = _A$size2[0],
+      aCol = _A$size2[1];
+
+  var _b$size = b.size(),
+      _b$size2 = _slicedToArray$d(_b$size, 2),
+      bRow = _b$size2[0],
+      bCol = _b$size2[1];
+
+  if (aCol !== bRow || bCol !== 1) {
+    throw new Error(SIZE_INCOMPATIBLE$5);
+  }
+
+  var EPSILON = 1 / (Math.pow(10, A._digit) * 2);
+
+  var _this$LU = this.LU(A, true),
+      _this$LU2 = _slicedToArray$d(_this$LU, 2),
+      P = _this$LU2[0],
+      LU = _this$LU2[1];
+
+  var matrixLU = LU._matrix;
+  var matrixB = b._matrix;
+
+  for (var i = aRow - 1; i >= 0; i--) {
+    if (Math.abs(matrixLU[i][i]) < EPSILON) {
+      throw new Error(NO_UNIQUE_SOLUTION$2);
+    }
+  }
+
+  var clonedVector = new Array(bRow);
+  var coefficients = new Array(bRow);
+
+  for (var _i2 = 0; _i2 < bRow; _i2++) {
+    // eslint-disable-next-line prefer-destructuring
+    clonedVector[_i2] = matrixB[P[_i2]][0];
+  }
+
+  for (var _i3 = 0; _i3 < aRow; _i3++) {
+    var summation = 0;
+
+    for (var j = 0; j < _i3; j++) {
+      summation += coefficients[j] * matrixLU[_i3][j];
+    }
+
+    coefficients[_i3] = clonedVector[_i3] - summation;
+  }
+
+  for (var _i4 = aRow - 1; _i4 >= 0; _i4--) {
+    var _summation = 0;
+
+    for (var _j = _i4 + 1; _j < aRow; _j++) {
+      _summation += matrixLU[_i4][_j] * clonedVector[_j];
+    }
+
+    clonedVector[_i4] = (coefficients[_i4] - _summation) / matrixLU[_i4][_i4];
+  }
+
+  for (var _i5 = 0; _i5 < bRow; _i5++) {
+    coefficients[_i5] = [clonedVector[_i5]];
+  }
+
+  return new this(coefficients);
+}
+var solve_1 = solve;
+
+function _slicedToArray$e(arr, i) { return _arrayWithHoles$e(arr) || _iterableToArrayLimit$e(arr, i) || _unsupportedIterableToArray$e(arr, i) || _nonIterableRest$e(); }
+
+function _nonIterableRest$e() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray$e(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray$e(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray$e(o, minLen); }
+
+function _arrayLikeToArray$e(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit$e(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles$e(arr) { if (Array.isArray(arr)) return arr; }
+
+var INVALID_MATRIX$9 = _Error.INVALID_MATRIX;
+/**
+ * Calculates the LUP decomposition of the Matrix,
+ * where L is lower triangular matrix which diagonal entries are always 1,
+ * U is upper triangular matrix, and P is permutation matrix.<br><br>
+ * 
+ * It is implemented using Gaussian Elimination with Partial Pivoting in order to
+ * reduce the error caused by floating-point arithmetic.<br><br>
+ * 
+ * Note that if optimized is true, P is a Permutation Array and both L and U are merged
+ * into one matrix in order to improve performance.
+ * @memberof Matrix
+ * @static
+ * @param {Matrix} A - Any matrix
+ * @param {boolean} [optimized=false] - Returns [P, LU] if it is true, [P, L, U] if it is false
+ * @returns {Matrix[]} The LUP decomposition of Matrix
+ */
+
+
+function LU(A) {
+  var optimized = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
+
+  if (!(A instanceof this)) {
+    throw new Error(INVALID_MATRIX$9);
+  }
+
+  var _A$size = A.size(),
+      _A$size2 = _slicedToArray$e(_A$size, 2),
+      row = _A$size2[0],
+      col = _A$size2[1];
+
+  var size = Math.min(row, col);
+  var EPSILON = 1 / (Math.pow(10, A._digit) * 2);
+  var permutation = initPermutation$1(row);
+
+  var copy = this.clone(A)._matrix;
+
+  for (var i = 0; i < row - 1; i++) {
+    var currentCol = Math.min(i, col); // apply Partial Pivoting
+
+    PartialPivoting(copy, permutation, currentCol, row, col);
+    var ith = permutation[i];
+    var pivot = copy[ith][currentCol];
+
+    if (Math.abs(pivot) < EPSILON) {
+      continue;
+    }
+
+    for (var j = i + 1; j < row; j++) {
+      var jth = permutation[j];
+      var entry = copy[jth][currentCol];
+
+      if (Math.abs(entry) >= EPSILON) {
+        var factor = entry / pivot;
+
+        for (var k = currentCol; k < col; k++) {
+          copy[jth][k] -= factor * copy[ith][k];
+        }
+
+        copy[jth][currentCol] = factor;
+      }
+    }
+  }
+
+  var result = new Array(row);
+
+  for (var _i2 = 0; _i2 < row; _i2++) {
+    result[_i2] = copy[permutation[_i2]];
+  }
+
+  if (optimized) {
+    return [permutation, new this(result)];
+  }
+
+  var P = this.generate(row, row, function (i, j) {
+    var idx = permutation[i];
+
+    if (j === idx) {
+      return 1;
+    }
+
+    return 0;
+  });
+  var L = this.generate(row, size, function (i, j) {
+    if (i === j) {
+      return 1;
+    }
+
+    if (i < j) {
+      return 0;
+    }
+
+    return result[i][j];
+  });
+  var U = this.generate(size, col, function (i, j) {
+    if (i > j) {
+      return 0;
+    }
+
+    return result[i][j];
+  });
+  return [P, L, U];
+}
+
+function initPermutation$1(size) {
+  var permutation = new Array(size);
+
+  for (var i = 0; i < size; i++) {
+    permutation[i] = i;
+  }
+
+  return permutation;
+}
+
+function PartialPivoting(matrix, permutation, pos, row, col) {
+  var currentCol = Math.min(pos, col);
+  var maxIdx = pos;
+  var max = Math.abs(matrix[permutation[pos]][currentCol]);
+
+  for (var i = pos + 1; i < row; i++) {
+    var value = Math.abs(matrix[permutation[i]][currentCol]);
+
+    if (value > max) {
+      maxIdx = i;
+      max = value;
+    }
+  }
+
+  var t = permutation[pos];
+  permutation[pos] = permutation[maxIdx];
+  permutation[maxIdx] = t;
+}
+
+var LU_1 = LU;
+
+function _slicedToArray$f(arr, i) { return _arrayWithHoles$f(arr) || _iterableToArrayLimit$f(arr, i) || _unsupportedIterableToArray$f(arr, i) || _nonIterableRest$f(); }
+
+function _nonIterableRest$f() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray$f(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray$f(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray$f(o, minLen); }
+
+function _arrayLikeToArray$f(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit$f(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles$f(arr) { if (Array.isArray(arr)) return arr; }
+
+var INVALID_MATRIX$a = _Error.INVALID_MATRIX;
+/**
+ * Calculates the QR decomposition of the Matrix
+ * where Q is orthogonal matrix, R is upper triangular matrix.<br><br>
+ * 
+ * The algorithm is implemented using Householder Transform instead of Gram–Schmidt process
+ * because the Householder Transform is more numerically stable.
+ * @memberof Matrix
+ * @static
+ * @param {Matrix} A - Any matrix
+ * @returns {Matrix[]} The QR decomposition of matrix in the form of [Q, R]
+ */
+
+
+function QR(A) {
+  if (!(A instanceof this)) {
+    throw new Error(INVALID_MATRIX$a);
+  }
+
+  var _A$size = A.size(),
+      _A$size2 = _slicedToArray$f(_A$size, 2),
+      row = _A$size2[0],
+      col = _A$size2[1];
+
+  var size = Math.min(row, col);
+  var EPSILON = 1 / (Math.pow(10, A._digit) * 2);
+
+  var matrixR = this.clone(A)._matrix;
+
+  var matrixQ = this.identity(row)._matrix;
+
+  for (var j = 0; j < size; j++) {
+    // if all entries below main diagonal are considered as zero, skip this round
+    var skip = true;
+
+    for (var i = j + 1; i < row; i++) {
+      if (Math.abs(matrixR[i][j]) >= EPSILON) {
+        skip = false;
+        break;
+      }
+    }
+
+    if (!skip) {
+      // Apply Householder transform
+      var norm = 0;
+
+      for (var _i2 = j; _i2 < row; _i2++) {
+        norm += Math.pow(matrixR[_i2][j], 2);
+      }
+
+      norm = Math.sqrt(norm); // reduce floating point arithmatic error
+
+      var s = -1;
+
+      if (matrixR[j][j] < 0) {
+        s = 1;
+      }
+
+      var u1 = matrixR[j][j] - s * norm;
+      var w = new Array(row - j);
+
+      for (var _i3 = 0; _i3 < row - j; _i3++) {
+        w[_i3] = matrixR[_i3 + j][j] / u1;
+      }
+
+      w[0] = 1;
+      var tau = -1 * s * u1 / norm;
+      var subR = new Array(row - j);
+
+      for (var _i4 = 0; _i4 < row - j; _i4++) {
+        var newRow = new Array(col);
+
+        for (var k = 0; k < col; k++) {
+          newRow[k] = matrixR[j + _i4][k];
+        }
+
+        subR[_i4] = newRow;
+      }
+
+      for (var _i5 = j; _i5 < row; _i5++) {
+        for (var _k = 0; _k < col; _k++) {
+          var summation = 0;
+
+          for (var m = 0; m < row - j; m++) {
+            summation += subR[m][_k] * w[m];
+          }
+
+          matrixR[_i5][_k] = subR[_i5 - j][_k] - tau * w[_i5 - j] * summation;
+        }
+      }
+
+      var subQ = new Array(row);
+
+      for (var _i6 = 0; _i6 < row; _i6++) {
+        var _newRow = new Array(row - j);
+
+        for (var _k2 = 0; _k2 < row - j; _k2++) {
+          _newRow[_k2] = matrixQ[_i6][j + _k2];
+        }
+
+        subQ[_i6] = _newRow;
+      }
+
+      for (var _i7 = 0; _i7 < row; _i7++) {
+        for (var _k3 = j; _k3 < row; _k3++) {
+          var _summation = 0;
+
+          for (var _m = 0; _m < row - j; _m++) {
+            _summation += subQ[_i7][_m] * w[_m];
+          }
+
+          matrixQ[_i7][_k3] = subQ[_i7][_k3 - j] - tau * w[_k3 - j] * _summation;
+        }
+      }
+    }
+  }
+
+  for (var _i8 = 0; _i8 < row; _i8++) {
+    for (var _j = 0; _j < col; _j++) {
+      if (_i8 > _j) {
+        matrixR[_i8][_j] = 0;
+      }
+    }
+  }
+
+  return [new this(matrixQ), new this(matrixR)];
+}
+var QR_1 = QR;
+
+function _slicedToArray$g(arr, i) { return _arrayWithHoles$g(arr) || _iterableToArrayLimit$g(arr, i) || _unsupportedIterableToArray$g(arr, i) || _nonIterableRest$g(); }
+
+function _nonIterableRest$g() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray$g(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray$g(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray$g(o, minLen); }
+
+function _arrayLikeToArray$g(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit$g(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles$g(arr) { if (Array.isArray(arr)) return arr; }
+
+var INVALID_MATRIX$b = _Error.INVALID_MATRIX;
+/**
+ * Creates a copy of Matrix. Note that it resets the cached data.
+ * @memberof Matrix
+ * @static
+ * @param {Matrix} A - Any Matrix
+ * @returns {Matrix} Copy of A
+ */
+
+
+function clone(A) {
+  if (!(A instanceof this)) {
+    throw new Error(INVALID_MATRIX$b);
+  }
+
+  var _A$size = A.size(),
+      _A$size2 = _slicedToArray$g(_A$size, 2),
+      row = _A$size2[0],
+      col = _A$size2[1];
+
+  var matrix = A._matrix;
+  return this.generate(row, col, function (i, j) {
+    return matrix[i][j];
+  });
+}
+var clone_1 = clone;
+
+function _slicedToArray$h(arr, i) { return _arrayWithHoles$h(arr) || _iterableToArrayLimit$h(arr, i) || _unsupportedIterableToArray$h(arr, i) || _nonIterableRest$h(); }
+
+function _nonIterableRest$h() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray$h(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray$h(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray$h(o, minLen); }
+
+function _arrayLikeToArray$h(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit$h(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles$h(arr) { if (Array.isArray(arr)) return arr; }
+
+var INVALID_ROW_COL$1 = _Error.INVALID_ROW_COL,
+    OVERFLOW_COLUMN = _Error.OVERFLOW_COLUMN,
+    INVALID_MATRIX$c = _Error.INVALID_MATRIX;
+/**
+ * Gets the column of a Matrix with valid index.
+ * @memberof Matrix
+ * @static
+ * @param {Matrix} A - Any Matrix
+ * @param {number} index - Any valid column index
+ * @returns {Matrix} Column of A
+ */
+
+
+function column(A, index) {
+  if (!(A instanceof this)) {
+    throw new Error(INVALID_MATRIX$c);
+  }
+
+  if (!Number.isInteger(index) || index < 0) {
+    throw new Error(INVALID_ROW_COL$1);
+  }
+
+  var _A$size = A.size(),
+      _A$size2 = _slicedToArray$h(_A$size, 2),
+      r = _A$size2[0],
+      c = _A$size2[1];
+
+  if (index >= c) {
+    throw new Error(OVERFLOW_COLUMN);
+  }
+
+  var matrix = A._matrix;
+  return this.generate(r, 1, function (i) {
+    return matrix[i][index];
+  });
+}
+var column_1 = column;
+
+var INVALID_ARRAY = _Error.INVALID_ARRAY,
+    EXPECTED_ARRAY_OF_NUMBERS_OR_MATRICES = _Error.EXPECTED_ARRAY_OF_NUMBERS_OR_MATRICES,
+    INVALID_SQUARE_MATRIX$9 = _Error.INVALID_SQUARE_MATRIX;
+/**
+ * Generates diagonal Matrix if the argument is an array of numbers,
+ * generates block diagonal Matrix if the argument is an array of Matrices.
+ * @memberof Matrix
+ * @static
+ * @param {(number[]|Matrix[])} values - Array of numbers or Matrices
+ * @returns {Matrix} Block diagonal Matrix
+ */
+
+
+function diag$1(values) {
+  if (!Array.isArray(values)) {
+    throw new Error(INVALID_ARRAY);
+  }
+
+  var argsNum = values.length;
+  var variant;
+
+  for (var i = 0; i < argsNum; i++) {
+    var entry = values[i];
+
+    if (!isNumber(entry) && !(entry instanceof lib$1)) {
+      throw new Error(EXPECTED_ARRAY_OF_NUMBERS_OR_MATRICES);
+    }
+
+    if (isNumber(entry)) {
+      if (!variant) {
+        variant = 'number';
+        continue;
+      }
+
+      if (variant !== 'number') {
+        throw new Error(EXPECTED_ARRAY_OF_NUMBERS_OR_MATRICES);
+      }
+    } else {
+      if (!entry.isSquare()) {
+        throw new Error(INVALID_SQUARE_MATRIX$9);
+      }
+
+      if (!variant) {
+        variant = 'square';
+        continue;
+      }
+
+      if (variant !== 'square') {
+        throw new Error(EXPECTED_ARRAY_OF_NUMBERS_OR_MATRICES);
+      }
+    }
+  } // HERE: variant should be either 'number' or 'square'
+
+
+  if (variant === 'number') {
+    return lib$1.generate(argsNum, argsNum, function (i, j) {
+      if (i === j) {
+        return values[i];
+      }
+
+      return 0;
+    });
+  } // Guaranteed that [values] is a list of square matrices
+
+
+  var size = 0;
+  var temp = new Array(argsNum);
+
+  for (var _i = 0; _i < argsNum; _i++) {
+    var _len = values[_i].size()[0];
+
+    size += _len;
+    temp[_i] = _len;
+  }
+
+  var idx = 0;
+  var start = 0;
+  var len = temp[idx];
+  return lib$1.generate(size, size, function (i, j) {
+    if (i - start === len && j - start === len) {
+      start += len;
+      idx++;
+    }
+
+    var ith = i - start; // ith < 0 if below main diagonal
+
+    var jth = j - start; // jth < 0 if above main diagonal
+    // skip 0x0 matrices
+
+    len = temp[idx];
+
+    while (len === 0) {
+      idx++;
+      len = temp[idx];
+    }
+
+    if (ith < len && ith >= 0 && jth < len && jth >= 0) {
+      return values[idx]._matrix[ith][jth];
+    }
+
+    return 0;
+  });
+}
+var diag_1 = diag$1;
+
+function _slicedToArray$i(arr, i) { return _arrayWithHoles$i(arr) || _iterableToArrayLimit$i(arr, i) || _unsupportedIterableToArray$i(arr, i) || _nonIterableRest$i(); }
+
+function _nonIterableRest$i() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray$i(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray$i(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray$i(o, minLen); }
+
+function _arrayLikeToArray$i(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit$i(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles$i(arr) { if (Array.isArray(arr)) return arr; }
+
+var INVALID_MATRIX$d = _Error.INVALID_MATRIX;
+/**
+ * This callback applies on each entry of a Matrix
+ * @callback entryCallback
+ * @param {number} entry - Entry of a Matrix
+ * @returns {number} New entry value
+ */
+
+/**
+ * Applys a function over each entry of a Matrix and returns
+ * a new copy of the new Matrix.
+ * @memberof Matrix
+ * @static
+ * @param {Matrix} A - Any Matrix
+ * @param {entryCallback} cb - Callback function which applies on each entry of A
+ * @returns {Matrix} A copy of new Matrix
+ */
+
+
+function elementwise(A, cb) {
+  if (!(A instanceof this)) {
+    throw new Error(INVALID_MATRIX$d);
+  }
+
+  var _A$size = A.size(),
+      _A$size2 = _slicedToArray$i(_A$size, 2),
+      row = _A$size2[0],
+      col = _A$size2[1];
+
+  var matrix = A._matrix;
+  return this.generate(row, col, function (i, j) {
+    return cb(matrix[i][j]);
+  });
+}
+var elementwise_1 = elementwise;
+
+/**
+ * This callback generates each entry of a Matrix
+ * @callback generateCallback
+ * @param {number} i - The i-th row of Matrix 
+ * @param {number} j - The j-th column of Matrix 
+ * @returns {number} Entry of Matrix
+ */
+
+/**
+ * Generates a Matrix which entries are the returned value of callback function.
+ * @memberof Matrix
+ * @static
+ * @param {number} row - Number of rows of Matrix
+ * @param {number} col - Number of columns of Matrix
+ * @param {generateCallback} cb - Callback function which takes row and column as arguments
+ * and generates the corresponding entry
+ * @returns {Matrix} - Generated Matrix
+ */
+
+
+function generate(row, col, cb) {
+  var matrix = empty(row, col);
+
+  if (row === 0 || col === 0) {
+    return new this([]);
+  }
+
+  for (var i = 0; i < row; i++) {
+    for (var j = 0; j < col; j++) {
+      matrix[i][j] = cb(i, j);
+    }
+  }
+
+  return new this(matrix);
+}
+var generate_1 = generate;
+
+function _slicedToArray$j(arr, i) { return _arrayWithHoles$j(arr) || _iterableToArrayLimit$j(arr, i) || _unsupportedIterableToArray$j(arr, i) || _nonIterableRest$j(); }
+
+function _nonIterableRest$j() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray$j(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray$j(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray$j(o, minLen); }
+
+function _arrayLikeToArray$j(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit$j(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles$j(arr) { if (Array.isArray(arr)) return arr; }
+
+var INVALID_MATRIX$e = _Error.INVALID_MATRIX;
+/**
+ * Gets the entries on the main diagonal.
+ * @memberof Matrix
+ * @static
+ * @param {Matrix} A - Any Matrix
+ * @returns {number[]} Array of entries of A on the main diagonal
+ */
+
+
+function getDiag(A) {
+  if (!(A instanceof this)) {
+    throw new Error(INVALID_MATRIX$e);
+  }
+
+  var _A$size = A.size(),
+      _A$size2 = _slicedToArray$j(_A$size, 2),
+      row = _A$size2[0],
+      col = _A$size2[1];
+
+  var size = Math.min(row, col);
+  var matrix = A._matrix;
+  var diags = new Array(size);
+
+  for (var i = 0; i < size; i++) {
+    diags[i] = matrix[i][i];
+  }
+
+  return diags;
+}
+var getDiag_1 = getDiag;
+
+/**
+ * Generates a random Matrix.
+ * @memberof Matrix
+ * @static
+ * @param {number} row - Number of rows of a Matrix
+ * @param {number} col - Number of columns of a Matrix
+ * @param {number} min - Lower bound of each entry
+ * @param {number} max - Upper bound of each entry
+ * @param {number} toFixed - Number of decimal places
+ * @returns {Matrix} Generated random Matrix
+ */
+function getRandomMatrix(row, col) {
+  var min = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 0;
+  var max = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : 1;
+  var toFixed = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : 0;
+  return this.generate(row, col, function () {
+    return Number.parseFloat((Math.random() * (max - min) + min).toFixed(toFixed));
+  });
+}
+var getRandomMatrix_1 = getRandomMatrix;
+
+/**
+ * Generates identity Matrix with given size.
+ * @memberof Matrix
+ * @static
+ * @param {number} size - The size of Matrix
+ * @returns {Matrix} Identity Matrix
+ */
+function identity$1(size) {
+  return this.generate(size, size, function (i, j) {
+    if (i === j) {
+      return 1;
+    }
+
+    return 0;
+  });
+}
+var identity_1 = identity$1;
+
+function _slicedToArray$k(arr, i) { return _arrayWithHoles$k(arr) || _iterableToArrayLimit$k(arr, i) || _unsupportedIterableToArray$k(arr, i) || _nonIterableRest$k(); }
+
+function _nonIterableRest$k() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray$k(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray$k(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray$k(o, minLen); }
+
+function _arrayLikeToArray$k(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit$k(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles$k(arr) { if (Array.isArray(arr)) return arr; }
+
+var INVALID_MATRIX$f = _Error.INVALID_MATRIX;
+/**
+ * Determines whether two Matrices are considered as equal.<br><br>
+ * 
+ * The test criterion is Math.abs(x - y) < 1 / (10 ** digit * 2).
+ * For default value 5, it should be 5e-5.
+ * That means if the difference of two numbers is less than 5e-5,
+ * they are considered as same value.
+ * @memberof Matrix
+ * @static
+ * @param {Matrix} A - Any Matrix
+ * @param {Matrix} B - Any Matrix
+ * @param {number} digit - Number of significant digits
+ * @returns {boolean} Returns true if two Matrices are considered as same
+ */
+
+
+function isEqual$1(A, B) {
+  var digit = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 5;
+
+  if (!(A instanceof this) || !(B instanceof this)) {
+    throw new Error(INVALID_MATRIX$f);
+  }
+
+  var _A$size = A.size(),
+      _A$size2 = _slicedToArray$k(_A$size, 2),
+      Arow = _A$size2[0],
+      Acol = _A$size2[1];
+
+  var _B$size = B.size(),
+      _B$size2 = _slicedToArray$k(_B$size, 2),
+      Brow = _B$size2[0],
+      Bcol = _B$size2[1];
+
+  if (Arow !== Brow || Acol !== Bcol) {
+    return false;
+  }
+
+  var EPISILON = 1 / (Math.pow(10, digit) * 2);
+  var matrixA = A._matrix;
+  var matrixB = B._matrix;
+
+  for (var i = 0; i < Arow; i++) {
+    for (var j = 0; j < Acol; j++) {
+      if (Math.abs(matrixA[i][j] - matrixB[i][j]) >= EPISILON) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+var isEqual_1$1 = isEqual$1;
+
+function _slicedToArray$l(arr, i) { return _arrayWithHoles$l(arr) || _iterableToArrayLimit$l(arr, i) || _unsupportedIterableToArray$l(arr, i) || _nonIterableRest$l(); }
+
+function _nonIterableRest$l() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray$l(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray$l(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray$l(o, minLen); }
+
+function _arrayLikeToArray$l(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit$l(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles$l(arr) { if (Array.isArray(arr)) return arr; }
+
+var INVALID_ROW_COL$2 = _Error.INVALID_ROW_COL,
+    OVERFLOW_ROW = _Error.OVERFLOW_ROW,
+    INVALID_MATRIX$g = _Error.INVALID_MATRIX;
+/**
+ * Gets the row of a Matrix with valid index.
+ * @memberof Matrix
+ * @static
+ * @param {Matrix} A - Any Matrix
+ * @param {number} index - Any valid row index
+ * @returns {Matrix} Row of A
+ */
+
+
+function row(A, index) {
+  if (!(A instanceof this)) {
+    throw new Error(INVALID_MATRIX$g);
+  }
+
+  if (!Number.isInteger(index) || index < 0) {
+    throw new Error(INVALID_ROW_COL$2);
+  }
+
+  var _A$size = A.size(),
+      _A$size2 = _slicedToArray$l(_A$size, 2),
+      r = _A$size2[0],
+      c = _A$size2[1];
+
+  if (index >= r) {
+    throw new Error(OVERFLOW_ROW);
+  }
+
+  var matrix = A._matrix;
+  return this.generate(1, c, function (i, j) {
+    return matrix[index][j];
+  });
+}
+var row_1 = row;
+
+function _slicedToArray$m(arr, i) { return _arrayWithHoles$m(arr) || _iterableToArrayLimit$m(arr, i) || _unsupportedIterableToArray$m(arr, i) || _nonIterableRest$m(); }
+
+function _nonIterableRest$m() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray$m(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray$m(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray$m(o, minLen); }
+
+function _arrayLikeToArray$m(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit$m(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles$m(arr) { if (Array.isArray(arr)) return arr; }
+
+function _typeof$1(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof$1 = function _typeof(obj) { return typeof obj; }; } else { _typeof$1 = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof$1(obj); }
+
+var INVALID_MATRIX$h = _Error.INVALID_MATRIX,
+    EXPECTED_STRING_NUMBER_AT_POS_1_2 = _Error.EXPECTED_STRING_NUMBER_AT_POS_1_2,
+    INVALID_ROW = _Error.INVALID_ROW,
+    INVALID_COLUMN = _Error.INVALID_COLUMN,
+    OVERFLOW_ROW$1 = _Error.OVERFLOW_ROW,
+    INVALID_ROWS_EXPRESSION = _Error.INVALID_ROWS_EXPRESSION,
+    INVALID_COLUMNS_EXPRESSION = _Error.INVALID_COLUMNS_EXPRESSION,
+    OVERFLOW_COLUMN$1 = _Error.OVERFLOW_COLUMN;
+/**
+ * Generates a submatrix of a matrix.
+ * @memberof Matrix
+ * @static
+ * @param {Matrix} A - Any matrix
+ * @param {string|number} rows - Rows expression
+ * @param {string|number} cols - Columns expression
+ * @returns {Matrix} Submatrix of A
+ */
+
+
+function submatrix(A, rows, cols) {
+  if (!(A instanceof this)) {
+    throw new Error(INVALID_MATRIX$h);
+  }
+
+  var arg1Type = _typeof$1(rows);
+
+  var arg2Type = _typeof$1(cols);
+
+  if (arg1Type !== 'string' && arg1Type !== 'number' || arg2Type !== 'string' && arg2Type !== 'number') {
+    throw new Error(EXPECTED_STRING_NUMBER_AT_POS_1_2);
+  }
+
+  var _A$size = A.size(),
+      _A$size2 = _slicedToArray$m(_A$size, 2),
+      row = _A$size2[0],
+      col = _A$size2[1];
+
+  var rowStart;
+  var rowEnd;
+  var colStart;
+  var colEnd;
+
+  if (arg1Type === 'number') {
+    if (!Number.isInteger(rows) || rows < 0) {
+      throw new Error(INVALID_ROW);
+    }
+
+    if (rows >= row) {
+      throw new Error(OVERFLOW_ROW$1);
+    }
+
+    rowStart = rows;
+    rowEnd = rows;
+  } else {
+    // string
+    var arg = rows.split(':');
+
+    if (arg.length !== 2) {
+      throw new Error(INVALID_ROWS_EXPRESSION);
+    }
+
+    var _arg = _slicedToArray$m(arg, 2),
+        r1 = _arg[0],
+        r2 = _arg[1];
+
+    if (r1 === '') {
+      rowStart = 0;
+    } else {
+      var r = Number(r1);
+
+      if (!Number.isInteger(r) || r < 0) {
+        throw new Error(INVALID_ROW);
+      }
+
+      if (r >= row) {
+        throw new Error(OVERFLOW_ROW$1);
+      }
+
+      rowStart = r;
+    }
+
+    if (r2 === '') {
+      rowEnd = row - 1;
+    } else {
+      var _r = Number(r2);
+
+      if (!Number.isInteger(_r) || _r < 0) {
+        throw new Error(INVALID_ROW);
+      }
+
+      if (_r >= row) {
+        throw new Error(OVERFLOW_ROW$1);
+      }
+
+      rowEnd = _r;
+    }
+
+    if (rowStart > rowEnd) {
+      throw new Error(INVALID_ROWS_EXPRESSION);
+    }
+  }
+
+  if (arg2Type === 'number') {
+    if (!Number.isInteger(cols) || cols < 0) {
+      throw new Error(INVALID_COLUMN);
+    }
+
+    if (cols >= col) {
+      throw new Error(OVERFLOW_COLUMN$1);
+    }
+
+    colStart = cols;
+    colEnd = cols;
+  } else {
+    // string
+    var _arg2 = cols.split(':');
+
+    if (_arg2.length !== 2) {
+      throw new Error(INVALID_COLUMNS_EXPRESSION);
+    }
+
+    var _arg3 = _slicedToArray$m(_arg2, 2),
+        c1 = _arg3[0],
+        c2 = _arg3[1];
+
+    if (c1 === '') {
+      colStart = 0;
+    } else {
+      var c = Number(c1);
+
+      if (!Number.isInteger(c) || c < 0) {
+        throw new Error(INVALID_COLUMN);
+      }
+
+      if (c >= col) {
+        throw new Error(OVERFLOW_COLUMN$1);
+      }
+
+      colStart = c;
+    }
+
+    if (c2 === '') {
+      colEnd = col - 1;
+    } else {
+      var _c = Number(c2);
+
+      if (!Number.isInteger(_c) || _c < 0) {
+        throw new Error(INVALID_COLUMN);
+      }
+
+      if (_c >= col) {
+        throw new Error(OVERFLOW_COLUMN$1);
+      }
+
+      colEnd = _c;
+    }
+
+    if (colStart > colEnd) {
+      throw new Error(INVALID_COLUMNS_EXPRESSION);
+    }
+  }
+
+  var matrix = A._matrix;
+  var subRow = rowEnd - rowStart + 1;
+  var subCol = colEnd - colStart + 1;
+  var subMatrix = new Array(subRow);
+
+  for (var i = rowStart; i <= rowEnd; i++) {
+    var newRow = new Array(subCol);
+
+    for (var j = colStart; j <= colEnd; j++) {
+      newRow[j - colStart] = matrix[i][j];
+    }
+
+    subMatrix[i - rowStart] = newRow;
+  }
+
+  return new this(subMatrix);
+}
+var submatrix_1 = submatrix;
+
+/**
+ * Generates a zero Matrix
+ * @memberof Matrix
+ * @static
+ * @param {number} row - Number of rows of the Matrix
+ * @param {number} col - Number of columns of the Matrix
+ * @returns {Matrix} Zero Matrix
+ */
+function zero(row, col) {
+  if (col === undefined) {
+    return this.generate(row, row, function () {
+      return 0;
+    });
+  }
+
+  return this.generate(row, col, function () {
+    return 0;
+  });
+}
+var zero_1 = zero;
+
+function _slicedToArray$n(arr, i) { return _arrayWithHoles$n(arr) || _iterableToArrayLimit$n(arr, i) || _unsupportedIterableToArray$n(arr, i) || _nonIterableRest$n(); }
+
+function _nonIterableRest$n() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray$n(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray$n(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray$n(o, minLen); }
+
+function _arrayLikeToArray$n(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit$n(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles$n(arr) { if (Array.isArray(arr)) return arr; }
+
+var INVALID_ROW_COL$3 = _Error.INVALID_ROW_COL,
+    OVERFLOW_INDEX = _Error.OVERFLOW_INDEX;
+/**
+ * Gets the entry of a Matrix.
+ * @memberof Matrix
+ * @instance
+ * @param {number} row - Any valid row index
+ * @param {number} col - Any valid column index
+ * @returns {number} Entry of the Matrix
+ */
+
+
+function entry(row, col) {
+  if (!Number.isInteger(row) || row < 0 || !Number.isInteger(col) || col < 0) {
+    throw new Error(INVALID_ROW_COL$3);
+  }
+
+  var A = this._matrix;
+
+  var _this$size = this.size(),
+      _this$size2 = _slicedToArray$n(_this$size, 2),
+      r = _this$size2[0],
+      c = _this$size2[1];
+
+  if (row >= r || col >= c) {
+    throw new Error(OVERFLOW_INDEX);
+  }
+
+  return A[row][col];
+}
+var entry_1 = entry;
+
+function _slicedToArray$o(arr, i) { return _arrayWithHoles$o(arr) || _iterableToArrayLimit$o(arr, i) || _unsupportedIterableToArray$o(arr, i) || _nonIterableRest$o(); }
+
+function _nonIterableRest$o() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray$o(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray$o(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray$o(o, minLen); }
+
+function _arrayLikeToArray$o(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit$o(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles$o(arr) { if (Array.isArray(arr)) return arr; }
+
+/**
+ * Gets the stringified Matrix
+ * @memberof Matrix
+ * @instance
+ * @returns {string} Stringified Matrix
+ */
+function toString$1() {
+  var matrix = this._matrix;
+
+  var _this$size = this.size(),
+      _this$size2 = _slicedToArray$o(_this$size, 2),
+      row = _this$size2[0],
+      col = _this$size2[1];
+
+  var str = '';
+
+  for (var i = 0; i < row; i++) {
+    for (var j = 0; j < col; j++) {
+      str += matrix[i][j].toString();
+
+      if (j !== col - 1) {
+        str += ' ';
+      }
+    }
+
+    if (i !== row - 1) {
+      str += '\n';
+    }
+  }
+
+  return str;
+}
+var toString_1$1 = toString$1;
+
+var INVALID_MATRIX$i = _Error.INVALID_MATRIX;
+/**
+ * Creates a new Matrix
+ * @namespace Matrix
+ * @class
+ * @param {number[][]} A - Two dimensional array where
+ * A[i][j] represents the i-th row and j-th column of a matrix
+ */
+
+
+function Matrix(A) {
+  if (!isMatrix(A)) {
+    throw new Error(INVALID_MATRIX$i);
+  }
+
+  this._matrix = A;
+  this._digit = 8;
+}
+
+var lib$1 = Matrix; // structure
+
+Matrix.prototype.isDiagonal = isDiagonal_1;
+Matrix.prototype.isSkewSymmetric = isSkewSymmetric_1;
+Matrix.prototype.isSquare = isSquare_1;
+Matrix.prototype.isSymmetric = isSymmetric_1;
+Matrix.prototype.isLowerTriangular = isLowerTriangular_1;
+Matrix.prototype.isUpperTriangular = isUpperTriangular_1;
+Matrix.prototype.isOrthogonal = isOrthogonal_1; // property
+
+Matrix.prototype.cond = cond_1;
+Matrix.prototype.det = det_1;
+Matrix.prototype.eigenvalues = eigenvalues_1;
+Matrix.prototype.nullity = nullity_1;
+Matrix.prototype.norm = norm_1;
+Matrix.prototype.rank = rank_1;
+Matrix.prototype.size = size_1;
+Matrix.prototype.trace = trace_1; // operations
+
+Matrix.add = add_1$1;
+Matrix.inverse = inverse_1$1;
+Matrix.multiply = multiply_1$1;
+Matrix.pow = pow_1$1;
+Matrix.subtract = subtract$1;
+Matrix.transpose = transpose_1; // Linear-equations
+
+Matrix.backward = backward_1;
+Matrix.forward = forward_1;
+Matrix.solve = solve_1; // decompositions
+
+Matrix.LU = LU_1;
+Matrix.QR = QR_1; // utils
+
+Matrix.clone = clone_1;
+Matrix.column = column_1;
+Matrix.diag = diag_1;
+Matrix.elementwise = elementwise_1;
+Matrix.generate = generate_1;
+Matrix.getDiag = getDiag_1;
+Matrix.getRandomMatrix = getRandomMatrix_1;
+Matrix.identity = identity_1;
+Matrix.isEqual = isEqual_1$1;
+Matrix.row = row_1;
+Matrix.submatrix = submatrix_1;
+Matrix.zero = zero_1;
+Matrix.prototype.entry = entry_1;
+Matrix.prototype.toString = toString_1$1;
+
+const tolerance = 0.1;
+
+
+
+const checkDefinitePositive = function (covariance, tolerance = 1e-10) {
+	const covarianceMatrix = new lib$1(covariance);
+	const eigenvalues = covarianceMatrix.eigenvalues();
+	eigenvalues.forEach(eigenvalue => {
+		if (eigenvalue <= -tolerance) {
+			console.log(covariance, eigenvalue);
+			throw new Error(`Eigenvalue should be positive (actual: ${eigenvalue})`);
+		}
+	});
+	console.log('is definite positive', covariance);
+};
+
+const checkSymetric = function (covariance, title = 'checkSymetric') {
+	covariance.forEach((row, rowId) => row.forEach((item, colId) => {
+		if (rowId === colId && item < 0) {
+			throw new Error(`[${title}] Variance[${colId}] should be positive (actual: ${item})`);
+		} else if (Math.abs(item) > Math.sqrt(covariance[rowId][rowId] * covariance[colId][colId])) {
+			console.log(covariance);
+			throw new Error(`[${title}] Covariance[${rowId}][${colId}] should verify Cauchy Schwarz Inequality ` +
+				`(expected: |x| <= sqrt(${covariance[rowId][rowId]} * ${covariance[colId][colId]})` +
+				` actual: ${item})`);
+		} else if (Math.abs(item - covariance[colId][rowId]) > tolerance) {
+			throw new Error(`[${title}] Covariance[${rowId}][${colId}] should equal Covariance[${colId}][${rowId}] ` +
+			` (actual diff: ${Math.abs(item - covariance[colId][rowId])})  = ${item} - ${covariance[colId][rowId]}\n` +
+			`${covariance.join('\n')} is invalid`
+			);
+		}
+	}));
+};
+
+var checkCovariance = function ({covariance, eigen = false}) {
+	checkMatrix(covariance);
+	checkSymetric(covariance);
+	if (eigen) {
+		checkDefinitePositive(covariance);
+	}
+};
+
+/**
+ * @class
+ * Class representing a multi dimensionnal gaussian, with his mean and his covariance
+ * @property {Number} [index=0] the index of the State in the process, this is not mandatory for simple Kalman Filter, but is needed for most of the use case of extended kalman filter
+ * @property {Array.<Array.<Number>>} covariance square matrix of size dimension
+ * @property {Array.<Array<Number>>} mean column matrix of size dimension x 1
+ */
+class State {
+	constructor({mean, covariance, index}) {
+		this.mean = mean;
+		this.covariance = covariance;
+		this.index = index;
+	}
+
+	/**
+	* Check the consistency of the State
+	*/
+	check(options) {
+		this.constructor.check(this, options);
+	}
+
+	/**
+	* Check the consistency of the State's attributes
+	*/
+
+	static check(state, {dimension = null, title = null, eigen} = {}) {
+		console.log('checkState', state);
+		if (!(state instanceof State)) {
+			throw (new TypeError(
+				'The argument is not a state \n' +
+        'Tips: maybe you are using 2 different version of kalman-filter in your npm deps tree'
+			));
+		}
+
+		const {mean, covariance} = state; // Index
+		const meanDimension = mean.length;
+		if (typeof (dimension) === 'number' && meanDimension !== dimension) {
+			throw (new Error(`[${title}] State.mean ${mean} with dimension ${meanDimension} does not match expected dimension (${dimension})`));
+		}
+
+		checkMatrix(mean, [meanDimension, 1], title ? title + '-mean' : 'mean');
+		checkMatrix(covariance, [meanDimension, meanDimension], title ? title + '-covariance' : 'covariance');
+		checkCovariance({covariance, eigen});
+		// If (typeof (index) !== 'number') {
+		// 	throw (new TypeError('t must be a number'));
+		// }
+	}
+
+	static matMul({state, matrix}) {
+		const covariance = matMul(
+			matMul(matrix, state.covariance),
+			transpose(matrix)
+		);
+		const mean = matMul(matrix, state.mean);
+
+		return new State({
+			mean,
+			covariance,
+			index: state.index
+		});
+	}
+
+	/**
+	* From a state in n-dimension create a state in a subspace
+	* If you see the state as a N-dimension gaussian,
+	* this can be viewed as the sub M-dimension gaussian (M < N)
+	* @param {Array.<Number>} obsIndexes list of dimension to extract,  (M < N <=> obsIndexes.length < this.mean.length)
+	* @returns {State} subState in subspace, with subState.mean.length === obsIndexes.length
+	*/
+	subState(obsIndexes) {
+		const state = new State({
+			mean: obsIndexes.map(i => this.mean[i]),
+			covariance: subSquareMatrix(this.covariance, obsIndexes),
+			index: this.index
+		});
+		return state;
+	}
+
+	/**
+	* Simple Malahanobis distance between the distribution (this) and a point
+	* @param {Array.<[Number]>} point a Nx1 matrix representing a point
+	*/
+	rawDetailedMahalanobis(point) {
+		const diff = sub(this.mean, point);
+		this.check();
+		const covarianceInvert = invert(this.covariance);
+		if (covarianceInvert === null) {
+			this.check({eigen: true});
+			throw (new Error(`Cannot invert covariance ${JSON.stringify(this.covariance)}`));
+		}
+
+		const diffTransposed = transpose(diff);
+
+		// Console.log('covariance in obs space', covarianceInObservationSpace);
+
+		const value = Math.sqrt(
+			matMul(
+				matMul(
+					diffTransposed,
+					covarianceInvert
+				),
+				diff
+			)
+		);
+		if (Number.isNaN(value)) {
+			console.log({diff, covarianceInvert, this: this, point}, matMul(
+				matMul(
+					diffTransposed,
+					covarianceInvert
+				),
+				diff
+			));
+			throw (new Error('mahalanobis is NaN'));
+		}
+
+		return {
+			diff,
+			covarianceInvert,
+			value
+		};
+	}
+
+	/**
+	* Malahanobis distance is made against an observation, so the mean and covariance
+	* are projected into the observation space
+	* @param {KalmanFilter} kf kalman filter use to project the state in observation's space
+	* @param {Observation} observation
+	* @param {Array.<Number>} obsIndexes list of indexes of observation state to use for the mahalanobis distance
+	*/
+	detailedMahalanobis({kf, observation, obsIndexes}) {
+		if (observation.length !== kf.observation.dimension) {
+			throw (new Error(`Mahalanobis observation ${observation} (dimension: ${observation.length}) does not match with kf observation dimension (${kf.observation.dimension})`));
+		}
+
+		let correctlySizedObservation = arrayToMatrix({observation, dimension: observation.length});
+
+		const stateProjection = kf.getValue(kf.observation.stateProjection, {});
+
+		let projectedState = this.constructor.matMul({state: this, matrix: stateProjection});
+
+		if (Array.isArray(obsIndexes)) {
+			projectedState = projectedState.subState(obsIndexes);
+			correctlySizedObservation = obsIndexes.map(i => correctlySizedObservation[i]);
+		}
+
+		return projectedState.rawDetailedMahalanobis(correctlySizedObservation);
+	}
+
+	/**
+	* @param {KalmanFilter} kf kalman filter use to project the state in observation's space
+	* @param {Observation} observation
+	* @param {Array.<Number>} obsIndexes list of indexes of observation state to use for the mahalanobis distance
+	* @returns {Number}
+	*/
+	mahalanobis(options) {
+		const result = this.detailedMahalanobis(options).value;
+		if (Number.isNaN(result)) {
+			throw (new TypeError('mahalanobis is NaN'));
+		}
+
+		return result;
+	}
+
+	/**
+	* Bhattacharyya distance is made against in the observation space
+	* to do it in the normal space see state.bhattacharyya
+	* @param {KalmanFilter} kf kalman filter use to project the state in observation's space
+	* @param {State} state
+	* @param {Array.<Number>} obsIndexes list of indexes of observation state to use for the bhattacharyya distance
+	* @returns {Number}
+	*/
+	obsBhattacharyya({kf, state, obsIndexes}) {
+		const stateProjection = kf.getValue(kf.observation.stateProjection, {});
+
+		let projectedSelfState = this.constructor.matMul({state: this, matrix: stateProjection});
+		let projectedOtherState = this.constructor.matMul({state, matrix: stateProjection});
+
+		if (Array.isArray(obsIndexes)) {
+			projectedSelfState = projectedSelfState.subState(obsIndexes);
+			projectedOtherState = projectedOtherState.subState(obsIndexes);
+		}
+
+		return projectedSelfState.bhattacharyya(projectedOtherState);
+	}
+
+	/**
+	* @param {State} otherState other state to compare with
+	* @returns {Number}
+	*/
+	bhattacharyya(otherState) {
+		const state = this;
+		const average = elemWise([state.covariance, otherState.covariance], ([a, b]) => (a + b) / 2);
+
+		let covarInverted;
+		try {
+			covarInverted = invert(average);
+		} catch (error) {
+			console.log('Cannot invert', average);
+			throw (error);
+		}
+
+		const diff = sub(state.mean, otherState.mean);
+
+		return matMul(transpose(diff), matMul(covarInverted, diff))[0][0];
+	}
+}
+
+var state = State;
+
+/**
+*Creates a dynamic model, following constant position model with respect with the dimensions provided in the observation parameters
+* @param {DynamicConfig} dynamic
+* @param {ObservationConfig} observation
+* @returns {DynamicConfig}
+*/
+
+var constantPosition = function (dynamic, observation) {
+	let {dimension} = dynamic;
+	const observationDimension = observation.dimension;
+	const {observedProjection} = observation;
+	const {stateProjection} = observation;
+	let {covariance} = dynamic;
+
+	if (!dynamic.dimension) {
+		if (observationDimension) {
+			dimension = observationDimension;
+		} else if (observedProjection) {
+			dimension = observedProjection[0].length;
+		} else if (stateProjection) {
+			dimension = stateProjection[0].length;
+		}
+	}
+
+	const transition = identity(dimension);
+	covariance = covariance || identity(dimension);
+	return Object.assign({}, dynamic, {dimension, transition, covariance});
+};
+
+/**
+*Creates a dynamic model, following constant position model with respect with the dimensions provided in the observation parameters
+* @param {DynamicConfig} dynamic
+* @param {ObservationConfig} observation
+* @returns {DynamicConfig}
+*/
+
+var constantSpeed = function (dynamic, observation) {
+	const timeStep = dynamic.timeStep || 1;
+	const {observedProjection} = observation;
+	const {stateProjection} = observation;
+	const observationDimension = observation.dimension;
+	let dimension;
+
+	if (stateProjection && Number.isInteger(stateProjection[0].length / 2)) {
+		dimension = observation.stateProjection[0].length;
+	} else if (observedProjection) {
+		dimension = observedProjection[0].length * 2;
+	} else if (observationDimension) {
+		dimension = observationDimension * 2;
+	} else {
+		throw (new Error('observedProjection or stateProjection should be defined in observation in order to use constant-speed filter'));
+	}
+
+	const baseDimension = dimension / 2;
+	// We construct the transition and covariance matrices
+	const transition = identity(dimension);
+	for (let i = 0; i < baseDimension; i++) {
+		transition[i][i + baseDimension] = timeStep;
+	}
+
+	const arrayCovariance = new Array(baseDimension).fill(1).concat(new Array(baseDimension).fill(timeStep * timeStep));
+	const covariance = dynamic.covariance || arrayCovariance;
+	return Object.assign({}, dynamic, {dimension, transition, covariance});
+};
+
+/**
+*Creates a dynamic model, following constant acceleration model with respect with the dimensions provided in the observation parameters
+* @param {DynamicConfig} dynamic
+* @param {ObservationConfig} observation
+* @returns {DynamicConfig}
+*/
+
+var constantAcceleration = function (dynamic, observation) {
+	const timeStep = dynamic.timeStep || 1;
+	const {observedProjection} = observation;
+	const {stateProjection} = observation;
+	const observationDimension = observation.dimension;
+	let dimension;
+
+	if (stateProjection && Number.isInteger(stateProjection[0].length / 3)) {
+		dimension = observation.stateProjection[0].length;
+	} else if (observedProjection) {
+		dimension = observedProjection[0].length * 3;
+	} else if (observationDimension) {
+		dimension = observationDimension * 3;
+	} else {
+		throw (new Error('observedProjection or stateProjection should be defined in observation in order to use constant-speed filter'));
+	}
+
+	const baseDimension = dimension / 3;
+	// We construct the transition and covariance matrices
+	const transition = identity(dimension);
+	for (let i = 0; i < baseDimension; i++) {
+		transition[i][i + baseDimension] = timeStep;
+		transition[i][i + (2 * baseDimension)] = 0.5 * (timeStep ** 2);
+		transition[i + baseDimension][i + (2 * baseDimension)] = timeStep;
+	}
+
+	const arrayCovariance = new Array(baseDimension).fill(1)
+		.concat(new Array(baseDimension).fill(timeStep * timeStep))
+		.concat(new Array(baseDimension).fill(timeStep ** 4));
+	const covariance = dynamic.covariance || arrayCovariance;
+	return Object.assign({}, dynamic, {dimension, transition, covariance});
+};
+
+/**
+* @param {Number} sensorDimension
+* @param {CovarianceParam} sensorCovariance
+* @param {Number} nSensors
+* @returns {ObservationConfig}
+*/
+
+const copy = mat => mat.map(a => a.concat());
+
+var sensor = function (options) {
+	const {sensorDimension = 1, sensorCovariance = 1, nSensors = 1} = options;
+	const sensorCovarianceFormatted = polymorphMatrix(sensorCovariance, {dimension: sensorDimension});
+	checkMatrix(sensorCovarianceFormatted, [sensorDimension, sensorDimension], 'observation.sensorCovariance');
+	const oneSensorObservedProjection = identity(sensorDimension);
+	let concatenatedObservedProjection = [];
+	const dimension = sensorDimension * nSensors;
+	const concatenatedCovariance = identity(dimension);
+	for (let i = 0; i < nSensors; i++) {
+		concatenatedObservedProjection = concatenatedObservedProjection.concat(copy(oneSensorObservedProjection));
+
+		sensorCovarianceFormatted.forEach((r, rIndex) => r.forEach((c, cIndex) => {
+			concatenatedCovariance[rIndex + (i * sensorDimension)][cIndex + (i * sensorDimension)] = c;
+		}));
+	}
+
+	return Object.assign({}, options, {
+		dimension,
+		observedProjection: concatenatedObservedProjection,
+		covariance: concatenatedCovariance
+	});
+};
+
+const registeredDynamicModels = {
+	'constant-position': constantPosition,
+	'constant-speed': constantSpeed,
+	'constant-acceleration': constantAcceleration
+};
+const registeredObservationModels = {
+	sensor: sensor
+};
+
+/**
+*RegisterObservation enables to create a new observation model and stock it
+* @param {String} name
+* @callback fn the function corresponding to the desired model
+*/
+
+/**
+*registerDynamic enables to create a new dynamic model and stocks it
+* @param {String} name
+* @callback fn the function corresponding to the desired model
+*/
+
+/**
+*buildObservation enables to build a model given an observation configuration
+* @param {ObservationConfig} observation
+* @returns {ObservationConfig} the configuration with respect to the model
+*/
+
+/**
+*buildDynamic enables to build a model given dynamic and observation configurations
+* @param {DynamicConfig} dynamic
+* @param {ObservationConfig} observation
+* @returns {DynamicConfig} the dynamic configuration with respect to the model
+*/
+
+var modelCollection = {
+	registerObservation: (name, fn) => {
+		registeredObservationModels[name] = fn;
+	},
+	registerDynamic: (name, fn) => {
+		registeredDynamicModels[name] = fn;
+	},
+	buildObservation: observation => {
+		if (!registeredObservationModels[observation.name]) {
+			throw (new Error(`The provided observation model name (${observation.name}) is not registered`));
+		}
+
+		return registeredObservationModels[observation.name](observation);
+	},
+	buildDynamic: (dynamic, observation) => {
+		if (!registeredDynamicModels[dynamic.name]) {
+			throw (new Error(`The provided dynamic model (${dynamic.name}) name is not registered`));
+		}
+
+		return registeredDynamicModels[dynamic.name](dynamic, observation);
+	}
+};
+
+/**
+* Add matrixes together
+* @param {...<Array.<Array.<Number>>} args list of matrix
+* @returns {Array.<Array.<Number>>} sum
+*/
+var add$2 = function (...args) {
+	return elemWise(args, args2 => {
+		return args2.reduce((a, b) => {
+			if (a === null || b === null) {
+				return null;
+			}
+
+			return a + b;
+		}, 0);
+	});
+};
+
+/**
+* @callback ObservationCallback
+* @param {Object} opts
+* @param {Number} opts.index
+* @param {Number} opts.previousCorrected
+*/
+
+/**
+* @typedef {Object} ObservationConfig
+* @property {Number} dimension
+* @property {Array.Array.<Number>> | ObservationCallback} stateProjection,
+* @property {Array.Array.<Number>> | ObservationCallback} covariance
+*/
+
+/**
+* @callback DynamicCallback
+* @param {Object} opts
+* @param {Number} opts.index
+* @param {State} opts.predicted
+* @param {Observation} opts.observation
+*/
+
+/**
+* @typedef {Object} DynamicConfig
+* @property {Number} dimension
+* @property {Array.Array.<Number>> | DynamicCallback} transition,
+* @property {Array.Array.<Number>> | DynamicCallback} covariance
+*/
+
+const defaultLogger = {
+	info: (...args) => console.log(...args),
+	debug: () => {},
+	warn: (...args) => console.log(...args),
+	error: (...args) => console.log(...args)
+};
+
+/**
+* @class
+* @property {DynamicConfig} dynamic the system's dynamic model
+* @property {ObservationConfig} observation the system's observation model
+*@property logger a Winston-like logger
+*/
+class CoreKalmanFilter {
+	/**
+	* @param {DynamicConfig} dynamic
+	* @param {ObservationConfig} observation the system's observation model
+	*/
+
+	constructor({dynamic, observation, logger = defaultLogger}) {
+		this.dynamic = dynamic;
+		this.observation = observation;
+		this.logger = logger;
+	}
+
+	getValue(fn, options) {
+		return (typeof (fn) === 'function' ? fn(options) : fn);
+	}
+
+	getInitState() {
+		const {mean: meanInit, covariance: covarianceInit, index: indexInit} = this.dynamic.init;
+		const initState = new state({
+			mean: meanInit,
+			covariance: covarianceInit,
+			index: indexInit
+		});
+		return initState;
+	}
+
+	/**
+	This will return the predicted covariance of a given previousCorrected State, this will help us to build the asymptoticState.
+	* @param {State} previousCorrected
+	* @returns{Array.<Array.<Number>>}
+	*/
+
+	getPredictedCovariance(options = {}) {
+		let {previousCorrected, index} = options;
+		previousCorrected = previousCorrected || this.getInitState();
+
+		const getValueOptions = Object.assign({}, {previousCorrected, index}, options);
+		const d = this.getValue(this.dynamic.transition, getValueOptions);
+		const dTransposed = transpose(d);
+		const covarianceInter = matMul(d, previousCorrected.covariance);
+		const covariancePrevious = matMul(covarianceInter, dTransposed);
+		const dynCov = this.getValue(this.dynamic.covariance, getValueOptions);
+
+		const covariance = add$2(
+			dynCov,
+			covariancePrevious
+		);
+		checkMatrix(covariance, [this.dynamic.dimension, this.dynamic.dimension], 'predicted.covariance');
+
+		return covariance;
+	}
+
+	/**
+	This will return the new prediction, relatively to the dynamic model chosen
+	* @param {State} previousCorrected State relative to our dynamic model
+	* @returns{State} predicted State
+	*/
+
+	predict(options = {}) {
+		let {previousCorrected, index} = options;
+		previousCorrected = previousCorrected || this.getInitState();
+
+		if (typeof (index) !== 'number' && typeof (previousCorrected.index) === 'number') {
+			index = previousCorrected.index + 1;
+		}
+
+		state.check(previousCorrected, {dimension: this.dynamic.dimension});
+
+		const getValueOptions = Object.assign({}, {
+			previousCorrected,
+			index
+		}, options);
+		const d = this.getValue(this.dynamic.transition, getValueOptions);
+
+		checkMatrix(d, [this.dynamic.dimension, this.dynamic.dimension], 'dynamic.transition');
+
+		const mean = matMul(d, previousCorrected.mean);
+
+		const covariance = this.getPredictedCovariance(getValueOptions);
+
+		const predicted = new state({mean, covariance, index});
+		this.logger.debug('Prediction done', predicted);
+
+		return predicted;
+	}
+	/**
+	This will return the new correction, taking into account the prediction made
+	and the observation of the sensor
+	* @param {State} predicted the previous State
+	* @returns{Array<Array>} kalmanGain
+	*/
+
+	getGain(options) {
+		let {predicted, stateProjection} = options;
+		const getValueOptions = Object.assign({}, {index: predicted.index}, options);
+		stateProjection = stateProjection || this.getValue(this.observation.stateProjection, getValueOptions);
+		const obsCovariance = this.getValue(this.observation.covariance, getValueOptions);
+		checkMatrix(obsCovariance, [this.observation.dimension, this.observation.dimension], 'observation.covariance');
+
+		const stateProjTransposed = transpose(stateProjection);
+		const noiselessInnovation = matMul(
+			matMul(stateProjection, predicted.covariance),
+			stateProjTransposed
+		);
+
+		const innovationCovariance = add$2(noiselessInnovation, obsCovariance);
+
+		const optimalKalmanGain = matMul(
+			matMul(predicted.covariance, stateProjTransposed),
+			invert(innovationCovariance)
+		);
+
+		return optimalKalmanGain;
+	}
+
+	/**
+	This will return the corrected covariance of a given predicted State, this will help us to build the asymptoticState.
+	* @param {State} predicted the previous State
+	* @returns{Array.<Array.<Number>>}
+	*/
+
+	getCorrectedCovariance(options) {
+		let {predicted, optimalKalmanGain, stateProjection} = options;
+		const identity$1 = identity(predicted.covariance.length);
+		if (!stateProjection) {
+			const getValueOptions = Object.assign({}, {index: predicted.index}, options);
+			stateProjection = this.getValue(this.observation.stateProjection, getValueOptions);
+		}
+
+		if (!optimalKalmanGain) {
+			optimalKalmanGain = this.getGain(Object.assign({stateProjection}, options));
+		}
+
+		return matMul(
+			sub(identity$1, matMul(optimalKalmanGain, stateProjection)),
+			predicted.covariance
+		);
+	}
+
+	/**
+	This will return the new correction, taking into account the prediction made
+	and the observation of the sensor
+	* @param {State} predicted the previous State
+	* @param {Array} observation the observation of the sensor
+	* @returns{State} corrected State of the Kalman Filter
+	*/
+
+	correct(options) {
+		const {predicted, observation} = options;
+		console.log('correct check', predicted);
+		state.check(predicted, {dimension: this.dynamic.dimension});
+		if (!observation) {
+			throw (new Error('no measure available'));
+		}
+
+		const getValueOptions = Object.assign({}, {observation, predicted, index: predicted.index}, options);
+		const stateProjection = this.getValue(this.observation.stateProjection, getValueOptions);
+
+		const optimalKalmanGain = this.getGain(Object.assign({predicted, stateProjection}, options));
+
+		const innovation = sub(
+			observation,
+			matMul(stateProjection, predicted.mean)
+		);
+		const mean = add$2(
+			predicted.mean,
+			matMul(optimalKalmanGain, innovation)
+		);
+		if (Number.isNaN(mean[0][0])) {
+			console.log({optimalKalmanGain, innovation, predicted});
+			throw (new TypeError('Mean is NaN after correction'));
+		}
+
+		const covariance = this.getCorrectedCovariance(Object.assign({predicted, optimalKalmanGain, stateProjection}, options));
+		const corrected = new state({mean, covariance, index: predicted.index});
+		this.logger.debug('Correction done', corrected);
+		return corrected;
+	}
+}
+
+var coreKalmanFilter = CoreKalmanFilter;
+
+const buildDefaultDynamic = function (dynamic) {
+	if (typeof (dynamic) === 'string') {
+		return {name: dynamic};
+	}
+
+	return {name: 'constant-position'};
+};
+
+const buildDefaultObservation = function (observation) {
+	if (typeof (observation) === 'number') {
+		return {name: 'sensor', sensorDimension: observation};
+	}
+
+	if (typeof (observation) === 'string') {
+		return {name: observation};
+	}
+
+	return {name: 'sensor'};
+};
+/**
+*This function fills the given options by successively checking if it uses a registered model,
+* it builds and checks the dynamic and observation dimensions, build the stateProjection if only observedProjection
+*is given, and initialize dynamic.init
+*@param {DynamicConfig} options.dynamic
+*@param {ObservationConfig} options.observation
+*/
+
+const setupModelsParameters = function ({observation, dynamic}) {
+	if (typeof (observation) !== 'object' || observation === null) {
+		observation = buildDefaultObservation(observation);
+	}
+
+	if (typeof (dynamic) !== 'object' || dynamic === null) {
+		dynamic = buildDefaultDynamic(dynamic);
+	}
+
+	if (typeof (observation.name) === 'string') {
+		observation = modelCollection.buildObservation(observation);
+	}
+
+	if (typeof (dynamic.name) === 'string') {
+		dynamic = modelCollection.buildDynamic(dynamic, observation);
+	}
+
+	const withDimensionOptions = setDimensions({observation, dynamic});
+	const checkedDimensionOptions = checkDimensions(withDimensionOptions);
+	const buildStateProjectionOptions = buildStateProjection(checkedDimensionOptions);
+	return extendDynamicInit(buildStateProjectionOptions);
+};
+
+/**
+*Returns the corresponding model without arrays as values but only functions
+*@param {ObservationConfig} observation
+*@param {DynamicConfig} dynamic
+*@returns {ObservationConfig, DynamicConfig} model with respect of the Core Kalman Filter properties
+*/
+const modelsParametersToCoreOptions = function (modelToBeChanged) {
+	const {observation, dynamic} = modelToBeChanged;
+	return deepAssign_1(modelToBeChanged, {
+		observation: {
+			stateProjection: toFunction(polymorphMatrix(observation.stateProjection)),
+			covariance: toFunction(polymorphMatrix(observation.covariance, {dimension: observation.dimension}))
+		},
+		dynamic: {
+			transition: toFunction(polymorphMatrix(dynamic.transition)),
+			covariance: toFunction(polymorphMatrix(dynamic.covariance, {dimension: dynamic.dimension}))
+		}
+	});
+};
+
+class KalmanFilter extends coreKalmanFilter {
+	/**
+	* @param {DynamicConfig} options.dynamic
+	* @param {ObservationConfig} options.observation the system's observation model
+	*/
+	constructor(options = {}) {
+		const modelsParameters = setupModelsParameters(options);
+		const coreOptions = modelsParametersToCoreOptions(modelsParameters);
+
+		super(Object.assign({}, options, coreOptions));
+	}
+
+	correct(options) {
+		const coreObservation = arrayToMatrix({observation: options.observation, dimension: this.observation.dimension});
+		return super.correct(Object.assign({}, options, {observation: coreObservation}));
+	}
+
+	/**
+	*Performs the prediction and the correction steps
+	*@param {State} previousCorrected
+	*@param {<Array.<Number>>} observation
+	*@returns {Array.<Number>} the mean of the corrections
+	*/
+
+	filter(options) {
+		const predicted = super.predict(options);
+		return this.correct(Object.assign({}, options, {predicted}));
+	}
+
+	/**
+*Filters all the observations
+*@param {Array.<Array.<Number>>} observations
+*@returns {Array.<Array.<Number>>} the mean of the corrections
+*/
+	filterAll(observations) {
+		const {mean: meanInit, covariance: covarianceInit, index: indexInit} = this.dynamic.init;
+		let previousCorrected = new state({
+			mean: meanInit,
+			covariance: covarianceInit,
+			index: indexInit});
+		const results = [];
+		for (const observation of observations) {
+			const predicted = this.predict({previousCorrected});
+			previousCorrected = this.correct({
+				predicted,
+				observation
+			});
+			results.push(previousCorrected.mean.map(m => m[0]));
+		}
+
+		return results;
+	}
+
+	/**
+	* Returns an estimation of the asymptotic state covariance as explained in https://en.wikipedia.org/wiki/Kalman_filter#Asymptotic_form
+	* in practice this can be used as a init.covariance value but is very costful calculation (that's why this is not made by default)
+	* @param {Number} [tolerance=1e-6] returns when the last values differences are less than tolerance
+	* @return {<Array.<Array.<Number>>>} covariance
+	*/
+	asymptoticStateCovariance(limitIterations = 1e2, tolerance = 1e-6) {
+		let previousCorrected = super.getInitState();
+		let predicted;
+		const results = [];
+		for (let i = 0; i < limitIterations; i++) {
+			// We create a fake mean that will not be used in order to keep coherence
+			predicted = new state({
+				mean: null,
+				covariance: super.getPredictedCovariance({previousCorrected})
+			});
+			previousCorrected = new state({
+				mean: null,
+				covariance: super.getCorrectedCovariance({predicted})
+			});
+			results.push(previousCorrected.covariance);
+			if (distanceMat(previousCorrected.covariance, results[i - 1]) < tolerance) {
+				return results[i];
+			}
+		}
+
+		throw (new Error('The state covariance does not converge asymptotically'));
+	}
+
+	/**
+	* Returns an estimation of the asymptotic gain, as explained in https://en.wikipedia.org/wiki/Kalman_filter#Asymptotic_form
+	* @param {Number} [tolerance=1e-6] returns when the last values differences are less than tolerance
+	* @return {<Array.<Array.<Number>>>} gain
+	*/
+	asymptoticGain(tolerance = 1e-6) {
+		const covariance = this.asymptoticStateCovariance(tolerance);
+
+		const asymptoticState = new state({
+			// We create a fake mean that will not be used in order to keep coherence
+			mean: new Array(covariance.length).fill(0).map(() => [0]),
+			covariance
+		});
+
+		return super.getGain({previousCorrected: asymptoticState});
+	}
+}
+
+var kalmanFilter = KalmanFilter;
+
+export default kalmanFilter;

--- a/package-lock.json
+++ b/package-lock.json
@@ -3389,6 +3389,19 @@
         }
       }
     },
+    "@rayyamhk/complex": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@rayyamhk/complex/-/complex-1.0.12.tgz",
+      "integrity": "sha512-UWvzpf+38nl0M5+ocRIyRvAodW+qLa5LaxECRmcnT6PQxhpkMHAE6E32+qu+YM3iYj+JpVo26glgu3xGkoef0w=="
+    },
+    "@rayyamhk/matrix": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@rayyamhk/matrix/-/matrix-1.0.6.tgz",
+      "integrity": "sha512-A2g0frvJfrVHFcXrAYHDwq02gGf5kWPNUn8tpJT3nQ96vp3g/EVe6jCxUQe/o0YTrOtM5WAUnfT2xP38i6LmTQ==",
+      "requires": {
+        "@rayyamhk/complex": "^1.0.10"
+      }
+    },
     "@rollup/plugin-alias": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-3.1.1.tgz",
@@ -6317,6 +6330,15 @@
       "integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo=",
       "dev": true
     },
+    "kalman-filter": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/kalman-filter/-/kalman-filter-1.9.2.tgz",
+      "integrity": "sha512-/e9ybLw8tP2xhUE9Ck10wRseZngOu1XZVaj7PXOWJkW3DU+zShniviT3dsMdLFItm/MM7bINCEyPMffDVcuCPA==",
+      "requires": {
+        "@rayyamhk/matrix": "^1.0.5",
+        "matrix-inverse": "^2.0.0"
+      }
+    },
     "keyv": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
@@ -6512,6 +6534,11 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
+    },
+    "matrix-inverse": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/matrix-inverse/-/matrix-inverse-2.0.0.tgz",
+      "integrity": "sha512-iUZfjmnAEDah54qLlj63PYFnZvcCwW+mhfYgf3KrtDn1ruyVE5vFrEeJ77RfsHaqMN/L3ZLnP+5/O2E7bgKEvQ=="
     },
     "meow": {
       "version": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@material/mwc-snackbar": "^0.19.1",
     "@material/mwc-tab-bar": "^0.19.1",
     "@material/mwc-top-app-bar": "^0.19.1",
+    "kalman-filter": "^1.9.2",
     "lit-element": "^2.4.0",
     "lit-html": "^1.3.0",
     "nan": "^2.14.2",

--- a/public/index.html
+++ b/public/index.html
@@ -24,6 +24,7 @@
   <body>
     <main-application></main-application>
     <script src="./dist/hid-usi.js"></script>
+    <script src="./dist/utils.js"></script>
     <script type="module" src="./dist/main-application.js"></script>
     <noscript>
       This page requires JavaScript scripting, please turn it on.

--- a/src/base-canvas-renderer.js
+++ b/src/base-canvas-renderer.js
@@ -63,6 +63,13 @@ export class BaseCanvasRenderer {
 
   get highlightPredictedEvents() { return this._highlightPredictedEvents; }
 
+  set predictionType(predictionType) {
+    this._predictionType = predictionType;
+    this.updateProperty('predictionType', predictionType);
+  }
+
+  get predictionType() { return this._predictionType; }
+
   set numOfPredictionPoints(numOfPredictionPoints) {
     this._numOfPredictionPoints = numOfPredictionPoints;
     this.updateProperty('numOfPredictionPoints', numOfPredictionPoints);
@@ -83,6 +90,7 @@ export class BaseCanvasRenderer {
     this._drawWithPreferredColor = false;
     this._drawWithPressure = false;
     this._highlightPredictedEvents = false;
+    this._predictionType = 'custom';
     this._numOfPredictionPoints = 1;
   }
 

--- a/src/js-canvas-renderer.js
+++ b/src/js-canvas-renderer.js
@@ -55,14 +55,16 @@ export class JSCanvasRenderer extends BaseCanvasRenderer {
       else
         this._drawStroke(this._context, newPoints);
 
-      if (this._drawPredictedEvents && this._currentPath.predictedPoints.length > 0) {
+      if (this._drawPredictedEvents) {
         // This will clear the canvas (which include the previous predictions).
         this._predictionContext.clearRect(0, 0,
           this._predictionContext.canvas.width, this._predictionContext.canvas.height);
-        if (this._drawPointsOnly)
-          this._strokePredictedPoints(this._predictionContext, this._currentPath.predictedPoints);
-        else
-          this._strokePredictedEvents(this._predictionContext, this._currentPath.predictedPoints);
+        if (this._currentPath.predictedPoints.length > 0) {
+          if (this._drawPointsOnly)
+            this._strokePredictedPoints(this._predictionContext, this._currentPath.predictedPoints);
+          else
+            this._strokePredictedEvents(this._predictionContext, this._currentPath.predictedPoints);
+        }
       }
 
       // mark all as rendered

--- a/src/main-application.js
+++ b/src/main-application.js
@@ -75,6 +75,7 @@ export class MainApplication extends LitElement {
   `;
 
   set currentEvent(currentEvent) {
+    this._previousEvent = this._currentEvent;
     this._currentEvent = currentEvent;
     this._isIdle = false;
     clearTimeout(this._idleTimer);
@@ -152,7 +153,8 @@ export class MainApplication extends LitElement {
     this._yOffset = 0;
     this._defaultIdleTimeout = 50;
     this._currentEvent = null;
-    this._pointerLatencySamples = new LatencySamples(60);
+    this._previousEvent = null;
+    this._pointerLatencySamples = new DataSamples(60);
   }
 
   _showSnackbar() {
@@ -318,6 +320,10 @@ export class MainApplication extends LitElement {
     this._mainCanvas.highlightPredictedEvents = event.detail.predictedEventsHighlightEnabled;
   }
 
+  _predictionTypeChanged(event) {
+    this._mainCanvas.predictionType = event.detail.predictionType;
+  }
+
   _numOfPredictionPointsChanged(event) {
     this._mainCanvas.numOfPredictionPoints = event.detail.numOfPredictionPoints;
   }
@@ -360,6 +366,7 @@ export class MainApplication extends LitElement {
           @pressureEventsEnabled-changed=${this._pressureEventsEnabledChanged}
           @predictedEventsEnabled-changed=${this._predictedEventsEnabledChanged}
           @predictedEventsHighlightEnabled-changed=${this._predictedEventsHighlightEnabledChanged}
+          @predictionType-changed=${this._predictionTypeChanged}
           @numOfPredictionPoints-changed=${this._numOfPredictionPointsChanged}
           @coalescedEventsEnabled-changed=${this._coalescedEventsEnabledChanged}
           @drawPointsOnlyEnabled-changed=${this._drawPointsOnlyEnabledChanged}
@@ -384,34 +391,6 @@ export class MainApplication extends LitElement {
     <mwc-button slot="action">RELOAD</mwc-button>
       <mwc-icon-button icon="close" slot="dismiss"></mwc-icon-button>
     </mwc-snackbar>`;
-  }
-}
-
-class LatencySamples {
-  constructor(size) {
-    this._elements = [];
-    this._maxSize = size;
-  }
-
-  clear() {
-    this._elements = [];
-  }
-
-  push(value) {
-    if (this._elements.length >= this._maxSize) {
-      this._elements.shift();
-    }
-    this._elements.push(value);
-  }
-
-  avg() {
-    if (this._elements.length === 0)
-      return 0;
-
-    let sum = this._elements.reduce(function(a, b){
-      return a + b;
-    }, 0);
-    return sum / this._elements.length;
   }
 }
 

--- a/src/toolbar.js
+++ b/src/toolbar.js
@@ -213,6 +213,7 @@ export class Toolbar extends LitElement {
            pressureEventsEnabled : {type: Boolean, reflectToAttribute: true, attribute: true},
            predictedEventsEnabled : {type: Boolean, reflectToAttribute: true, attribute: true},
            predictedEventsHighlightEnabled : {type: Boolean, reflectToAttribute: true, attribute: true},
+           predictedType : {type: String, reflectToAttribute: true, attribute: true},
            numOfPredictionPoints : {type: Number, reflectToAttribute: true, attribute: true},
            coalescedEventsEnabled : {type: Boolean, reflectToAttribute: true, attribute: true},
            drawPointsOnlyEnabled : {type: Boolean, reflectToAttribute: true, attribute: true}};
@@ -348,6 +349,19 @@ export class Toolbar extends LitElement {
 
   get predictedEventsHighlightEnabled() { return this._predictedEventsHighlightEnabled; }
 
+  set predictionType(predictionType) {
+    let oldPredictionType = this._predictionType;
+    this._predictionType = predictionType;
+    let event = new CustomEvent('predictionType-changed', {
+      detail: { predictionType: predictionType },
+      bubbles: true,
+      composed: true });
+    this.dispatchEvent(event);
+    this.requestUpdate('predictionType', oldPredictionType);
+  }
+
+  get predictionType() { return this._predictionType; }
+
   set numOfPredictionPoints(points) {
     let oldPoints = this._numOfPredictionPoints;
     this._numOfPredictionPoints = points;
@@ -411,6 +425,8 @@ export class Toolbar extends LitElement {
     this._pressureEventsCheckbox = this.shadowRoot.querySelector('#pressure-events-checkbox');
     this._predictedEventsCheckbox = this.shadowRoot.querySelector('#predicted-events-checkbox');
     this._predictedEventsHighlightCheckbox = this.shadowRoot.querySelector('#predicted-events-highlight-checkbox');
+    this._chromePredictionRadio = this.shadowRoot.querySelector('#chrome-prediction-radio');
+    this._customPredictionRadio = this.shadowRoot.querySelector('#custom-prediction-radio');
     this._coalescedEventsCheckbox = this.shadowRoot.querySelector('#coalesced-events-checkbox');
     this._drawPointsOnlyCheckbox = this.shadowRoot.querySelector('#points-only-checkbox');
     this._lineWidthSlider = this.shadowRoot.querySelector('#line-width-slider');
@@ -519,6 +535,7 @@ export class Toolbar extends LitElement {
     this.pressureEventsEnabled = this.pressureEventsEnabled;
     this.predictedEventsEnabled = this.predictedEventsEnabled;
     this.predictedEventsHighlightEnabled = this.predictedEventsHighlightEnabled;
+    this.predictionType = this.predictionType;
     this.numOfPredictionPoints = this.numOfPredictionPoints;
     this.coalescedEventsEnabled = this.coalescedEventsEnabled;
     this.drawPointsOnlyEnabled = this.drawPointsOnlyEnabled;
@@ -711,7 +728,7 @@ export class Toolbar extends LitElement {
       // enabling pointerrawupdate will not work with predictedEvents
       this.predictedEventsEnabled = this._predictedEventsCheckbox.checked = false;
       this.predictedEventsHighlightEnabled = this._predictedEventsHighlightCheckbox.checked = false;
-      this._numOfPredictionPointsSlider.disabled = !this._predictedEventsCheckbox.checked;
+      this._chromePredictionRadio.disabled = this._customPredictionRadio.disabled = this._numOfPredictionPointsSlider.disabled = !this._predictedEventsCheckbox.checked;
     }
   }
 
@@ -728,11 +745,19 @@ export class Toolbar extends LitElement {
     } else {
       this.predictedEventsHighlightEnabled = this._predictedEventsHighlightCheckbox.checked = false;
     }
-    this._numOfPredictionPointsSlider.disabled = !this._predictedEventsCheckbox.checked;
+    this._chromePredictionRadio.disabled = this._customPredictionRadio.disabled = this._numOfPredictionPointsSlider.disabled = !this._predictedEventsCheckbox.checked;
   }
 
   _predictedEventsHighlightChanged() {
     this.predictedEventsHighlightEnabled = this._predictedEventsHighlightCheckbox.checked;
+  }
+
+  _customPredictionSelected() {
+    this.predictionType = 'custom';
+  }
+
+  _chromePredictionSelected() {
+    this.predictionType = 'chrome';
   }
 
   _coalescedEventsChanged() {
@@ -803,7 +828,7 @@ export class Toolbar extends LitElement {
       </div>
       <div class="usi-section" id="usi-group">
         <mwc-formfield spaceBetween="true" class="usi-text" label="Always use my preferred color when drawing" alignEnd="true">
-          <mwc-checkbox id="drawing-preferences-checkbox" @change="${this._drawingPreferenceChanged}"></mwc-checkbox>
+          <mwc-checkbox id="drawing-preferences-checkbox" reducedTouchTarget="true" @change="${this._drawingPreferenceChanged}"></mwc-checkbox>
         </mwc-formfield>
         <div class="usi-text">Read my preferred color from my stylus*:</div>
         <div class="usi-read-write-section">
@@ -827,24 +852,30 @@ export class Toolbar extends LitElement {
     <div id="pointer-events-tab" class="content">
       <div class="canvas-section">
         <mwc-formfield spaceBetween="true" class="canvas-text" label="Desynchronized Canvas" alignEnd="true">
-          <mwc-checkbox id="desynchronized-checkbox" @change="${this._desynchronizedChanged}"></mwc-checkbox>
+          <mwc-checkbox id="desynchronized-checkbox" reducedTouchTarget="true" @change="${this._desynchronizedChanged}"></mwc-checkbox>
         </mwc-formfield>
       </div>
       <div class="pointer-events-section">
         <mwc-formfield spaceBetween="true" class="pointer-events-text" label="Enable Pointer Raw Update" alignEnd="true">
-          <mwc-checkbox id="pointer-raw-update-checkbox" @change="${this._pointerRawUpdateChanged}"></mwc-checkbox>
+          <mwc-checkbox id="pointer-raw-update-checkbox" reducedTouchTarget="true" @change="${this._pointerRawUpdateChanged}"></mwc-checkbox>
         </mwc-formfield>
         <mwc-formfield spaceBetween="true" class="pointer-events-text" label="Enable Pen Pressure" alignEnd="true">
-          <mwc-checkbox id="pressure-events-checkbox" @change="${this._pressureEventsChanged}"></mwc-checkbox>
+          <mwc-checkbox id="pressure-events-checkbox" reducedTouchTarget="true" @change="${this._pressureEventsChanged}"></mwc-checkbox>
         </mwc-formfield>
         <mwc-formfield spaceBetween="true" class="pointer-events-text" label="Enable Coalesced Events" alignEnd="true">
-          <mwc-checkbox id="coalesced-events-checkbox" @change="${this._coalescedEventsChanged}"></mwc-checkbox>
+          <mwc-checkbox id="coalesced-events-checkbox" reducedTouchTarget="true" @change="${this._coalescedEventsChanged}"></mwc-checkbox>
         </mwc-formfield>
         <mwc-formfield spaceBetween="true" class="pointer-events-text" label="Enable Pointer Events Prediction" alignEnd="true">
-          <mwc-checkbox id="predicted-events-checkbox" @change="${this._predictedEventsChanged}"></mwc-checkbox>
+          <mwc-checkbox id="predicted-events-checkbox" reducedTouchTarget="true" @change="${this._predictedEventsChanged}"></mwc-checkbox>
         </mwc-formfield>
         <mwc-formfield spaceBetween="true" class="pointer-events-text" label="Highlight Pointer Events Prediction" alignEnd="true">
-          <mwc-checkbox id="predicted-events-highlight-checkbox" @change="${this._predictedEventsHighlightChanged}"></mwc-checkbox>
+          <mwc-checkbox id="predicted-events-highlight-checkbox" reducedTouchTarget="true" @change="${this._predictedEventsHighlightChanged}"></mwc-checkbox>
+        </mwc-formfield>
+        <mwc-formfield label="Custom Prediction (KalmanFilter)">
+          <mwc-radio id="custom-prediction-radio"  name="predictionType" value="custom" checked @change="${this._customPredictionSelected}"></mwc-radio>
+        </mwc-formfield>
+        <mwc-formfield label="Chrome Prediction">
+          <mwc-radio id="chrome-prediction-radio" name="predictionType" value="chrome" @change="${this._chromePredictionSelected}"></mwc-radio>
         </mwc-formfield>
         <div class="prediction-title">Number of Prediction Points Drawn</div>
         <mwc-slider pin markers step="1" value="1" min="1" max="10" id="prediction-points-slider" @change="${this._numOfPredictionPointsChanged}"></mwc-slider>
@@ -852,7 +883,7 @@ export class Toolbar extends LitElement {
       <div class="grow"></div>
       <div class="debug-section">
         <mwc-formfield spaceBetween="true" class="pointer-events-text" label="Draw Points Only" alignEnd="true">
-          <mwc-checkbox id="points-only-checkbox" @change="${this._drawPointsOnlyChanged}"></mwc-checkbox>
+          <mwc-checkbox id="points-only-checkbox" reducedTouchTarget="true" @change="${this._drawPointsOnlyChanged}"></mwc-checkbox>
         </mwc-formfield>
       </div>
     </div>`;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,27 @@
+class DataSamples {
+  constructor(size) {
+    this._elements = [];
+    this._maxSize = size;
+  }
+
+  clear() {
+    this._elements = [];
+  }
+
+  push(value) {
+    if (this._elements.length >= this._maxSize) {
+      this._elements.shift();
+    }
+    this._elements.push(value);
+  }
+
+  avg() {
+    if (this._elements.length === 0)
+      return 0;
+
+    let sum = this._elements.reduce(function(a, b){
+      return a + b;
+    }, 0);
+    return sum / this._elements.length;
+  }
+}


### PR DESCRIPTION
This patch implements a custom prediction algorithm using KalmanFilter
JS library, that samples the previous set of points and uses the
velocity and timestamps to predict the next set of predicted position.
The benefit using this is we have better control of what data is used to
feed into the KalmanFilter, for example, velocity only or with
acceleration.  Also added a select radio button to switch between chrome's
Chrome's prediction.